### PR TITLE
Fix/graceful shutdown

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: 0xv1n
+ko_fi: 0xv1n

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
       - name: Run unit tests
         run: make test
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
       - name: Run integration tests
         run: make test-integration
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
       - name: Build darwin/${{ matrix.goarch }}
         run: make build-${{ matrix.goarch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-_Add your changes here under the appropriate subsection before opening a PR._
+### Fixed
+
+- Module `Cleanup()` now runs when a run is interrupted, so Ctrl-C no longer
+  leaves persistence artifacts on the host.
+- An interrupted scenario stops at the step it reached and still writes its
+  audit record.
+
+### Changed
+
+- `make test` and `make coverage` now include `./cmd/...`.
 
 <!-- Subsections (remove any that are empty):
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ release: build-amd64 build-arm64
 
 ## Run unit tests (no macOS required)
 test:
-	go test -race -count=1 ./pkg/... ./internal/...
+	go test -race -count=1 ./cmd/... ./pkg/... ./internal/...
 
 ## Run integration tests (macOS only)
 test-integration:
@@ -39,7 +39,7 @@ vet:
 	go vet ./...
 
 coverage:
-	go test -race -coverprofile=coverage.out ./pkg/... ./internal/...
+	go test -race -coverprofile=coverage.out ./cmd/... ./pkg/... ./internal/...
 	go tool cover -html=coverage.out
 
 ## Install git hooks (one-time setup per clone)

--- a/cmd/macnoise/main.go
+++ b/cmd/macnoise/main.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -125,6 +127,37 @@ func buildAuditLogger(path string) (*audit.Logger, func(), error) {
 	return l, func() { _ = l.Close() }, nil
 }
 
+// signalContext returns a context that is cancelled on SIGINT or SIGTERM.
+//
+// Several modules install real persistence (LaunchAgents, cron entries, shell
+// profile blocks, defaults keys) that only the runner's Cleanup step removes.
+// Without a cancellable context an interrupted run leaves those artifacts on
+// the host, so the signal must reach the module rather than killing the process.
+//
+// After the first signal, delivery is stopped so the default disposition is
+// restored: a second Ctrl-C aborts immediately rather than trapping an operator
+// behind a slow or wedged cleanup.
+func signalContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		select {
+		case <-ch:
+			fmt.Fprintln(os.Stderr, "\ninterrupted - running module cleanup (Ctrl-C again to abort immediately)")
+			signal.Stop(ch)
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return ctx, func() {
+		signal.Stop(ch)
+		cancel()
+	}
+}
+
 func buildRunOpts(auditLogger *audit.Logger) runner.Options {
 	timeout := time.Duration(globalTimeout) * time.Second
 	return runner.Options{
@@ -163,7 +196,8 @@ func buildRun() *cobra.Command {
 
 			params := parseParams(paramFlags)
 			opts := buildRunOpts(auditLogger)
-			ctx := context.Background()
+			ctx, stop := signalContext()
+			defer stop()
 
 			switch {
 			case runAll:
@@ -302,7 +336,10 @@ func buildScenario() *cobra.Command {
 			defer closeAL()
 
 			opts := buildRunOpts(auditLogger)
-			return runner.RunScenario(context.Background(), args[0], em.EmitFunc(), opts)
+			ctx, stop := signalContext()
+			defer stop()
+
+			return runner.RunScenario(ctx, args[0], em.EmitFunc(), opts)
 		},
 	}
 }

--- a/cmd/macnoise/main_test.go
+++ b/cmd/macnoise/main_test.go
@@ -1,0 +1,52 @@
+//go:build unix
+
+package main
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// signalContext must cancel on SIGTERM so the runner's Cleanup step still runs
+// when an operator interrupts a module that installed persistence.
+//
+// Unix-only: the test delivers a real signal to itself, which has no portable
+// equivalent on Windows. CI runs unit tests on Linux, so this is covered there.
+func TestSignalContextCancelsOnSignal(t *testing.T) {
+	ctx, stop := signalContext()
+	defer stop()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("context cancelled before any signal was delivered")
+	default:
+	}
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("failed to signal self: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Errorf("expected context.Canceled, got %v", ctx.Err())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("context was not cancelled within 2s of SIGTERM")
+	}
+}
+
+// signalContext's stop function must be safe to call more than once, so the
+// deferred cleanup path in every command is harmless on a normal run.
+func TestSignalContextStopIsIdempotent(t *testing.T) {
+	ctx, stop := signalContext()
+	stop()
+	stop()
+
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Errorf("expected context cancelled after stop, got %v", ctx.Err())
+	}
+}

--- a/configs/scenarios/lazarus_group.yaml
+++ b/configs/scenarios/lazarus_group.yaml
@@ -8,11 +8,11 @@ description: |
   Sequence: dropper execution → dylib injection → service discovery → C2 resolution
              → reverse shell attempt → payload staging → plist persistence → C2 comms
 
-  MITRE ATT&CK techniques: T1059.004, T1574.006, T1057, T1071.004, T1059.004,
+  MITRE ATT&CK techniques: T1059.004, T1574.006, T1057, T1568, T1059.004,
                             T1074.001, T1543.001, T1071.001
 
 steps:
-  # T1059.004 — initial execution via trojanized application dropper
+  # T1059.004 + T1082 — system fingerprinting via shell (typical Lazarus first-stage recon)
   - module: proc_spawn
     params:
       command: "uname -a && sysctl hw.model"
@@ -26,7 +26,7 @@ steps:
   # T1057 — enumerate system XPC services for discovery and lateral movement planning
   - module: xpc_connect
 
-  # T1071.004 — resolve multi-stage C2 domains
+  # T1568 — resolve multi-stage C2 domains (dynamic resolution)
   - module: net_dns
     params:
       domains: "downloads.example.com,assets.example.net,api.example.org"
@@ -44,10 +44,13 @@ steps:
       count: "4"
       prefix: "stage2_"
 
-  # T1543.001 — write plist for persistence (masquerading as system component)
+  # T1543.001 — write LaunchAgent plist for persistence (masquerading as system component)
   - module: plist_create
     params:
       output_path: "/tmp/macnoise_lazarus/com.apple.coredata.plist"
+      bundle_id: "com.apple.coredata"
+      mode: "launchagent"
+      label: "com.apple.coredata"
 
   # T1071.001 — establish persistent beaconing to C2 for tasking
   - module: net_beacon

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -129,7 +129,21 @@ func RunScenario(ctx context.Context, path string, emit module.EventEmitter, opt
 	stepsPassed := 0
 	stepsFailed := 0
 
+	var interruptErr error
+
+stepLoop:
 	for i, step := range sc.Steps {
+		// Stop on cancellation rather than fast-failing every remaining step.
+		// An interrupted scenario should end at the step it reached, and still
+		// record a scenario audit entry describing how far it got.
+		select {
+		case <-ctx.Done():
+			interruptErr = fmt.Errorf("scenario %q: interrupted after %d of %d step(s): %w",
+				sc.Name, i, len(sc.Steps), ctx.Err())
+			break stepLoop
+		default:
+		}
+
 		params := module.Params(step.Params)
 		if params == nil {
 			params = module.Params{}
@@ -177,12 +191,18 @@ func RunScenario(ctx context.Context, path string, emit module.EventEmitter, opt
 			StepsFailed: stepsFailed,
 			TotalSteps:  len(sc.Steps),
 		}
-		if stepsFailed > 0 {
+		switch {
+		case interruptErr != nil:
+			ld.GenerateError = interruptErr.Error()
+		case stepsFailed > 0:
 			ld.GenerateError = fmt.Sprintf("%d step(s) failed", stepsFailed)
 		}
 		opts.AuditLog.LogScenario(sc.Name, path, ld)
 	}
 
+	if interruptErr != nil {
+		return interruptErr
+	}
 	if stepsFailed > 0 {
 		return fmt.Errorf("scenario %q: %d of %d step(s) failed", sc.Name, stepsFailed, len(sc.Steps))
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2,10 +2,15 @@ package runner_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/0xv1n/macnoise/internal/audit"
 	"github.com/0xv1n/macnoise/internal/runner"
 	"github.com/0xv1n/macnoise/pkg/module"
 )
@@ -24,7 +29,7 @@ func (m *mockGen) Info() module.ModuleInfo {
 	return module.ModuleInfo{Name: m.name, Category: "test"}
 }
 func (m *mockGen) ParamSpecs() []module.ParamSpec { return nil }
-func (m *mockGen) CheckPrereqs() error             { return m.prereqErr }
+func (m *mockGen) CheckPrereqs() error            { return m.prereqErr }
 func (m *mockGen) Generate(_ context.Context, _ module.Params, emit module.EventEmitter) error {
 	for _, ev := range m.events {
 		emit(ev)
@@ -87,15 +92,12 @@ func TestRunSingleDryRun(t *testing.T) {
 }
 
 func TestRunSingleTimeout(t *testing.T) {
-	gen := &mockGen{name: "mock_timeout"}
-	gen.events = nil
 	slowGen := &slowMockGen{name: "mock_slow", delay: 2 * time.Second}
 
 	err := runner.RunSingle(context.Background(), slowGen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{Timeout: 50 * time.Millisecond})
 	if err == nil {
 		t.Error("expected timeout error")
 	}
-	_ = gen
 }
 
 func TestRunManyCollectsErrors(t *testing.T) {
@@ -110,13 +112,14 @@ func TestRunManyCollectsErrors(t *testing.T) {
 }
 
 type slowMockGen struct {
-	name  string
-	delay time.Duration
+	name      string
+	delay     time.Duration
+	cleanedUp bool
 }
 
-func (s *slowMockGen) Info() module.ModuleInfo { return module.ModuleInfo{Name: s.name} }
+func (s *slowMockGen) Info() module.ModuleInfo        { return module.ModuleInfo{Name: s.name} }
 func (s *slowMockGen) ParamSpecs() []module.ParamSpec { return nil }
-func (s *slowMockGen) CheckPrereqs() error { return nil }
+func (s *slowMockGen) CheckPrereqs() error            { return nil }
 func (s *slowMockGen) Generate(ctx context.Context, _ module.Params, _ module.EventEmitter) error {
 	select {
 	case <-ctx.Done():
@@ -126,4 +129,144 @@ func (s *slowMockGen) Generate(ctx context.Context, _ module.Params, _ module.Ev
 	}
 }
 func (s *slowMockGen) DryRun(_ module.Params) []string { return nil }
-func (s *slowMockGen) Cleanup() error { return nil }
+func (s *slowMockGen) Cleanup() error {
+	s.cleanedUp = true
+	return nil
+}
+
+// Cleanup must run when an operator interrupts a run, otherwise modules that
+// install persistence leave artifacts behind on Ctrl-C.
+func TestRunSingleCleansUpOnCancel(t *testing.T) {
+	gen := &slowMockGen{name: "mock_cancel", delay: 10 * time.Second}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	err := runner.RunSingle(ctx, gen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if !gen.cleanedUp {
+		t.Error("expected Cleanup to run after cancellation")
+	}
+}
+
+// countingGen records how many times Generate was invoked and can trigger a
+// side-effect (used here to cancel the scenario context mid-run).
+type countingGen struct {
+	name   string
+	calls  int
+	onCall func()
+}
+
+func (c *countingGen) Info() module.ModuleInfo {
+	return module.ModuleInfo{Name: c.name, Category: "test"}
+}
+func (c *countingGen) ParamSpecs() []module.ParamSpec { return nil }
+func (c *countingGen) CheckPrereqs() error            { return nil }
+func (c *countingGen) Generate(_ context.Context, _ module.Params, _ module.EventEmitter) error {
+	c.calls++
+	if c.onCall != nil {
+		c.onCall()
+	}
+	return nil
+}
+func (c *countingGen) DryRun(_ module.Params) []string { return nil }
+func (c *countingGen) Cleanup() error                  { return nil }
+
+// writeScenario builds a temp scenario file invoking moduleName stepCount times.
+func writeScenario(t *testing.T, moduleName string, stepCount int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "scenario.yaml")
+	body := "name: cancel test\nsteps:\n" +
+		strings.Repeat("  - module: "+moduleName+"\n", stepCount)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write scenario: %v", err)
+	}
+	return path
+}
+
+// An interrupted scenario must stop at the step it reached rather than
+// fast-failing through every remaining step.
+func TestRunScenarioStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gen := &countingGen{name: "mock_scenario_step", onCall: cancel}
+	module.Register(gen)
+
+	path := writeScenario(t, gen.name, 4)
+
+	err := runner.RunScenario(ctx, path, func(module.TelemetryEvent) {}, runner.Options{})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if gen.calls != 1 {
+		t.Errorf("expected scenario to stop after 1 step, ran %d", gen.calls)
+	}
+}
+
+// Interrupting a scenario must still produce a scenario-level audit record, so
+// an operator can see how far the run got before it was cut short.
+func TestRunScenarioAuditsInterrupt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gen := &countingGen{name: "mock_audited_step", onCall: cancel}
+	module.Register(gen)
+
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	logger, err := audit.NewLogger(auditPath, "test")
+	if err != nil {
+		t.Fatalf("new audit logger: %v", err)
+	}
+
+	path := writeScenario(t, gen.name, 5)
+	runErr := runner.RunScenario(ctx, path, func(module.TelemetryEvent) {}, runner.Options{AuditLog: logger})
+	if !errors.Is(runErr, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", runErr)
+	}
+	if err := logger.Close(); err != nil {
+		t.Fatalf("close audit logger: %v", err)
+	}
+
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+
+	var scenarioRec map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("audit line is not valid JSON: %v", err)
+		}
+		if unmapped, ok := rec["unmapped"].(map[string]any); ok {
+			if _, isScenario := unmapped["total_steps"]; isScenario {
+				scenarioRec = rec
+			}
+		}
+	}
+
+	if scenarioRec == nil {
+		t.Fatal("no scenario-level audit record was written for the interrupted run")
+	}
+
+	unmapped := scenarioRec["unmapped"].(map[string]any)
+	if got := unmapped["steps_passed"]; got != float64(1) {
+		t.Errorf("steps_passed = %v, want 1", got)
+	}
+	if got := unmapped["total_steps"]; got != float64(5) {
+		t.Errorf("total_steps = %v, want 5", got)
+	}
+	if msg, _ := unmapped["scenario_error"].(string); !strings.Contains(msg, "interrupted") {
+		t.Errorf("scenario_error = %q, want it to mention the interrupt", msg)
+	}
+	if got := scenarioRec["status_id"]; got != float64(2) {
+		t.Errorf("status_id = %v, want 2 (Failure) for an interrupted scenario", got)
+	}
+}

--- a/modules/network/dns.go
+++ b/modules/network/dns.go
@@ -20,7 +20,7 @@ func (n *netDNS) Info() module.ModuleInfo {
 		Tags:        []string{"dns", "lookup", "outbound"},
 		Privileges:  module.PrivilegeNone,
 		MITRE: []module.MITRE{
-			{Technique: "T1071", SubTech: ".004", Name: "Application Layer Protocol: DNS"},
+			{Technique: "T1568", Name: "Dynamic Resolution"},
 		},
 		Author:   "0xv1n",
 		MinMacOS: "12.0",

--- a/modules/plist/create.go
+++ b/modules/plist/create.go
@@ -26,6 +26,7 @@ func (p *plistCreate) Info() module.ModuleInfo {
 		Privileges:  module.PrivilegeNone,
 		MITRE: []module.MITRE{
 			{Technique: "T1543", Name: "Create or Modify System Process"},
+			{Technique: "T1543", SubTech: ".001", Name: "Create or Modify System Process: Launch Agent"},
 		},
 		Author:   "0xv1n",
 		MinMacOS: "10.10",
@@ -36,6 +37,9 @@ func (p *plistCreate) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{Name: "output_path", Description: "Path for the created plist file", Required: false, DefaultValue: "/tmp/macnoise_test.plist", Example: "/tmp/test.plist"},
 		{Name: "bundle_id", Description: "Bundle ID value to embed in plist", Required: false, DefaultValue: "com.macnoise.test", Example: "com.example.app"},
+		{Name: "mode", Description: "Plist mode: 'bundle' (default) writes CFBundle keys; 'launchagent' writes LaunchAgent keys", Required: false, DefaultValue: "bundle", Example: "launchagent"},
+		{Name: "label", Description: "LaunchAgent Label key (used when mode=launchagent, defaults to bundle_id)", Required: false, DefaultValue: "", Example: "com.apple.coredata"},
+		{Name: "program", Description: "LaunchAgent ProgramArguments first element (used when mode=launchagent)", Required: false, DefaultValue: "/usr/bin/true", Example: "/Library/LaunchAgents/helper"},
 	}
 }
 
@@ -44,20 +48,39 @@ func (p *plistCreate) CheckPrereqs() error { return nil }
 func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	outPath := params.Get("output_path", "/tmp/macnoise_test.plist")
 	bundleID := params.Get("bundle_id", "com.macnoise.test")
+	mode := params.Get("mode", "bundle")
 	info := p.Info()
 
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return fmt.Errorf("mkdir: %w", err)
 	}
 
-	plistData := map[string]any{
-		"CFBundleIdentifier": bundleID,
-		"CFBundleVersion":    "1.0",
-		"MacnoiseGenerated":  true,
-		"GeneratedBy":        "MacNoise",
+	var plistData map[string]any
+	var evAction, evMsg string
+
+	if mode == "launchagent" {
+		label := params.Get("label", bundleID)
+		program := params.Get("program", "/usr/bin/true")
+		plistData = map[string]any{
+			"Label":             label,
+			"ProgramArguments":  []string{program},
+			"RunAtLoad":         true,
+			"KeepAlive":         false,
+		}
+		evAction = "plist_create_launchagent"
+		evMsg = fmt.Sprintf("creating LaunchAgent plist at %s (label: %s)", outPath, label)
+	} else {
+		plistData = map[string]any{
+			"CFBundleIdentifier": bundleID,
+			"CFBundleVersion":    "1.0",
+			"MacnoiseGenerated":  true,
+			"GeneratedBy":        "MacNoise",
+		}
+		evAction = "plist_create"
+		evMsg = fmt.Sprintf("creating plist at %s", outPath)
 	}
 
-	ev := output.NewEvent(info, "plist_create", false, fmt.Sprintf("creating plist at %s", outPath))
+	ev := output.NewEvent(info, evAction, false, evMsg)
 	f, err := os.Create(outPath)
 	if err != nil {
 		ev = output.WithError(ev, err)
@@ -75,15 +98,32 @@ func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit m
 	_ = f.Close()
 	p.createdPath = outPath
 
-	ev.Success = true
-	ev.Message = fmt.Sprintf("created plist at %s (bundle ID: %s)", outPath, bundleID)
-	ev = output.WithDetails(ev, map[string]any{"path": outPath, "bundle_id": bundleID, "format": "xml"})
+	if mode == "launchagent" {
+		label := params.Get("label", bundleID)
+		program := params.Get("program", "/usr/bin/true")
+		ev.Success = true
+		ev.Message = fmt.Sprintf("created LaunchAgent plist at %s (label: %s, program: %s)", outPath, label, program)
+		ev = output.WithDetails(ev, map[string]any{"path": outPath, "label": label, "program": program, "run_at_load": true, "format": "xml"})
+	} else {
+		ev.Success = true
+		ev.Message = fmt.Sprintf("created plist at %s (bundle ID: %s)", outPath, bundleID)
+		ev = output.WithDetails(ev, map[string]any{"path": outPath, "bundle_id": bundleID, "format": "xml"})
+	}
 	emit(ev)
 	return nil
 }
 
 func (p *plistCreate) DryRun(params module.Params) []string {
 	outPath := params.Get("output_path", "/tmp/macnoise_test.plist")
+	mode := params.Get("mode", "bundle")
+	if mode == "launchagent" {
+		bundleID := params.Get("bundle_id", "com.macnoise.test")
+		label := params.Get("label", bundleID)
+		program := params.Get("program", "/usr/bin/true")
+		return []string{
+			fmt.Sprintf("create LaunchAgent plist at %s with Label=%s ProgramArguments=[%s] RunAtLoad=true", outPath, label, program),
+		}
+	}
 	bundleID := params.Get("bundle_id", "com.macnoise.test")
 	return []string{
 		fmt.Sprintf("create XML plist at %s with CFBundleIdentifier=%s", outPath, bundleID),


### PR DESCRIPTION
## Summary

run and scenario executed under context.Background(), so Ctrl-C killed the process before the runner's Cleanup() step could execute, leaving LaunchAgents, cron entries, shell profile blocks, and defaults keys installed on the host. Both commands now run under a context cancelled on SIGINT/SIGTERM.

## Type of change

<!-- Check all that apply -->

- [ ] New telemetry module
- [x] Bug fix
- [ ] Enhancement to an existing module
- [ ] Scenario / config change
- [x] Documentation update
- [ ] Refactor / internal improvement

## Telemetry details

<!-- Required for new or modified modules. Skip for doc-only changes. -->

**What telemetry does this generate?**

<!-- Describe the events emitted and what system activity they represent. -->

**MITRE ATT&CK mapping(s)**

| Technique ID | Name |
|--------------|------|
| T<!-- e.g. T1071.001 --> | <!-- Web Protocols --> |

**Privilege requirements**

- [ ] None (runs as standard user)
- [ ] Root / `sudo`
- [ ] TCC permission(s) required: <!-- list them, e.g. FDA, Contacts -->
- [ ] macOS system extension / SIP interaction

**How does `Cleanup()` revert changes?**

<!-- Describe every persistent side-effect this module introduces and how Cleanup removes it. -->

## Module implementation checklist

<!-- Required for new modules. Skip for doc-only / config-only changes. -->

- [ ] Implements all 6 methods of the `Generator` interface
- [ ] `Info()` has accurate `Category`, `Tags`, `Privileges`, and `MITRE` entries
- [ ] `ParamSpecs()` documents every accepted parameter with defaults and examples
- [ ] `CheckPrereqs()` returns a clear error when requirements aren't met
- [ ] `DryRun()` describes every action without executing side-effects
- [ ] `Cleanup()` fully reverts any persistent changes
- [ ] Module emits events via `emit()`, never writes directly to stdout
- [ ] Registered in `cmd/macnoise/main.go` via blank import
- [ ] Integration test file added (`modules/<category>/<name>_test.go`)

## General checklist

- [x] `make test` passes
- [x] `make lint` passes (no `go vet` or `golangci-lint` warnings)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Targets the `main` branch
- [x] PR scope is limited to a single fix or module (see AI Code Policy in CONTRIBUTING.md)

## Testing notes

<!-- How did you verify this works? Include any manual steps, edge cases tested, or known limitations. -->
