### PR TITLE
fix: don't overwrite crontab when listing it fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   leaves persistence artifacts on the host.
 - An interrupted scenario stops at the step it reached and still writes its
   audit record.
+- `svc_cron` no longer overwrites the user's crontab when `crontab -l` fails
+  for a reason other than "no crontab exists" (e.g. access denied); it now
+  aborts instead. `Cleanup()` also reports an error instead of silently
+  succeeding when it can't verify the installed entry was removed.
 
 ### Changed
 
-- `make test` and `make coverage` now include `./cmd/...`.
+- `make test` and `make coverage` now include `./cmd/...` and `./modules/...`.
 
 <!-- Subsections (remove any that are empty):
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ release: build-amd64 build-arm64
 
 ## Run unit tests (no macOS required)
 test:
-	go test -race -count=1 ./cmd/... ./pkg/... ./internal/...
+	go test -race -count=1 ./cmd/... ./pkg/... ./internal/... ./modules/...
 
 ## Run integration tests (macOS only)
 test-integration:
@@ -39,7 +39,7 @@ vet:
 	go vet ./...
 
 coverage:
-	go test -race -coverprofile=coverage.out ./cmd/... ./pkg/... ./internal/...
+	go test -race -coverprofile=coverage.out ./cmd/... ./pkg/... ./internal/... ./modules/...
 	go tool cover -html=coverage.out
 
 ## Install git hooks (one-time setup per clone)

--- a/modules/service/cron.go
+++ b/modules/service/cron.go
@@ -38,6 +38,33 @@ func (s *svcCron) ParamSpecs() []module.ParamSpec {
 
 func (s *svcCron) CheckPrereqs() error { return nil }
 
+// noCrontabMarker is the substring `crontab -l` prints to stderr when a user
+// genuinely has no crontab yet (e.g. "crontab: no crontab for alice"). It is
+// the only listing failure treated as safe to overwrite; see
+// classifyCrontabList for why every other failure is not.
+const noCrontabMarker = "no crontab for"
+
+// classifyCrontabList inspects the result of `crontab -l` and reports whether
+// it is safe to treat the user's crontab as known (existing, possibly empty).
+//
+// `crontab -l` exits non-zero both when the user genuinely has no crontab yet
+// and when access is denied - for example when the calling terminal lacks
+// Full Disk Access on modern macOS, or another read failure occurs. Treating
+// every listing failure as "empty crontab" and overwriting it, as this
+// function's caller previously did, risks silently destroying a real
+// crontab that macnoise was simply unable to read. Only the well-known
+// "no crontab for <user>" message is trusted as genuinely empty; any other
+// failure is reported unsafe so the caller can abort instead of guessing.
+func classifyCrontabList(out []byte, err error) (existing string, safe bool) {
+	if err == nil {
+		return string(out), true
+	}
+	if strings.Contains(strings.ToLower(string(out)), noCrontabMarker) {
+		return "", true
+	}
+	return "", false
+}
+
 func (s *svcCron) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	schedule := params.Get("schedule", "*/5 * * * *")
 	command := params.Get("command", "/usr/bin/true")
@@ -48,13 +75,18 @@ func (s *svcCron) Generate(ctx context.Context, params module.Params, emit modul
 
 	listEv := output.NewEvent(info, "cron_job_list", false, "listing current crontab entries")
 	listOut, listErr := exec.CommandContext(ctx, "crontab", "-l").CombinedOutput()
-	existing := ""
+	existing, safe := classifyCrontabList(listOut, listErr)
+	if !safe {
+		listEv = output.WithError(listEv, fmt.Errorf("crontab -l failed without reporting an empty crontab, refusing to overwrite: %v: %s", listErr, strings.TrimSpace(string(listOut))))
+		emit(listEv)
+		return fmt.Errorf("svc_cron: cannot safely determine existing crontab contents, aborting rather than risk overwriting it: %w", listErr)
+	}
+
 	if listErr != nil {
 		listEv.Success = true
 		listEv.Message = "no existing crontab (empty crontab)"
 		listEv = output.WithDetails(listEv, map[string]any{"entries": ""})
 	} else {
-		existing = string(listOut)
 		lineCount := len(strings.Split(strings.TrimSpace(existing), "\n"))
 		listEv.Success = true
 		listEv.Message = fmt.Sprintf("retrieved crontab (%d lines)", lineCount)
@@ -96,12 +128,16 @@ func (s *svcCron) Cleanup() error {
 	if s.addedEntry == "" {
 		return nil
 	}
-	out, err := exec.Command("crontab", "-l").Output()
-	if err != nil {
-		s.addedEntry = ""
-		return nil
+	out, err := exec.Command("crontab", "-l").CombinedOutput()
+	existing, safe := classifyCrontabList(out, err)
+	if !safe {
+		// Leave addedEntry set: we don't know whether our entry is still
+		// installed, so a caller retrying Cleanup should try again rather
+		// than have this silently reported as done.
+		return fmt.Errorf("svc_cron: cleanup cannot safely list crontab, entry %q may still be installed: %v: %s", s.addedEntry, err, strings.TrimSpace(string(out)))
 	}
-	lines := strings.Split(string(out), "\n")
+
+	lines := strings.Split(existing, "\n")
 	filtered := make([]string, 0, len(lines))
 	for _, line := range lines {
 		if strings.TrimSpace(line) != strings.TrimSpace(s.addedEntry) {
@@ -111,8 +147,11 @@ func (s *svcCron) Cleanup() error {
 	newCrontab := strings.Join(filtered, "\n")
 	cmd := exec.Command("crontab", "-")
 	cmd.Stdin = strings.NewReader(newCrontab)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("svc_cron: failed to reinstall filtered crontab during cleanup: %w", err)
+	}
 	s.addedEntry = ""
-	return cmd.Run()
+	return nil
 }
 
 func init() {

--- a/modules/service/cron_test.go
+++ b/modules/service/cron_test.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+// classifyCrontabList must never mistake a permission or access failure for
+// an empty crontab: doing so is what let Generate silently overwrite a real
+// crontab when `crontab -l` was denied rather than genuinely empty.
+func TestClassifyCrontabList(t *testing.T) {
+	tests := []struct {
+		name         string
+		out          string
+		err          error
+		wantSafe     bool
+		wantExisting string
+	}{
+		{
+			name:         "success with existing entries",
+			out:          "*/5 * * * * /usr/bin/true\n",
+			err:          nil,
+			wantSafe:     true,
+			wantExisting: "*/5 * * * * /usr/bin/true\n",
+		},
+		{
+			name:         "success with no error and empty content",
+			out:          "",
+			err:          nil,
+			wantSafe:     true,
+			wantExisting: "",
+		},
+		{
+			name:         "genuinely no crontab, macOS wording",
+			out:          "crontab: no crontab for gdejesus\n",
+			err:          errors.New("exit status 1"),
+			wantSafe:     true,
+			wantExisting: "",
+		},
+		{
+			name:         "genuinely no crontab, unprefixed wording",
+			out:          "no crontab for root\n",
+			err:          errors.New("exit status 1"),
+			wantSafe:     true,
+			wantExisting: "",
+		},
+		{
+			name:         "match is case-insensitive",
+			out:          "CRONTAB: NO CRONTAB FOR root\n",
+			err:          errors.New("exit status 1"),
+			wantSafe:     true,
+			wantExisting: "",
+		},
+		{
+			name:     "permission denied must not be treated as empty",
+			out:      "crontab: operation not permitted\n",
+			err:      errors.New("exit status 1"),
+			wantSafe: false,
+		},
+		{
+			name:     "unrecognized error text must not be treated as empty",
+			out:      "crontab: some future error we have never seen\n",
+			err:      errors.New("exit status 1"),
+			wantSafe: false,
+		},
+		{
+			name:     "empty output with an error must not be treated as empty",
+			out:      "",
+			err:      errors.New(`exec: "crontab": executable file not found in $PATH`),
+			wantSafe: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing, safe := classifyCrontabList([]byte(tt.out), tt.err)
+			if safe != tt.wantSafe {
+				t.Errorf("safe = %v, want %v", safe, tt.wantSafe)
+			}
+			if tt.wantSafe && existing != tt.wantExisting {
+				t.Errorf("existing = %q, want %q", existing, tt.wantExisting)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`svc_cron` treated every `crontab -l` failure as "empty crontab" and overwrote it accordingly, which silently destroys a real crontab when listing fails for a reason other than genuine absence (e.g. access denied). `Generate()` now only proceeds when it can positively confirm the crontab is empty or readable; every other listing failure aborts instead of guessing. `Cleanup()` had the mirror bug and any listing failure was reported as successful cleanup while the installed entry stayed behind; it now returns an error instead.