### PR TITLE
fix: correct release-please tag component config for existing repo

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,10 +2,15 @@
   "release-type": "go",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
-  "extra-files": [
-    {
-      "type": "generic",
-      "path": "cmd/macnoise/version.go"
+  "include-component-in-tag": false,
+  "packages": {
+    ".": {
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "cmd/macnoise/version.go"
+        }
+      ]
     }
-  ]
+  }
 }


### PR DESCRIPTION
The release automation merged in #7 silently opened 0 PRs because release-please couldn't reconcile the existing v0.1.0 tag with the manifest config. Fixed by adding include-component-in-tag: false and nesting config under an explicit packages block; verified with a real dry-run against this branch, which now correctly proposes a 0.2.0 release.