### PR TITLE
fix: restore prior state correctly in file_modify and plist_modify cleanup

### DIFF
--- a/modules/file/modify.go
+++ b/modules/file/modify.go
@@ -14,6 +14,7 @@ import (
 type fileModify struct {
 	targetPath  string
 	origContent []byte
+	existed     bool
 }
 
 func (f *fileModify) Info() module.ModuleInfo {
@@ -48,7 +49,8 @@ func (f *fileModify) Generate(ctx context.Context, params module.Params, emit mo
 	f.targetPath = targetPath
 
 	orig, err := os.ReadFile(targetPath)
-	if os.IsNotExist(err) {
+	switch {
+	case os.IsNotExist(err):
 		if err2 := os.MkdirAll(filepath.Dir(targetPath), 0o755); err2 != nil {
 			ev := output.NewEvent(info, "file_modify", false, "failed to create parent directory")
 			ev = output.WithError(ev, err2)
@@ -56,11 +58,14 @@ func (f *fileModify) Generate(ctx context.Context, params module.Params, emit mo
 			return err2
 		}
 		orig = []byte{}
-	} else if err != nil {
+		f.existed = false
+	case err != nil:
 		ev := output.NewEvent(info, "file_modify", false, fmt.Sprintf("failed to read %s", targetPath))
 		ev = output.WithError(ev, err)
 		emit(ev)
 		return err
+	default:
+		f.existed = true
 	}
 	f.origContent = orig
 
@@ -95,8 +100,11 @@ func (f *fileModify) Cleanup() error {
 	if f.targetPath == "" {
 		return nil
 	}
-	if f.origContent == nil {
-		return os.Remove(f.targetPath)
+	if !f.existed {
+		if err := os.Remove(f.targetPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
 	}
 	return os.WriteFile(f.targetPath, f.origContent, 0o644)
 }

--- a/modules/file/modify_test.go
+++ b/modules/file/modify_test.go
@@ -1,0 +1,74 @@
+package file
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func noopEmit(module.TelemetryEvent) {}
+
+// Cleanup must delete a file that fileModify itself created, not leave an
+// empty file behind. The bug: origContent was set to a non-nil empty slice
+// when the target didn't exist, so Cleanup's `origContent == nil` check
+// never took the os.Remove branch.
+func TestFileModify_CleanupRemovesFileItCreated(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "does-not-exist-yet.txt")
+
+	f := &fileModify{}
+	params := module.Params{"target_path": target}
+	if err := f.Generate(context.Background(), params, noopEmit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("expected Generate to create %s: %v", target, err)
+	}
+
+	if err := f.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed by Cleanup, stat err = %v", target, err)
+	}
+}
+
+// Cleanup must restore a pre-existing file's exact original content, not
+// leave macnoise's appended modification in place.
+func TestFileModify_CleanupRestoresPriorContent(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "existing.txt")
+	original := []byte("original content\n")
+	if err := os.WriteFile(target, original, 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	f := &fileModify{}
+	params := module.Params{"target_path": target}
+	if err := f.Generate(context.Background(), params, noopEmit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	modified, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read after Generate: %v", err)
+	}
+	if string(modified) == string(original) {
+		t.Fatal("Generate did not modify the file, test setup is invalid")
+	}
+
+	if err := f.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	restored, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read after Cleanup: %v", err)
+	}
+	if string(restored) != string(original) {
+		t.Errorf("Cleanup did not restore original content:\n got:  %q\n want: %q", restored, original)
+	}
+}

--- a/modules/plist/modify.go
+++ b/modules/plist/modify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/0xv1n/macnoise/internal/output"
 	"github.com/0xv1n/macnoise/internal/prereqs"
@@ -11,8 +12,58 @@ import (
 )
 
 type plistModify struct {
-	domain string
-	key    string
+	domain       string
+	key          string
+	priorExisted bool
+	priorValue   string
+}
+
+// defaultsReadOutcome is the result of classifying a `defaults read domain
+// key` invocation before plistModify overwrites it.
+type defaultsReadOutcome struct {
+	// safe is true when Generate can trust existed/value enough to proceed:
+	// either the key definitely doesn't exist yet, or it holds a value simple
+	// enough to restore faithfully later.
+	safe    bool
+	existed bool
+	value   string
+}
+
+// classifyDefaultsRead inspects the result of `defaults read domain key` and
+// reports whether it is safe to overwrite the key, knowing how to restore it.
+//
+// `defaults read` exits non-zero both when the key genuinely does not exist
+// and when some other read failure occurs. Only the well-known "does not
+// exist" message is trusted as genuinely absent; any other failure is
+// reported unsafe so Generate can abort instead of guessing, and Cleanup
+// never has to choose between destroying or fabricating a value it never
+// actually saw.
+//
+// A successful read is only trusted when the value is a single line with no
+// defaults array/dict delimiters. `defaults read` renders array and
+// dictionary values across multiple lines; blindly feeding that text back
+// through `-string` on restore would corrupt rather than restore them, so
+// those are reported unsafe too.
+func classifyDefaultsRead(out []byte, err error) defaultsReadOutcome {
+	text := strings.TrimRight(string(out), "\n")
+	if err == nil {
+		if isRestorableScalar(text) {
+			return defaultsReadOutcome{safe: true, existed: true, value: text}
+		}
+		return defaultsReadOutcome{safe: false}
+	}
+	if strings.Contains(strings.ToLower(text), "does not exist") {
+		return defaultsReadOutcome{safe: true, existed: false}
+	}
+	return defaultsReadOutcome{safe: false}
+}
+
+func isRestorableScalar(text string) bool {
+	if strings.Contains(text, "\n") {
+		return false
+	}
+	trimmed := strings.TrimSpace(text)
+	return !strings.HasPrefix(trimmed, "(") && !strings.HasPrefix(trimmed, "{")
 }
 
 func (p *plistModify) Info() module.ModuleInfo {
@@ -48,8 +99,27 @@ func (p *plistModify) Generate(ctx context.Context, params module.Params, emit m
 	value := params.Get("value", "true")
 	info := p.Info()
 
+	readEv := output.NewEvent(info, "plist_read_prior", false, fmt.Sprintf("reading prior value of %s %s", domain, key))
+	readOut, readErr := exec.CommandContext(ctx, "defaults", "read", domain, key).CombinedOutput()
+	outcome := classifyDefaultsRead(readOut, readErr)
+	if !outcome.safe {
+		readEv = output.WithError(readEv, fmt.Errorf("cannot safely determine prior value of %s %s, refusing to overwrite: %v: %s", domain, key, readErr, strings.TrimSpace(string(readOut))))
+		emit(readEv)
+		return fmt.Errorf("plist_modify: cannot safely determine prior value of %s %s, aborting rather than risk losing it: %w", domain, key, readErr)
+	}
+
 	p.domain = domain
 	p.key = key
+	p.priorExisted = outcome.existed
+	p.priorValue = outcome.value
+
+	readEv.Success = true
+	if outcome.existed {
+		readEv.Message = fmt.Sprintf("%s %s already set, prior value will be restored on cleanup", domain, key)
+	} else {
+		readEv.Message = fmt.Sprintf("%s %s not set, key will be removed on cleanup", domain, key)
+	}
+	emit(readEv)
 
 	writeEv := output.NewEvent(info, "plist_modify", false, fmt.Sprintf("defaults write %s %s %s", domain, key, value))
 	cmd := exec.CommandContext(ctx, "defaults", "write", domain, key, "-string", value)
@@ -71,12 +141,20 @@ func (p *plistModify) DryRun(params module.Params) []string {
 	key := params.Get("key", "MacnoiseTest")
 	value := params.Get("value", "true")
 	return []string{
+		fmt.Sprintf("defaults read %s %s (capture prior value for cleanup)", domain, key),
 		fmt.Sprintf("defaults write %s %s -string %s", domain, key, value),
 	}
 }
 
 func (p *plistModify) Cleanup() error {
 	if p.domain == "" || p.key == "" {
+		return nil
+	}
+	if p.priorExisted {
+		out, err := exec.Command("defaults", "write", p.domain, p.key, "-string", p.priorValue).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("defaults write %s %s (restore prior value): %v: %s", p.domain, p.key, err, out)
+		}
 		return nil
 	}
 	out, err := exec.Command("defaults", "delete", p.domain, p.key).CombinedOutput()

--- a/modules/plist/modify_test.go
+++ b/modules/plist/modify_test.go
@@ -1,0 +1,106 @@
+package plistmod
+
+import (
+	"errors"
+	"testing"
+)
+
+// classifyDefaultsRead must never mistake a permission or unexpected read
+// failure for "key does not exist": doing so is what let Generate overwrite
+// a real user preference without any way to restore it, since Cleanup could
+// then only ever delete the key.
+func TestClassifyDefaultsRead(t *testing.T) {
+	tests := []struct {
+		name        string
+		out         string
+		err         error
+		wantSafe    bool
+		wantExisted bool
+		wantValue   string
+	}{
+		{
+			name:        "existing simple string value",
+			out:         "true\n",
+			err:         nil,
+			wantSafe:    true,
+			wantExisted: true,
+			wantValue:   "true",
+		},
+		{
+			name:        "existing numeric-looking value",
+			out:         "1\n",
+			err:         nil,
+			wantSafe:    true,
+			wantExisted: true,
+			wantValue:   "1",
+		},
+		{
+			name:        "key does not exist, short message form",
+			out:         "The domain/default pair of (com.macnoise.test, MacnoiseTest) does not exist\n",
+			err:         errors.New("exit status 1"),
+			wantSafe:    true,
+			wantExisted: false,
+		},
+		{
+			name:     "empty output with a generic error must not be treated as absent",
+			out:      "",
+			err:      errors.New("exit status 1"),
+			wantSafe: false,
+		},
+		{
+			name:        "does not exist message with domain/key detail",
+			out:         "2026-07-30 12:00:00.000 defaults[1234:5678]\nThe domain/default pair of (com.macnoise.test, MacnoiseTest) does not exist\n",
+			err:         errors.New("exit status 1"),
+			wantSafe:    true,
+			wantExisted: false,
+		},
+		{
+			name:     "array value must not be treated as restorable",
+			out:      "(\n    item1,\n    item2\n)\n",
+			err:      nil,
+			wantSafe: false,
+		},
+		{
+			name:     "dict value must not be treated as restorable",
+			out:      "{\n    key1 = val1;\n}\n",
+			err:      nil,
+			wantSafe: false,
+		},
+		{
+			name:     "permission denied must not be treated as absent",
+			out:      "defaults: Could not read domain com.apple.finder; operation not permitted\n",
+			err:      errors.New("exit status 1"),
+			wantSafe: false,
+		},
+		{
+			name:     "unrecognized error text must not be treated as absent",
+			out:      "defaults: some future error we have never seen\n",
+			err:      errors.New("exit status 1"),
+			wantSafe: false,
+		},
+		{
+			name:     "exec-level failure must not be treated as absent",
+			out:      "",
+			err:      errors.New(`exec: "defaults": executable file not found in $PATH`),
+			wantSafe: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyDefaultsRead([]byte(tt.out), tt.err)
+			if got.safe != tt.wantSafe {
+				t.Errorf("safe = %v, want %v", got.safe, tt.wantSafe)
+			}
+			if !tt.wantSafe {
+				return
+			}
+			if got.existed != tt.wantExisted {
+				t.Errorf("existed = %v, want %v", got.existed, tt.wantExisted)
+			}
+			if tt.wantExisted && got.value != tt.wantValue {
+				t.Errorf("value = %q, want %q", got.value, tt.wantValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
file_modify left an empty file behind on cleanup instead of removing it, due to a nil-vs-empty-slice bug. plist_modify could only ever delete a key on cleanup since it never read the prior value first, which meant it destroyed real user preferences if pointed at one instead of just its own test values. Both now restore actual prior state, with real end-to-end tests for file_modify and unit tests for plist_modify's extracted decision logic.