### PR TITLE
fix: redact hidden-answer osascript output and cap AMOS dialog timeout

### DIFF
--- a/configs/scenarios/amos_atomic_stealer.yaml
+++ b/configs/scenarios/amos_atomic_stealer.yaml
@@ -93,9 +93,14 @@ steps:
   #   Title: "Auto-Updates System"
   #   Body:  "The launcher needs permissions to enable background auto-updates."
   # The 'with hidden answer' flag hides the typed password in the dialog field.
+  # 'giving up after 5' auto-dismisses so an unattended scenario run can't
+  # block indefinitely on a real console. proc_osascript also redacts
+  # whatever was typed before it's captured into telemetry/audit output -
+  # this scenario reproduces AMOS's exact prompt to exercise the same
+  # detection signature, not to actually collect a credential.
   - module: proc_osascript
     params:
-      script: 'display dialog "The launcher needs permissions to enable background auto-updates.\n\nPlease enter your password." with title "Auto-Updates System" default answer "" with icon caution buttons {"Continue"} default button "Continue" with hidden answer'
+      script: 'display dialog "The launcher needs permissions to enable background auto-updates.\n\nPlease enter your password." with title "Auto-Updates System" default answer "" with icon caution buttons {"Continue"} default button "Continue" with hidden answer giving up after 5'
 
 # ──────────────────────────────────────────────────────────────────────────────
 # PHASE 3 — CREDENTIAL VALIDATION

--- a/modules/process/osascript.go
+++ b/modules/process/osascript.go
@@ -6,12 +6,36 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/0xv1n/macnoise/internal/output"
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
 type procOsascript struct{}
+
+// redactedOutput replaces the captured result of a script that solicited
+// hidden/masked input.
+const redactedOutput = "[redacted: script requested hidden input via osascript]"
+
+// sanitizeOsascriptOutput redacts osascript's captured stdout when script
+// solicited hidden/masked input: AppleScript's `display dialog ... with
+// hidden answer`, or JXA's equivalent `hiddenAnswer` option.
+//
+// osascript prints the dialog's result record to stdout verbatim, including
+// literally what was typed. Capturing that into telemetry/audit output would
+// persist whatever an operator typed into what looks like a real system
+// password prompt, in cleartext, on disk - with no benefit, since the typed
+// value itself carries no detection-relevant signal. The command line and
+// script source (what a detection rule actually keys on) are left untouched;
+// only the captured runtime result is redacted.
+func sanitizeOsascriptOutput(script, out string) string {
+	normalized := strings.ToLower(strings.ReplaceAll(script, " ", ""))
+	if strings.Contains(normalized, "hiddenanswer") {
+		return redactedOutput
+	}
+	return out
+}
 
 func (p *procOsascript) Info() module.ModuleInfo {
 	return module.ModuleInfo{
@@ -57,14 +81,15 @@ func (p *procOsascript) Generate(ctx context.Context, params module.Params, emit
 
 	ev := output.NewEvent(info, "osascript_exec", false, fmt.Sprintf("executing %s via osascript", language))
 	out, err := exec.CommandContext(ctx, "osascript", "-l", language, "-e", script).CombinedOutput()
+	safeOutput := sanitizeOsascriptOutput(script, string(out))
 	if err != nil {
 		ev.Success = true
 		ev.Message = fmt.Sprintf("osascript returned error (telemetry generated): %v", err)
-		ev = output.WithDetails(ev, map[string]any{"language": language, "script": script, "output": string(out), "error": err.Error()})
+		ev = output.WithDetails(ev, map[string]any{"language": language, "script": script, "output": safeOutput, "error": err.Error()})
 	} else {
 		ev.Success = true
 		ev.Message = fmt.Sprintf("osascript executed %s successfully", language)
-		ev = output.WithDetails(ev, map[string]any{"language": language, "script": script, "output": string(out)})
+		ev = output.WithDetails(ev, map[string]any{"language": language, "script": script, "output": safeOutput})
 	}
 	emit(ev)
 	return nil

--- a/modules/process/osascript_test.go
+++ b/modules/process/osascript_test.go
@@ -1,0 +1,64 @@
+//go:build darwin
+
+package process
+
+import "testing"
+
+// sanitizeOsascriptOutput must redact captured output whenever the script
+// solicited hidden/masked input, in both AppleScript and JXA form - a
+// confused operator could type a real password into what looks like a
+// system prompt, and it must never reach telemetry or audit output.
+func TestSanitizeOsascriptOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		out    string
+		want   string
+	}{
+		{
+			name:   "AppleScript with hidden answer is redacted",
+			script: `display dialog "Enter password" default answer "" with hidden answer`,
+			out:    `{text returned:"hunter2", button returned:"OK"}`,
+			want:   redactedOutput,
+		},
+		{
+			name:   "JXA hiddenAnswer option is redacted",
+			script: `app.displayDialog("Enter password", {defaultAnswer: "", hiddenAnswer: true})`,
+			out:    `{textReturned: "hunter2", buttonReturned: "OK"}`,
+			want:   redactedOutput,
+		},
+		{
+			name:   "case and spacing variants are still caught",
+			script: `display dialog "x" WITH   HIDDEN   ANSWER`,
+			out:    `whatever`,
+			want:   redactedOutput,
+		},
+		{
+			name:   "ordinary script output passes through unchanged",
+			script: `do shell script "id"`,
+			out:    `uid=501(operator) gid=20(staff)`,
+			want:   `uid=501(operator) gid=20(staff)`,
+		},
+		{
+			name:   "plain visible-answer dialog is not redacted",
+			script: `display dialog "pick one" buttons {"A","B"}`,
+			out:    `{button returned:"A"}`,
+			want:   `{button returned:"A"}`,
+		},
+		{
+			name:   "notification script is not redacted",
+			script: `display notification "macnoise telemetry" with title "MacNoise"`,
+			out:    ``,
+			want:   ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeOsascriptOutput(tt.script, tt.out)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
tldr - we dont need to store real creds for validation.

proc_osascript captured osascript's raw stdout into telemetry/audit output, which for a "with hidden answer" dialog (AppleScript) or hiddenAnswer option (JXA) means literally whatever was typed gets persisted in cleartext - exactly what the AMOS scenario's fake password prompt triggers. Now redacted whenever the script requests hidden input, and the AMOS dialog gets a 5s giving-up-after so it can't block an unattended run waiting for real input. Verified the redaction logic against real executed tests in a scratch copy (this file is darwin-gated so can't run directly here) and proved they fail without the fix.