### PR TITLE
chore: add gofmt CI gate and pin golangci-lint to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10.1
+          version: v2.12.2
       - name: govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,7 @@ linters:
       - path: '_test\.go'
         linters:
           - errcheck
+
+formatters:
+  enable:
+    - gofmt

--- a/modules/network/beacon.go
+++ b/modules/network/beacon.go
@@ -44,7 +44,7 @@ func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit modu
 	intervalStr := params.Get("interval", "2")
 
 	count := 3
-	fmt.Sscanf(countStr, "%d", &count)         //nolint:errcheck
+	fmt.Sscanf(countStr, "%d", &count) //nolint:errcheck
 	intervalSecs := 2
 	fmt.Sscanf(intervalStr, "%d", &intervalSecs) //nolint:errcheck
 	interval := time.Duration(intervalSecs) * time.Second

--- a/modules/plist/create.go
+++ b/modules/plist/create.go
@@ -62,10 +62,10 @@ func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit m
 		label := params.Get("label", bundleID)
 		program := params.Get("program", "/usr/bin/true")
 		plistData = map[string]any{
-			"Label":             label,
-			"ProgramArguments":  []string{program},
-			"RunAtLoad":         true,
-			"KeepAlive":         false,
+			"Label":            label,
+			"ProgramArguments": []string{program},
+			"RunAtLoad":        true,
+			"KeepAlive":        false,
 		}
 		evAction = "plist_create_launchagent"
 		evMsg = fmt.Sprintf("creating LaunchAgent plist at %s (label: %s)", outPath, label)

--- a/pkg/module/registry_test.go
+++ b/pkg/module/registry_test.go
@@ -21,11 +21,13 @@ func (t *testGen) Info() module.ModuleInfo {
 		Privileges: module.PrivilegeNone,
 	}
 }
-func (t *testGen) ParamSpecs() []module.ParamSpec                                                { return nil }
-func (t *testGen) CheckPrereqs() error                                                           { return nil }
-func (t *testGen) Generate(_ context.Context, _ module.Params, _ module.EventEmitter) error     { return nil }
-func (t *testGen) DryRun(_ module.Params) []string                                              { return nil }
-func (t *testGen) Cleanup() error                                                               { return nil }
+func (t *testGen) ParamSpecs() []module.ParamSpec { return nil }
+func (t *testGen) CheckPrereqs() error            { return nil }
+func (t *testGen) Generate(_ context.Context, _ module.Params, _ module.EventEmitter) error {
+	return nil
+}
+func (t *testGen) DryRun(_ module.Params) []string { return nil }
+func (t *testGen) Cleanup() error                  { return nil }
 
 func TestRegisterAndGet(t *testing.T) {
 	gen := &testGen{name: "test_reg_get", category: "network"}


### PR DESCRIPTION
Fixed the 3 files with drifted formatting (gofmt -w, no logic changes) and added a gofmt check to CI so this class of drift gets caught going forward - golangci-lint v2 moved formatters into a separate config block from linters, which is why this needed its own section rather than just adding gofmt to the existing linters list. Also bumped the pinned golangci-lint version to v2.12.2 (latest, matches what's installed locally) so local and CI runs can't silently disagree anymore.