### PR TITLE
fix: give proc_gatekeeper's 4 events distinct labels

### DIFF
--- a/modules/process/README.md
+++ b/modules/process/README.md
@@ -22,7 +22,7 @@ macnoise run proc_discovery --param commands="sw_vers,whoami,csrutil status"
 ```
 
 ### `proc_gatekeeper`
-Sets and removes the `com.apple.quarantine` xattr on a test file, then queries `spctl --status`. Emits `xattr_quarantine_remove` and `spctl_status_check` events. Maps to T1553.001. Cleanup removes the test file.
+Sets and removes the `com.apple.quarantine` xattr on a test file, then queries `spctl --status`. Emits `xattr_quarantine_set`, `xattr_quarantine_remove`, and `spctl_status_check` events. Maps to T1553.001. Cleanup removes the test file.
 
 ```bash
 macnoise run proc_gatekeeper

--- a/modules/process/gatekeeper.go
+++ b/modules/process/gatekeeper.go
@@ -50,13 +50,13 @@ func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emi
 	info := p.Info()
 
 	if err := os.WriteFile(targetPath, []byte("macnoise gatekeeper test\n"), 0o644); err != nil {
-		ev := output.NewEvent(info, "xattr_quarantine_remove", false, fmt.Sprintf("failed to create test file %s", targetPath))
+		ev := output.NewEvent(info, "test_file_create_fail", false, fmt.Sprintf("failed to create test file %s", targetPath))
 		ev = output.WithError(ev, err)
 		emit(ev)
 		return err
 	}
 
-	setEv := output.NewEvent(info, "xattr_quarantine_remove", false, fmt.Sprintf("setting quarantine xattr on %s", targetPath))
+	setEv := output.NewEvent(info, "xattr_quarantine_set", false, fmt.Sprintf("setting quarantine xattr on %s", targetPath))
 	setOut, setErr := exec.CommandContext(ctx, "xattr", "-w", "com.apple.quarantine", "0081;00000000;macnoise;", targetPath).CombinedOutput()
 	if setErr != nil {
 		setEv = output.WithError(setEv, fmt.Errorf("%v: %s", setErr, setOut))


### PR DESCRIPTION
Three of proc_gatekeeper's four events (test-file-creation failure, xattr set, xattr remove) all shared the event-type xattr_quarantine_remove, so nothing filtering audit logs by event type could tell which one actually happened. Now test_file_create_fail, xattr_quarantine_set, and xattr_quarantine_remove are distinct, with the module README updated to match. Pure rename, no logic or message text changed.