### PR TITLE
fix: thread es_process's chain_depth through argv instead of nested string quoting

### DIFF
--- a/modules/endpoint_security/es_process.go
+++ b/modules/endpoint_security/es_process.go
@@ -34,20 +34,10 @@ func (e *esProcess) ParamSpecs() []module.ParamSpec {
 
 func (e *esProcess) CheckPrereqs() error { return nil }
 
-// buildExecChainArgs returns an argv slice that, when exec'd, nests depth-1
-// levels of `sh -c '"$@"' sh <rest>` around a final `echo es_exit`, so each
-// level really forks/execs the next.
-//
-// The fixed script '"$@"' just re-executes its own positional parameters as
-// a command, so nesting threads through argv directly - no shell-quote
-// escaping needed at any level. The previous implementation built this by
-// literally wrapping the growing string in `sh -c '%s'` via fmt.Sprintf,
-// which breaks past depth 2 (the embedded single quotes from the inner
-// layer aren't escaped, so the shell parser doesn't see what the code
-// intends) and, even fixed to escape correctly, grows exponentially and
-// fails outright by depth 10 - this module's own clamp ceiling. Verified
-// against real POSIX sh at every depth up to 50 with zero issues; argv
-// length here grows linearly (4 elements per depth) instead.
+// buildExecChainArgs nests depth-1 levels of `sh -c '"$@"' sh <rest>` around
+// a final `echo es_exit`. The '"$@"' script just re-execs its own
+// positional params, so nesting threads through argv with no shell-quote
+// escaping needed.
 func buildExecChainArgs(depth int) []string {
 	args := []string{"echo", "es_exit"}
 	for i := 0; i < depth-1; i++ {

--- a/modules/endpoint_security/es_process.go
+++ b/modules/endpoint_security/es_process.go
@@ -34,6 +34,31 @@ func (e *esProcess) ParamSpecs() []module.ParamSpec {
 
 func (e *esProcess) CheckPrereqs() error { return nil }
 
+// buildExecChainArgs returns an argv slice that, when exec'd, nests depth-1
+// levels of `sh -c '"$@"' sh <rest>` around a final `echo es_exit`, so each
+// level really forks/execs the next.
+//
+// The fixed script '"$@"' just re-executes its own positional parameters as
+// a command, so nesting threads through argv directly - no shell-quote
+// escaping needed at any level. The previous implementation built this by
+// literally wrapping the growing string in `sh -c '%s'` via fmt.Sprintf,
+// which breaks past depth 2 (the embedded single quotes from the inner
+// layer aren't escaped, so the shell parser doesn't see what the code
+// intends) and, even fixed to escape correctly, grows exponentially and
+// fails outright by depth 10 - this module's own clamp ceiling. Verified
+// against real POSIX sh at every depth up to 50 with zero issues; argv
+// length here grows linearly (4 elements per depth) instead.
+func buildExecChainArgs(depth int) []string {
+	args := []string{"echo", "es_exit"}
+	for i := 0; i < depth-1; i++ {
+		wrapped := make([]string, 0, len(args)+4)
+		wrapped = append(wrapped, "sh", "-c", `"$@"`, "sh")
+		wrapped = append(wrapped, args...)
+		args = wrapped
+	}
+	return args
+}
+
 func (e *esProcess) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	depthStr := params.Get("chain_depth", "3")
 	depth := 3
@@ -44,15 +69,11 @@ func (e *esProcess) Generate(ctx context.Context, params module.Params, emit mod
 
 	info := e.Info()
 
-	inner := "echo es_exit"
-	for i := 0; i < depth-1; i++ {
-		inner = fmt.Sprintf("sh -c '%s'", inner)
-	}
-
 	ev := output.NewEvent(info, "es_exec_chain", false,
 		fmt.Sprintf("executing %d-deep process fork/exec chain", depth))
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", inner)
+	chainArgs := buildExecChainArgs(depth)
+	cmd := exec.CommandContext(ctx, chainArgs[0], chainArgs[1:]...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		ev = output.WithError(ev, err)

--- a/modules/endpoint_security/es_process_exec_test.go
+++ b/modules/endpoint_security/es_process_exec_test.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package endpointsecurity
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The whole point of buildExecChainArgs is that the chain actually executes
+// correctly - this runs it for real via the exact exec.Command call
+// Generate uses, at the module's default (3), a middling value (5), and its
+// own clamp ceiling (10). Verified independently against real POSIX sh up
+// to depth 50 during development; this locks in the depths that matter.
+//
+// Windows-excluded: Go's os/exec on Windows reconstructs a command-line
+// string for CreateProcess, and MSYS2/Cygwin-style sh.exe builds re-parse
+// that string with their own (non-POSIX-matching) conventions - a
+// Windows-hosted sh.exe failed this exact test during development even
+// though the fix is correct, which isn't a signal about the fix itself
+// since this module only ever runs against a real macOS target.
+func TestBuildExecChainArgs_ActuallyExecutes(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+
+	for _, depth := range []int{3, 5, 10} {
+		args := buildExecChainArgs(depth)
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		if err != nil {
+			t.Errorf("depth=%d: exec failed: %v (output: %q)", depth, err, out)
+			continue
+		}
+		if got := strings.TrimSpace(string(out)); got != "es_exit" {
+			t.Errorf("depth=%d: output = %q, want %q", depth, got, "es_exit")
+		}
+	}
+}

--- a/modules/endpoint_security/es_process_exec_test.go
+++ b/modules/endpoint_security/es_process_exec_test.go
@@ -8,18 +8,9 @@ import (
 	"testing"
 )
 
-// The whole point of buildExecChainArgs is that the chain actually executes
-// correctly - this runs it for real via the exact exec.Command call
-// Generate uses, at the module's default (3), a middling value (5), and its
-// own clamp ceiling (10). Verified independently against real POSIX sh up
-// to depth 50 during development; this locks in the depths that matter.
-//
-// Windows-excluded: Go's os/exec on Windows reconstructs a command-line
-// string for CreateProcess, and MSYS2/Cygwin-style sh.exe builds re-parse
-// that string with their own (non-POSIX-matching) conventions - a
-// Windows-hosted sh.exe failed this exact test during development even
-// though the fix is correct, which isn't a signal about the fix itself
-// since this module only ever runs against a real macOS target.
+// Excluded on Windows: Go's os/exec there builds a command-line string that
+// MSYS2/Cygwin-style sh.exe re-parses differently than real POSIX sh, which
+// doesn't reflect this module's actual (macOS) target.
 func TestBuildExecChainArgs_ActuallyExecutes(t *testing.T) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh not on PATH")

--- a/modules/endpoint_security/es_process_test.go
+++ b/modules/endpoint_security/es_process_test.go
@@ -5,20 +5,16 @@ import (
 	"testing"
 )
 
-// buildExecChainArgs must produce the fixed 4-element wrapper
-// (sh, -c, "$@", sh) once per nesting level, ending in the literal
-// innermost command - this is what makes the chain threadable through argv
-// without any string-level shell-quote escaping.
 func TestBuildExecChainArgs_Shape(t *testing.T) {
 	tests := []struct {
 		depth   int
 		wantLen int
 	}{
-		{depth: 1, wantLen: 2},  // echo es_exit
-		{depth: 2, wantLen: 6},  // + sh -c "$@" sh
-		{depth: 3, wantLen: 10}, // + another wrapper
+		{depth: 1, wantLen: 2},
+		{depth: 2, wantLen: 6},
+		{depth: 3, wantLen: 10},
 		{depth: 5, wantLen: 18},
-		{depth: 10, wantLen: 38}, // this module's own clamp ceiling
+		{depth: 10, wantLen: 38}, // module's clamp ceiling
 	}
 
 	for _, tt := range tests {
@@ -43,10 +39,6 @@ func TestBuildExecChainArgs_Shape(t *testing.T) {
 	}
 }
 
-// depth grows the argv slice linearly, not exponentially - this is the
-// actual property that fixes the bug. The previous implementation built a
-// single string via repeated fmt.Sprintf("sh -c '%s'", inner) wrapping,
-// which is what grows exponentially and fails outright at depth 10.
 func TestBuildExecChainArgs_LinearGrowth(t *testing.T) {
 	prevLen := -1
 	for depth := 1; depth <= 10; depth++ {
@@ -61,17 +53,10 @@ func TestBuildExecChainArgs_LinearGrowth(t *testing.T) {
 	}
 }
 
-// The built script must always be the literal `"$@"` idiom, never something
-// derived from user input - this module's chain_depth param only controls
-// nesting count, never gets interpolated into the script text itself.
 func TestBuildExecChainArgs_NoUserInputInScript(t *testing.T) {
-	args := buildExecChainArgs(5)
-	for _, a := range args {
-		if a == "-c" {
-			continue
-		}
+	for _, a := range buildExecChainArgs(5) {
 		if strings.Contains(a, "'") {
-			t.Errorf("argv element %q contains a raw single quote - the whole point of this construction is that none should ever appear", a)
+			t.Errorf("argv element %q contains a raw single quote", a)
 		}
 	}
 }

--- a/modules/endpoint_security/es_process_test.go
+++ b/modules/endpoint_security/es_process_test.go
@@ -1,0 +1,77 @@
+package endpointsecurity
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildExecChainArgs must produce the fixed 4-element wrapper
+// (sh, -c, "$@", sh) once per nesting level, ending in the literal
+// innermost command - this is what makes the chain threadable through argv
+// without any string-level shell-quote escaping.
+func TestBuildExecChainArgs_Shape(t *testing.T) {
+	tests := []struct {
+		depth   int
+		wantLen int
+	}{
+		{depth: 1, wantLen: 2},  // echo es_exit
+		{depth: 2, wantLen: 6},  // + sh -c "$@" sh
+		{depth: 3, wantLen: 10}, // + another wrapper
+		{depth: 5, wantLen: 18},
+		{depth: 10, wantLen: 38}, // this module's own clamp ceiling
+	}
+
+	for _, tt := range tests {
+		args := buildExecChainArgs(tt.depth)
+		if len(args) != tt.wantLen {
+			t.Errorf("depth=%d: len(args) = %d, want %d (%v)", tt.depth, len(args), tt.wantLen, args)
+		}
+		if args[len(args)-2] != "echo" || args[len(args)-1] != "es_exit" {
+			t.Errorf("depth=%d: chain must end in echo es_exit, got tail %v", tt.depth, args[len(args)-2:])
+		}
+		for i := 0; i < tt.depth-1; i++ {
+			base := i * 4
+			got := args[base : base+4]
+			want := []string{"sh", "-c", `"$@"`, "sh"}
+			for j := range want {
+				if got[j] != want[j] {
+					t.Errorf("depth=%d level=%d: wrapper = %v, want %v", tt.depth, i, got, want)
+					break
+				}
+			}
+		}
+	}
+}
+
+// depth grows the argv slice linearly, not exponentially - this is the
+// actual property that fixes the bug. The previous implementation built a
+// single string via repeated fmt.Sprintf("sh -c '%s'", inner) wrapping,
+// which is what grows exponentially and fails outright at depth 10.
+func TestBuildExecChainArgs_LinearGrowth(t *testing.T) {
+	prevLen := -1
+	for depth := 1; depth <= 10; depth++ {
+		args := buildExecChainArgs(depth)
+		if prevLen >= 0 {
+			grew := len(args) - prevLen
+			if grew != 4 {
+				t.Errorf("depth=%d: argv grew by %d elements from depth=%d, want exactly 4 (linear)", depth, grew, depth-1)
+			}
+		}
+		prevLen = len(args)
+	}
+}
+
+// The built script must always be the literal `"$@"` idiom, never something
+// derived from user input - this module's chain_depth param only controls
+// nesting count, never gets interpolated into the script text itself.
+func TestBuildExecChainArgs_NoUserInputInScript(t *testing.T) {
+	args := buildExecChainArgs(5)
+	for _, a := range args {
+		if a == "-c" {
+			continue
+		}
+		if strings.Contains(a, "'") {
+			t.Errorf("argv element %q contains a raw single quote - the whole point of this construction is that none should ever appear", a)
+		}
+	}
+}


### PR DESCRIPTION
es_process built its nested sh -c chain by literally wrapping a growing string in sh -c '%s', which breaks past depth 2 since the inner single quotes never get escaped - reproduced this exactly, output goes empty at the module's own default depth of 3. Fixed by threading the chain through argv using the sh -c '"$@"' idiom instead, which needs no string escaping and grows linearly rather than exponentially (the naive escaped-string fix I tried first is correct but blows up past ~1000 chars and fails outright by depth 10, the module's own clamp ceiling). Verified end-to-end against real POSIX (WSL Ubuntu, both a raw shell test and the actual cross-compiled Go test binary) at every depth up to 50, and confirmed the new tests fail against the original bug by reverting and rerunning the same real-Linux binary.