### PR TITLE
fix: correct net_dns MITRE mapping and add real T1518 coverage to proc_discovery

### DIFF
--- a/configs/scenarios/lazarus_group.yaml
+++ b/configs/scenarios/lazarus_group.yaml
@@ -8,7 +8,7 @@ description: |
   Sequence: dropper execution → dylib injection → service discovery → C2 resolution
              → reverse shell attempt → payload staging → plist persistence → C2 comms
 
-  MITRE ATT&CK techniques: T1059.004, T1574.006, T1057, T1568, T1059.004,
+  MITRE ATT&CK techniques: T1059.004, T1574.006, T1057, T1071.004, T1059.004,
                             T1074.001, T1543.001, T1071.001
 
 steps:
@@ -26,7 +26,7 @@ steps:
   # T1057 — enumerate system XPC services for discovery and lateral movement planning
   - module: xpc_connect
 
-  # T1568 — resolve multi-stage C2 domains (dynamic resolution)
+  # T1071.004 - resolve known C2 domains via DNS
   - module: net_dns
     params:
       domains: "downloads.example.com,assets.example.net,api.example.org"

--- a/modules/network/dns.go
+++ b/modules/network/dns.go
@@ -20,7 +20,7 @@ func (n *netDNS) Info() module.ModuleInfo {
 		Tags:        []string{"dns", "lookup", "outbound"},
 		Privileges:  module.PrivilegeNone,
 		MITRE: []module.MITRE{
-			{Technique: "T1568", Name: "Dynamic Resolution"},
+			{Technique: "T1071", SubTech: ".004", Name: "Application Layer Protocol: DNS"},
 		},
 		Author:   "0xv1n",
 		MinMacOS: "12.0",

--- a/modules/process/discovery.go
+++ b/modules/process/discovery.go
@@ -13,6 +13,7 @@ import (
 var defaultDiscoveryCommands = []string{
 	"sw_vers",
 	"system_profiler SPHardwareDataType",
+	"system_profiler SPApplicationsDataType",
 	"sysctl hw.model",
 	"ifconfig",
 	"whoami",


### PR DESCRIPTION
net_dns claimed T1568 (Dynamic Resolution, i.e. DGA/fast-flux) for a plain static LookupHost call - verified against MITRE ATT&CK directly, confirmed T1071.004 (Application Layer Protocol: DNS) is correct, and modules/network/README.md already said T1071.004 even though the code said T1568. proc_discovery claimed T1518 (Software Discovery) but its command list never actually enumerated installed software, so added system_profiler SPApplicationsDataType. Also fixed the same T1568 mistake in lazarus_group.yaml, which had the identical static-domain-list-as-"dynamic resolution" error.