### PR TITLE
fix: rewrite OCSF classify.go to match real event types and correct activity IDs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ The runner automatically wraps the `emit` callback with `Logger.WrapEmitter()` w
 func fileActivity(eventType string) (int, string) {
     switch eventType {
     case "my_read_event":
-        return 4, "Read"
+        return 2, "Read"
     // ...
     }
 }

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -1,7 +1,5 @@
 package audit
 
-import "strings"
-
 // Classification holds the OCSF class, category, and activity identifiers for an event.
 type Classification struct {
 	ClassUID     int
@@ -15,9 +13,11 @@ type Classification struct {
 // Classify maps a macnoise category and event type to its OCSF Classification.
 func Classify(category, eventType string) Classification {
 	switch eventType {
-	case "http_get", "http_post", "http_put", "http_delete", "http_request", "http_response", "http_connect":
-		return Classification{4002, "HTTP Activity", 4, "Network Activity", 1, "Connect"}
-	case "dns_query", "dns_lookup", "dns_response", "dns_request":
+	case "http_get", "http_beacon":
+		return Classification{4002, "HTTP Activity", 4, "Network Activity", 3, "Get"}
+	case "http_post_exfil":
+		return Classification{4002, "HTTP Activity", 4, "Network Activity", 6, "Post"}
+	case "dns_lookup":
 		return Classification{4003, "DNS Activity", 4, "Network Activity", 1, "Query"}
 	}
 
@@ -35,21 +35,15 @@ func Classify(category, eventType string) Classification {
 		return Classification{1001, "File System Activity", 1, "System Activity", actID, actName}
 
 	case "tcc", "xpc":
-		return Classification{6003, "API Activity", 6, "Application Activity", 99, "Other"}
+		actID, actName := apiActivity(eventType)
+		return Classification{6003, "API Activity", 6, "Application Activity", actID, actName}
 
 	case "endpoint_security":
-		if strings.Contains(eventType, "file") {
-			actID, actName := fileActivity(eventType)
-			return Classification{1001, "File System Activity", 1, "System Activity", actID, actName}
-		}
-		if strings.Contains(eventType, "process") {
-			actID, actName := processActivity(eventType)
-			return Classification{1007, "Process Activity", 1, "System Activity", actID, actName}
-		}
-		return Classification{6003, "API Activity", 6, "Application Activity", 99, "Other"}
+		return endpointSecurityActivity(eventType)
 
 	case "service":
-		return Classification{1006, "Scheduled Job Activity", 1, "System Activity", 1, "Create"}
+		actID, actName := serviceActivity(eventType)
+		return Classification{1006, "Scheduled Job Activity", 1, "System Activity", actID, actName}
 	}
 
 	return Classification{6003, "API Activity", 6, "Application Activity", 99, "Other"}
@@ -58,35 +52,74 @@ func Classify(category, eventType string) Classification {
 func networkActivity(eventType string) (int, string) {
 	switch eventType {
 	case "tcp_listen":
-		return 5, "Listen"
-	case "beacon", "revshell", "tcp_connect":
-		return 1, "Connect"
+		return 7, "Listen"
+	case "tcp_connect", "tcp_accept", "reverse_shell_attempt":
+		return 1, "Open"
 	}
-	return 1, "Connect"
+	return 99, "Other"
 }
 
 func processActivity(eventType string) (int, string) {
 	switch eventType {
-	case "spawn", "exec", "launch":
+	case "process_spawn", "process_fork", "osascript_exec", "system_discovery",
+		"xattr_quarantine_set", "xattr_quarantine_remove", "spctl_status_check":
 		return 1, "Launch"
-	case "terminate", "kill":
-		return 2, "Terminate"
-	case "signal", "sigstop", "sigcont", "inject":
-		return 99, "Other"
+	case "dylib_inject_attempt":
+		return 4, "Inject"
 	}
-	return 1, "Launch"
+	return 99, "Other"
 }
 
 func fileActivity(eventType string) (int, string) {
 	switch eventType {
-	case "create", "write":
-		return 3, "Create"
-	case "read", "open":
-		return 4, "Read"
-	case "modify", "update", "rename":
-		return 5, "Update"
-	case "delete", "remove":
-		return 6, "Delete"
+	case "file_create", "dir_create", "file_hide_dotfile", "archive_create",
+		"plist_create", "plist_create_launchagent":
+		return 1, "Create"
+	case "plist_read_prior":
+		return 2, "Read"
+	case "file_modify", "plist_modify":
+		return 3, "Update"
+	case "file_hide_chflags":
+		return 6, "Set Attributes"
+	case "browser_cred_probe":
+		return 8, "Get Attributes"
 	}
-	return 3, "Create"
+	return 99, "Other"
+}
+
+func serviceActivity(eventType string) (int, string) {
+	switch eventType {
+	case "cron_job_create", "launchagent_create", "launchdaemon_create":
+		return 1, "Create"
+	case "shell_profile_modify":
+		return 2, "Update"
+	case "launchagent_load", "launchdaemon_load":
+		return 6, "Start"
+	}
+	return 99, "Other"
+}
+
+func apiActivity(eventType string) (int, string) {
+	switch eventType {
+	case "keychain_list", "keychain_dump_attempt", "tcc_contacts_probe",
+		"tcc_fda_probe", "xpc_enumerate":
+		return 2, "Read"
+	case "keychain_unlock_attempt":
+		return 3, "Update"
+	}
+	return 99, "Other"
+}
+
+func endpointSecurityActivity(eventType string) Classification {
+	switch eventType {
+	case "es_notify_create":
+		return Classification{1001, "File System Activity", 1, "System Activity", 1, "Create"}
+	case "es_notify_write":
+		return Classification{1001, "File System Activity", 1, "System Activity", 3, "Update"}
+	case "es_notify_unlink":
+		return Classification{1001, "File System Activity", 1, "System Activity", 4, "Delete"}
+	case "es_exec_chain":
+		return Classification{1007, "Process Activity", 1, "System Activity", 1, "Launch"}
+	}
+	return Classification{6003, "API Activity", 6, "Application Activity", 99, "Other"}
 }

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -2,145 +2,98 @@ package audit
 
 import "testing"
 
-func TestClassify_NetworkTCP(t *testing.T) {
-	cl := Classify("network", "tcp_connect")
-	if cl.ClassUID != 4001 {
-		t.Errorf("expected class_uid 4001, got %d", cl.ClassUID)
+// One row per event type actually emitted by a module (re-derived with
+// grep -rhoP 'NewEvent\(info,\s*"\K[a-z_0-9]+' modules/ | sort -u, plus
+// plist_create/plist_create_launchagent which build their event type via a
+// variable rather than a literal and so don't show up in that grep).
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		category     string
+		eventType    string
+		wantClassUID int
+		wantActID    int
+	}{
+		// network
+		{"network", "dns_lookup", 4003, 1},
+		{"network", "http_get", 4002, 3},
+		{"network", "http_beacon", 4002, 3},
+		{"network", "http_post_exfil", 4002, 6},
+		{"network", "tcp_connect", 4001, 1},
+		{"network", "tcp_accept", 4001, 1},
+		{"network", "tcp_listen", 4001, 7},
+		{"network", "reverse_shell_attempt", 4001, 1},
+
+		// file
+		{"file", "archive_create", 1001, 1},
+		{"file", "browser_cred_probe", 1001, 8},
+		{"file", "dir_create", 1001, 1},
+		{"file", "file_create", 1001, 1},
+		{"file", "file_hide_chflags", 1001, 6},
+		{"file", "file_hide_dotfile", 1001, 1},
+		{"file", "file_modify", 1001, 3},
+
+		// plist (routed through the file/plist case)
+		{"plist", "plist_modify", 1001, 3},
+		{"plist", "plist_read_prior", 1001, 2},
+		{"plist", "plist_create", 1001, 1},
+		{"plist", "plist_create_launchagent", 1001, 1},
+
+		// process
+		{"process", "dylib_inject_attempt", 1007, 4},
+		{"process", "osascript_exec", 1007, 1},
+		{"process", "process_fork", 1007, 1},
+		{"process", "process_spawn", 1007, 1},
+		{"process", "signal_send", 1007, 99},
+		{"process", "spctl_status_check", 1007, 1},
+		{"process", "system_discovery", 1007, 1},
+		{"process", "test_file_create_fail", 1007, 99},
+		{"process", "xattr_quarantine_remove", 1007, 1},
+		{"process", "xattr_quarantine_set", 1007, 1},
+
+		// service
+		{"service", "cron_job_create", 1006, 1},
+		{"service", "cron_job_list", 1006, 99},
+		{"service", "launchagent_create", 1006, 1},
+		{"service", "launchagent_load", 1006, 6},
+		{"service", "launchdaemon_create", 1006, 1},
+		{"service", "launchdaemon_load", 1006, 6},
+		{"service", "shell_profile_modify", 1006, 2},
+
+		// tcc / xpc
+		{"tcc", "keychain_dump_attempt", 6003, 2},
+		{"tcc", "keychain_list", 6003, 2},
+		{"tcc", "keychain_unlock_attempt", 6003, 3},
+		{"tcc", "tcc_contacts_probe", 6003, 2},
+		{"tcc", "tcc_fda_probe", 6003, 2},
+		{"xpc", "xpc_enumerate", 6003, 2},
+
+		// endpoint_security
+		{"endpoint_security", "es_exec_chain", 1007, 1},
+		{"endpoint_security", "es_notify_create", 1001, 1},
+		{"endpoint_security", "es_notify_write", 1001, 3},
+		{"endpoint_security", "es_notify_unlink", 1001, 4},
+
+		// unmapped category/event falls back to API Activity/Other
+		{"unknown_category", "unknown_event", 6003, 99},
 	}
-	if cl.CategoryUID != 4 {
-		t.Errorf("expected category_uid 4, got %d", cl.CategoryUID)
-	}
-	if cl.ActivityID != 1 {
-		t.Errorf("expected activity_id 1 (Connect), got %d", cl.ActivityID)
+
+	for _, tt := range tests {
+		t.Run(tt.category+"/"+tt.eventType, func(t *testing.T) {
+			cl := Classify(tt.category, tt.eventType)
+			if cl.ClassUID != tt.wantClassUID {
+				t.Errorf("ClassUID = %d, want %d", cl.ClassUID, tt.wantClassUID)
+			}
+			if cl.ActivityID != tt.wantActID {
+				t.Errorf("ActivityID = %d, want %d", cl.ActivityID, tt.wantActID)
+			}
+		})
 	}
 }
 
-func TestClassify_NetworkHTTP(t *testing.T) {
-	cl := Classify("network", "http_get")
-	if cl.ClassUID != 4002 {
-		t.Errorf("expected class_uid 4002 for http_get, got %d", cl.ClassUID)
-	}
-	if cl.ClassName != "HTTP Activity" {
-		t.Errorf("expected 'HTTP Activity', got %q", cl.ClassName)
-	}
-}
-
-func TestClassify_NetworkDNS(t *testing.T) {
-	cl := Classify("network", "dns_query")
-	if cl.ClassUID != 4003 {
-		t.Errorf("expected class_uid 4003 for dns_query, got %d", cl.ClassUID)
-	}
-}
-
-func TestClassify_NetworkListen(t *testing.T) {
-	cl := Classify("network", "tcp_listen")
-	if cl.ClassUID != 4001 {
-		t.Errorf("expected class_uid 4001, got %d", cl.ClassUID)
-	}
-	if cl.ActivityID != 5 {
-		t.Errorf("expected activity_id 5 (Listen), got %d", cl.ActivityID)
-	}
-}
-
-func TestClassify_Process(t *testing.T) {
-	cl := Classify("process", "spawn")
-	if cl.ClassUID != 1007 {
-		t.Errorf("expected class_uid 1007 for process, got %d", cl.ClassUID)
-	}
-	if cl.CategoryUID != 1 {
-		t.Errorf("expected category_uid 1, got %d", cl.CategoryUID)
-	}
-	if cl.ActivityID != 1 {
-		t.Errorf("expected activity_id 1 (Launch), got %d", cl.ActivityID)
-	}
-}
-
-func TestClassify_ProcessTerminate(t *testing.T) {
-	cl := Classify("process", "terminate")
-	if cl.ActivityID != 2 {
-		t.Errorf("expected activity_id 2 (Terminate), got %d", cl.ActivityID)
-	}
-}
-
-func TestClassify_FileCreate(t *testing.T) {
-	cl := Classify("file", "create")
-	if cl.ClassUID != 1001 {
-		t.Errorf("expected class_uid 1001 for file, got %d", cl.ClassUID)
-	}
-	if cl.ActivityID != 3 {
-		t.Errorf("expected activity_id 3 (Create), got %d", cl.ActivityID)
-	}
-}
-
-func TestClassify_FileRead(t *testing.T) {
-	cl := Classify("file", "read")
-	if cl.ActivityID != 4 {
-		t.Errorf("expected activity_id 4 (Read), got %d", cl.ActivityID)
-	}
-}
-
-func TestClassify_PlistModify(t *testing.T) {
-	cl := Classify("plist", "modify")
-	if cl.ClassUID != 1001 {
-		t.Errorf("expected class_uid 1001 for plist, got %d", cl.ClassUID)
-	}
-	if cl.ActivityID != 5 {
-		t.Errorf("expected activity_id 5 (Update) for modify, got %d", cl.ActivityID)
-	}
-}
-
-func TestClassify_TCC(t *testing.T) {
-	cl := Classify("tcc", "fda_access")
-	if cl.ClassUID != 6003 {
-		t.Errorf("expected class_uid 6003 for tcc, got %d", cl.ClassUID)
-	}
-	if cl.CategoryUID != 6 {
-		t.Errorf("expected category_uid 6 for tcc, got %d", cl.CategoryUID)
-	}
-}
-
-func TestClassify_XPC(t *testing.T) {
-	cl := Classify("xpc", "connect")
-	if cl.ClassUID != 6003 {
-		t.Errorf("expected class_uid 6003 for xpc, got %d", cl.ClassUID)
-	}
-}
-
-func TestClassify_Service(t *testing.T) {
-	cl := Classify("service", "launch_agent")
-	if cl.ClassUID != 1006 {
-		t.Errorf("expected class_uid 1006 for service, got %d", cl.ClassUID)
-	}
-}
-
-func TestClassify_EndpointSecurityFile(t *testing.T) {
-	cl := Classify("endpoint_security", "es_file_create")
-	if cl.ClassUID != 1001 {
-		t.Errorf("expected class_uid 1001 for es_file_*, got %d", cl.ClassUID)
-	}
-}
-
-func TestClassify_EndpointSecurityProcess(t *testing.T) {
-	cl := Classify("endpoint_security", "es_process_exec")
-	if cl.ClassUID != 1007 {
-		t.Errorf("expected class_uid 1007 for es_process_*, got %d", cl.ClassUID)
-	}
-}
-
-func TestClassify_UnknownFallback(t *testing.T) {
-	cl := Classify("unknown_category", "unknown_event")
-	if cl.ClassUID != 6003 {
-		t.Errorf("expected fallback class_uid 6003, got %d", cl.ClassUID)
-	}
-	if cl.ActivityID != 99 {
-		t.Errorf("expected fallback activity_id 99 (Other), got %d", cl.ActivityID)
-	}
-}
-
-func TestClassify_TypeUID(t *testing.T) {
+func TestClassify_TypeUIDConsistency(t *testing.T) {
 	cl := Classify("network", "tcp_connect")
 	typeUID := cl.ClassUID*100 + cl.ActivityID
 	if typeUID != 400101 {
-		t.Errorf("expected type_uid 400101, got %d", typeUID)
+		t.Errorf("type_uid = %d, want 400101", typeUID)
 	}
 }


### PR DESCRIPTION
classify.go's switches matched event-type strings no module actually emits, so nearly everything fell through to wrong defaults (all 4 endpoint_security events landed in the wrong OCSF class entirely). Rewrote it against all 46 real event types with activity IDs verified live against the OCSF 1.7.0 schema.