### PR TITLE
fix: populate required OCSF file/process/device fields on audit records

### DIFF
--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -37,6 +38,7 @@ type Logger struct {
 	runID   string
 	version string
 	actor   *OCSFActor
+	device  *OCSFDevice
 }
 
 // NewLogger opens (or creates) path for append and returns a ready Logger.
@@ -50,6 +52,7 @@ func NewLogger(path, version string) (*Logger, error) {
 		runID:   generateRunID(),
 		version: version,
 		actor:   currentActor(),
+		device:  currentDevice(),
 	}, nil
 }
 
@@ -107,6 +110,7 @@ func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, para
 		Status:       status,
 		Metadata:     l.metadata(),
 		Actor:        l.actor,
+		Device:       l.device,
 		Attacks:      mitreToAttacks(info.MITRE),
 		Unmapped: UnmappedData{
 			Module:         info.Name,
@@ -114,6 +118,13 @@ func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, para
 			Params:         map[string]string(params),
 			Privileges:     string(info.Privileges),
 		},
+	}
+
+	switch cl.ClassUID {
+	case 1001:
+		rec.File = extractFile(ev.EventType, ev.Details)
+	case 1007:
+		rec.Process = extractProcess(ev.Details, l.actor.Process)
 	}
 
 	l.write(rec)
@@ -173,6 +184,7 @@ func (l *Logger) LogLifecycle(recordType string, info module.ModuleInfo, params 
 		Duration:     dur,
 		Metadata:     l.metadata(),
 		Actor:        l.actor,
+		Device:       l.device,
 		Attacks:      mitreToAttacks(info.MITRE),
 		Unmapped:     unmapped,
 	}
@@ -231,6 +243,7 @@ func (l *Logger) LogScenario(name, path string, data LifecycleData) {
 		Duration:     dur,
 		Metadata:     l.metadata(),
 		Actor:        l.actor,
+		Device:       l.device,
 		Unmapped: ScenarioUnmappedData{
 			ScenarioName:  name,
 			ScenarioFile:  path,
@@ -284,6 +297,60 @@ func currentActor() *OCSFActor {
 		proc.User = &OCSFUser{Name: u.Username}
 	}
 	return &OCSFActor{Process: proc}
+}
+
+// currentDevice identifies the local host. type_id is Unknown (0) rather
+// than a guess at Desktop/Laptop, since nothing here can reliably tell them
+// apart; hostname alone satisfies OCSF's "at least one identifying field" rule.
+func currentDevice() *OCSFDevice {
+	hostname, _ := os.Hostname()
+	return &OCSFDevice{TypeID: 0, Hostname: hostname}
+}
+
+// extractFile builds the file object a file_activity (1001) record requires
+// from whatever the emitting module put in ev.Details. Modules aren't
+// required to use a consistent key for this (most use "path"; file_archive
+// uses "output_path" for the archive it created), so this is deliberately
+// best-effort: if no known key is present, it still returns a non-nil File
+// (satisfying the required field) generic enough not to claim data that
+// isn't there.
+func extractFile(eventType string, details map[string]any) *OCSFFile {
+	path, _ := details["path"].(string)
+	if path == "" {
+		path, _ = details["output_path"].(string)
+	}
+	typeID := 1 // Regular File
+	if eventType == "dir_create" {
+		typeID = 2 // Folder
+	}
+	if path == "" {
+		return &OCSFFile{Name: eventType, TypeID: typeID}
+	}
+	return &OCSFFile{Name: filepath.Base(path), Path: path, TypeID: typeID}
+}
+
+// extractProcess builds the process object a process_activity (1007) record
+// requires. A handful of modules record the actual target process's pid
+// and/or command in ev.Details (process_fork has both; process_spawn and
+// dylib_inject_attempt have a command/target with no pid, since those exec
+// synchronously rather than tracking a forked pid); everything else falls
+// back to macnoise's own process, since it performed the activity even when
+// it didn't hand off to a distinctly-tracked child.
+func extractProcess(details map[string]any, fallback *OCSFProcess) *OCSFProcess {
+	name, hasName := details["command"].(string)
+	if !hasName {
+		name, hasName = details["target"].(string)
+	}
+	pid, hasPID := details["pid"].(int)
+
+	if !hasName && !hasPID {
+		return fallback
+	}
+	proc := &OCSFProcess{Name: name}
+	if hasPID {
+		proc.PID = pid
+	}
+	return proc
 }
 
 func mitreToAttacks(mitre []module.MITRE) []OCSFAttack {

--- a/internal/audit/record.go
+++ b/internal/audit/record.go
@@ -25,8 +25,27 @@ type Record struct {
 	Duration     int64        `json:"duration,omitempty"`
 	Metadata     OCSFMetadata `json:"metadata"`
 	Actor        *OCSFActor   `json:"actor,omitempty"`
+	Device       *OCSFDevice  `json:"device,omitempty"`
+	File         *OCSFFile    `json:"file,omitempty"`
+	Process      *OCSFProcess `json:"process,omitempty"`
 	Attacks      []OCSFAttack `json:"attacks,omitempty"`
 	Unmapped     any          `json:"unmapped,omitempty"`
+}
+
+// OCSFDevice identifies the host macnoise is running on. Required by OCSF for
+// file_activity (1001) and process_activity (1007); populated once per
+// Logger and reused across every record rather than recomputed per event.
+type OCSFDevice struct {
+	TypeID   int    `json:"type_id"`
+	Hostname string `json:"hostname,omitempty"`
+}
+
+// OCSFFile identifies the file targeted by a file_activity (1001) record.
+// Required by OCSF for that class.
+type OCSFFile struct {
+	Name   string `json:"name"`
+	Path   string `json:"path,omitempty"`
+	TypeID int    `json:"type_id"`
 }
 
 // OCSFMetadata carries OCSF product and log metadata embedded in every Record.

--- a/internal/audit/record_test.go
+++ b/internal/audit/record_test.go
@@ -1,0 +1,166 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestExtractFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		details   map[string]any
+		wantName  string
+		wantPath  string
+		wantType  int
+	}{
+		{
+			name:      "path key",
+			eventType: "file_create",
+			details:   map[string]any{"path": "/tmp/macnoise_test/file1.txt"},
+			wantName:  "file1.txt",
+			wantPath:  "/tmp/macnoise_test/file1.txt",
+			wantType:  1,
+		},
+		{
+			name:      "output_path key (file_archive)",
+			eventType: "archive_create",
+			details:   map[string]any{"output_path": "/tmp/macnoise_archive.zip", "source_dir": "/tmp/src"},
+			wantName:  "macnoise_archive.zip",
+			wantPath:  "/tmp/macnoise_archive.zip",
+			wantType:  1,
+		},
+		{
+			name:      "dir_create gets Folder type_id",
+			eventType: "dir_create",
+			details:   map[string]any{"path": "/tmp/macnoise_test"},
+			wantName:  "macnoise_test",
+			wantPath:  "/tmp/macnoise_test",
+			wantType:  2,
+		},
+		{
+			name:      "no known path key still returns a non-nil File",
+			eventType: "plist_modify",
+			details:   map[string]any{"domain": "com.macnoise.test", "key": "MacnoiseTest"},
+			wantName:  "plist_modify",
+			wantPath:  "",
+			wantType:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := extractFile(tt.eventType, tt.details)
+			if f == nil {
+				t.Fatal("extractFile returned nil, OCSF requires file to be present for file_activity records")
+			}
+			if f.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", f.Name, tt.wantName)
+			}
+			if f.Path != tt.wantPath {
+				t.Errorf("Path = %q, want %q", f.Path, tt.wantPath)
+			}
+			if f.TypeID != tt.wantType {
+				t.Errorf("TypeID = %d, want %d", f.TypeID, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestExtractProcess(t *testing.T) {
+	fallback := &OCSFProcess{PID: 999, Name: "MacNoise"}
+
+	tests := []struct {
+		name     string
+		details  map[string]any
+		wantPID  int
+		wantName string
+	}{
+		{
+			name:     "pid and command (process_fork)",
+			details:  map[string]any{"pid": 4242, "command": "sleep 30"},
+			wantPID:  4242,
+			wantName: "sleep 30",
+		},
+		{
+			name:     "command only, no pid (process_spawn)",
+			details:  map[string]any{"command": "echo hi"},
+			wantPID:  0,
+			wantName: "echo hi",
+		},
+		{
+			name:     "target only (dylib_inject_attempt)",
+			details:  map[string]any{"target": "/usr/bin/true", "dyld_insert_libs": "/tmp/x.dylib"},
+			wantPID:  0,
+			wantName: "/usr/bin/true",
+		},
+		{
+			name:     "neither key present falls back to macnoise's own process",
+			details:  map[string]any{"language": "AppleScript", "script": "display notification"},
+			wantPID:  fallback.PID,
+			wantName: fallback.Name,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := extractProcess(tt.details, fallback)
+			if p == nil {
+				t.Fatal("extractProcess returned nil, OCSF requires process to be present for process_activity records")
+			}
+			if p.PID != tt.wantPID {
+				t.Errorf("PID = %d, want %d", p.PID, tt.wantPID)
+			}
+			if p.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", p.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+// LogEvent must populate device on every record, and file/process only for
+// the classes that actually require them (1001/1007) - not spuriously on
+// classes where OCSF doesn't ask for them.
+func TestLogEvent_RequiredFieldsByClass(t *testing.T) {
+	tests := []struct {
+		name        string
+		category    string
+		eventType   string
+		details     map[string]any
+		wantFile    bool
+		wantProcess bool
+	}{
+		{"file_activity gets file, no process", "file", "file_create", map[string]any{"path": "/tmp/x.txt"}, true, false},
+		{"process_activity gets process, no file", "process", "process_spawn", map[string]any{"command": "id"}, false, true},
+		{"network_activity gets neither", "network", "tcp_connect", nil, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, path := newTestLogger(t)
+			defer l.Close()
+
+			info := module.ModuleInfo{Name: "test_mod", Category: module.Category(tt.category), Privileges: module.PrivilegeNone}
+			ev := module.TelemetryEvent{Category: tt.category, EventType: tt.eventType, Success: true, Details: tt.details}
+			l.LogEvent(ev, info, module.Params{})
+			l.Close()
+
+			records := readRecords(t, path)
+			if len(records) != 1 {
+				t.Fatalf("expected 1 record, got %d", len(records))
+			}
+			rec := records[0]
+
+			if rec.Device == nil {
+				t.Error("device must be populated on every record")
+			}
+			if (rec.File != nil) != tt.wantFile {
+				t.Errorf("file present = %v, want %v", rec.File != nil, tt.wantFile)
+			}
+			if (rec.Process != nil) != tt.wantProcess {
+				t.Errorf("process present = %v, want %v", rec.Process != nil, tt.wantProcess)
+			}
+		})
+	}
+}


### PR DESCRIPTION
file_activity and process_activity records were missing OCSF's required file/process/device objects entirely. Added best-effort extraction from each module's existing event details, plus a device object populated once per run, with tests covering the extraction logic and per-class wiring.