### PR TITLE
fix: wire context cancellation into net_listen and net_revshell dials

### DIFF
--- a/modules/network/listen.go
+++ b/modules/network/listen.go
@@ -32,6 +32,7 @@ func (n *netListen) Info() module.ModuleInfo {
 func (n *netListen) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{Name: "port", Description: "Local port to bind", Required: false, DefaultValue: "8080", Example: "9999"},
+		{Name: "bind_addr", Description: "Address to bind", Required: false, DefaultValue: "127.0.0.1", Example: "0.0.0.0"},
 	}
 }
 
@@ -39,7 +40,8 @@ func (n *netListen) CheckPrereqs() error { return nil }
 
 func (n *netListen) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	port := params.Get("port", "8080")
-	address := net.JoinHostPort("0.0.0.0", port)
+	bindAddr := params.Get("bind_addr", "127.0.0.1")
+	address := net.JoinHostPort(bindAddr, port)
 	info := n.Info()
 
 	l, err := net.Listen("tcp", address)
@@ -66,23 +68,38 @@ func (n *netListen) Generate(ctx context.Context, params module.Params, emit mod
 		_ = conn.Close()
 	}()
 
-	conn, err := l.Accept()
-	if err != nil {
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	acceptCh := make(chan acceptResult, 1)
+	go func() {
+		conn, err := l.Accept()
+		acceptCh <- acceptResult{conn, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = l.Close()
+		return ctx.Err()
+	case res := <-acceptCh:
+		if res.err != nil {
+			return nil
+		}
+		defer func() { _ = res.conn.Close() }()
+
+		accepted := output.NewEvent(info, "tcp_accept", true, fmt.Sprintf("accepted connection from %s", res.conn.RemoteAddr()))
+		accepted = output.WithDetails(accepted, map[string]any{"remote_addr": res.conn.RemoteAddr().String()})
+		emit(accepted)
 		return nil
 	}
-	defer func() { _ = conn.Close() }()
-
-	accepted := output.NewEvent(info, "tcp_accept", true, fmt.Sprintf("accepted connection from %s", conn.RemoteAddr()))
-	accepted = output.WithDetails(accepted, map[string]any{"remote_addr": conn.RemoteAddr().String()})
-	emit(accepted)
-
-	return nil
 }
 
 func (n *netListen) DryRun(params module.Params) []string {
 	port := params.Get("port", "8080")
+	bindAddr := params.Get("bind_addr", "127.0.0.1")
 	return []string{
-		fmt.Sprintf("bind TCP 0.0.0.0:%s", port),
+		fmt.Sprintf("bind TCP %s:%s", bindAddr, port),
 		"accept one connection from self (127.0.0.1)",
 	}
 }

--- a/modules/network/listen_test.go
+++ b/modules/network/listen_test.go
@@ -1,0 +1,102 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestNetListen_AcceptsSelfConnection(t *testing.T) {
+	n := &netListen{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := n.Generate(ctx, module.Params{"port": "18081"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	defer n.Cleanup() //nolint:errcheck
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (tcp_listen, tcp_accept), got %d", len(events))
+	}
+	if events[0].EventType != "tcp_listen" || !events[0].Success {
+		t.Errorf("event[0] = %+v, want successful tcp_listen", events[0])
+	}
+	if events[1].EventType != "tcp_accept" || !events[1].Success {
+		t.Errorf("event[1] = %+v, want successful tcp_accept", events[1])
+	}
+}
+
+// Before the fix, ctx was never wired into l.Accept(), so an expired context
+// had no effect and Generate only returned once the self-dial goroutine
+// connected (~200ms) or hung forever if it didn't. An already-cancelled
+// context must now short-circuit Accept() immediately.
+func TestNetListen_RespectsContextCancellation(t *testing.T) {
+	n := &netListen{}
+	emit := func(module.TelemetryEvent) {}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := n.Generate(ctx, module.Params{"port": "18082"}, emit)
+	elapsed := time.Since(start)
+	defer n.Cleanup() //nolint:errcheck
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if elapsed > 150*time.Millisecond {
+		t.Errorf("Generate took %v to return after cancellation, want well under the 200ms self-dial delay", elapsed)
+	}
+}
+
+func TestNetListen_DefaultBindsLoopback(t *testing.T) {
+	n := &netListen{}
+	emit := func(module.TelemetryEvent) {}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := n.Generate(ctx, module.Params{"port": "18083"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	defer n.Cleanup() //nolint:errcheck
+
+	addr, ok := n.listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener.Addr() is %T, want *net.TCPAddr", n.listener.Addr())
+	}
+	if !addr.IP.IsLoopback() {
+		t.Errorf("bound IP = %s, want loopback (127.0.0.1) by default", addr.IP)
+	}
+}
+
+func TestNetListen_CustomBindAddr(t *testing.T) {
+	n := &netListen{}
+	emit := func(module.TelemetryEvent) {}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	params := module.Params{"port": "18084", "bind_addr": "0.0.0.0"}
+	if err := n.Generate(ctx, params, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	defer n.Cleanup() //nolint:errcheck
+
+	addr, ok := n.listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener.Addr() is %T, want *net.TCPAddr", n.listener.Addr())
+	}
+	if !addr.IP.IsUnspecified() {
+		t.Errorf("bound IP = %s, want 0.0.0.0 when bind_addr is set explicitly", addr.IP)
+	}
+}

--- a/modules/network/revshell.go
+++ b/modules/network/revshell.go
@@ -45,7 +45,8 @@ func (n *netRevShell) Generate(ctx context.Context, params module.Params, emit m
 	info := n.Info()
 	ev := output.NewEvent(info, "reverse_shell_attempt", false, fmt.Sprintf("connecting /bin/sh to %s", address))
 
-	conn, err := net.Dial("tcp", address)
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
 		ev = output.WithError(ev, err)
 		ev.Success = true

--- a/modules/network/revshell_test.go
+++ b/modules/network/revshell_test.go
@@ -1,0 +1,58 @@
+package network
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// Dial failures are reported as a (Success=true, Error=<detail>) event rather
+// than a Generate error - "connection refused" is expected, valid telemetry
+// when nothing is listening. Before the fix, net.Dial ignored ctx entirely,
+// so an already-cancelled context still ran a real connect attempt and
+// failed with "connection refused". net.Dialer.DialContext checks ctx.Err()
+// before attempting anything, so a pre-cancelled context now short-circuits
+// with a context error instead of ever reaching the network stack -
+// verified directly (see scratch dialtest) that DialContext against an
+// already-cancelled context never produces a "refused" error.
+func TestNetRevShell_DialRespectsContext(t *testing.T) {
+	n := &netRevShell{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := n.Generate(ctx, module.Params{"target": "127.0.0.1", "port": "1"}, emit)
+	if err != nil {
+		t.Fatalf("Generate: %v, want nil (dial failures are reported via event)", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if strings.Contains(events[0].Error, "refused") {
+		t.Errorf("dial reached the network despite an already-cancelled context: %q", events[0].Error)
+	}
+}
+
+func TestNetRevShell_ConnectionRefusedIsReportedAsSuccess(t *testing.T) {
+	n := &netRevShell{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	err := n.Generate(context.Background(), module.Params{"target": "127.0.0.1", "port": "1"}, emit)
+	if err != nil {
+		t.Fatalf("Generate: %v, want nil", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if !events[0].Success {
+		t.Errorf("event.Success = false, want true (connection refused is expected telemetry)")
+	}
+	if !strings.Contains(events[0].Error, "refused") {
+		t.Errorf("event.Error = %q, want it to mention connection refused", events[0].Error)
+	}
+}


### PR DESCRIPTION
--timeout and Ctrl-C did nothing for net_listen (Accept() had no deadline) or net_revshell (Dial ignored ctx entirely), so both could hang past their deadline with cleanup never running. Wired ctx into both via a cancellable Accept goroutine and DialContext, and added a bind_addr param (default 127.0.0.1) since net_listen previously bound 0.0.0.0 with no way to restrict it.