### PR TITLE
feat: read browser credential files instead of stat-only probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make build
 |----------|-------------|---------|
 | `network` | Outbound connections, DNS, beaconing, listeners, reverse shells, exfiltration | net_connect, net_listen, net_beacon, net_revshell, net_dns, net_exfil |
 | `process` | Process spawning, signal delivery, dylib injection, discovery, Gatekeeper bypass, osascript | proc_spawn, proc_signal, proc_inject, proc_discovery, proc_gatekeeper, proc_osascript |
-| `file` | File creation, modification, browser credential probing, archiving, hiding | file_create, file_modify, file_browser_creds, file_archive, file_hide |
+| `file` | File creation, modification, browser credential reads, archiving, hiding | file_create, file_modify, file_browser_creds, file_archive, file_hide |
 | `tcc` | TCC permission probes (FDA, Contacts, Keychain) | tcc_fda, tcc_contacts, tcc_keychain |
 | `endpoint_security` | ES framework event triggers | es_file, es_process |
 | `service` | LaunchAgent/Daemon persistence, cron, shell profile | svc_launch_agent, svc_launch_daemon, svc_cron, svc_shell_profile |

--- a/configs/scenarios/amos_atomic_stealer.yaml
+++ b/configs/scenarios/amos_atomic_stealer.yaml
@@ -159,9 +159,10 @@ steps:
   # AMOS: security unlock-keychain -p <pass> login.keychain-db, then cp to exfil/Keychain/kc.db
   - module: tcc_keychain
 
-  # T1555.003 — probe credential paths for all browser families:
+  # T1555.003 — read credential files for all browser families:
   # Chrome, Brave, Edge, Arc, Vivaldi, Opera, OperaGX (Login Data/Cookies/Web Data),
-  # Firefox (logins.json + key4.db), and Safari (Cookies.binarycookies)
+  # Firefox (logins.json + key4.db), and Safari (Cookies.binarycookies).
+  # Contents are discarded; only the open/read is generated.
   - module: file_browser_creds
     params:
       browsers: all

--- a/configs/scenarios/amos_atomic_stealer.yaml
+++ b/configs/scenarios/amos_atomic_stealer.yaml
@@ -160,7 +160,8 @@ steps:
   - module: tcc_keychain
 
   # T1555.003 — read credential files for all browser families:
-  # Chrome, Brave, Edge, Arc, Vivaldi, Opera, OperaGX (Login Data/Cookies/Web Data),
+  # Chrome, ChromeCanary, Brave, Arc, Edge, Vivaldi, Yandex, Opera, OperaGX
+  # (Login Data/Cookies/Web Data/Local State, every profile directory),
   # Firefox (logins.json + key4.db), and Safari (Cookies.binarycookies).
   # Contents are discarded; only the open/read is generated.
   - module: file_browser_creds

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -75,7 +75,7 @@ func fileActivity(eventType string) (int, string) {
 	case "file_create", "dir_create", "file_hide_dotfile", "archive_create",
 		"plist_create", "plist_create_launchagent":
 		return 1, "Create"
-	case "plist_read_prior":
+	case "plist_read_prior", "browser_cred_read":
 		return 2, "Read"
 	case "file_modify", "plist_modify":
 		return 3, "Update"

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -26,6 +26,7 @@ func TestClassify(t *testing.T) {
 		// file
 		{"file", "archive_create", 1001, 1},
 		{"file", "browser_cred_probe", 1001, 8},
+		{"file", "browser_cred_read", 1001, 2},
 		{"file", "dir_create", 1001, 1},
 		{"file", "file_create", 1001, 1},
 		{"file", "file_hide_chflags", 1001, 6},

--- a/modules/file/README.md
+++ b/modules/file/README.md
@@ -11,7 +11,7 @@ Creates files in a directory. Maps to T1074.001. Cleanup removes created files.
 Appends to a file. Maps to T1565.001. Cleanup restores original content.
 
 ### `file_browser_creds`
-Probes known browser credential file paths via `os.Stat` (no read, no copy). Covers Chrome, Brave, Edge, Arc, Vivaldi, Opera, OperaGX, Firefox, and Safari. Emits one `browser_cred_probe` event per path indicating existence, size, and last-modified time. Maps to T1555.003.
+Opens and reads known browser credential files, discarding the contents (no copy, nothing retained). Covers Chrome, Brave, Edge, Arc, Vivaldi, Opera, OperaGX, Firefox (`logins.json`, `key4.db`, `cookies.sqlite` across every profile), and Safari. Emits `browser_cred_read` per file opened, carrying bytes read or the denial reason, and `browser_cred_probe` for paths that are not present. Maps to T1555.003.
 
 ```bash
 macnoise run file_browser_creds

--- a/modules/file/README.md
+++ b/modules/file/README.md
@@ -11,7 +11,7 @@ Creates files in a directory. Maps to T1074.001. Cleanup removes created files.
 Appends to a file. Maps to T1565.001. Cleanup restores original content.
 
 ### `file_browser_creds`
-Opens and reads known browser credential files, discarding the contents (no copy, nothing retained). Covers Chrome, Brave, Edge, Arc, Vivaldi, Opera, OperaGX, Firefox (`logins.json`, `key4.db`, `cookies.sqlite` across every profile), and Safari. Emits `browser_cred_read` per file opened, carrying bytes read or the denial reason, and `browser_cred_probe` for paths that are not present. Maps to T1555.003.
+Opens and reads known browser credential files, discarding the contents (no copy, nothing retained). Covers the Chromium family (Chrome, Chrome Canary, Brave, Arc, Edge, Vivaldi, Yandex, Opera, OperaGX) across every profile directory, reading `Login Data`, `Cookies` (both the legacy and `Network/` locations), `Web Data`, and the `Local State` key that decrypts them; Firefox (`logins.json`, `key4.db`, `cookies.sqlite` per profile); and Safari. Emits `browser_cred_read` per file opened, carrying bytes read or the denial reason, and `browser_cred_probe` for paths that are not present. Maps to T1555.003.
 
 ```bash
 macnoise run file_browser_creds

--- a/modules/file/browser_creds.go
+++ b/modules/file/browser_creds.go
@@ -2,7 +2,9 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +20,10 @@ type browserTarget struct {
 	paths []string
 }
 
+// errNotRegularFile marks a target path that exists but holds nothing to read,
+// so it is reported as a probe rather than a denied read.
+var errNotRegularFile = errors.New("not a regular file")
+
 func chromiumCredPaths(profileBase string) []string {
 	return []string{
 		filepath.Join(profileBase, "Default", "Login Data"),
@@ -26,10 +32,58 @@ func chromiumCredPaths(profileBase string) []string {
 	}
 }
 
+// firefoxCredPaths expands each profile directory into its credential files.
+// Firefox names profile directories with a random prefix, so they have to be
+// enumerated rather than hardcoded. When no profile exists the profiles
+// directory itself is returned, so an absent Firefox still produces a probe
+// event instead of silently emitting nothing.
+func firefoxCredPaths(home string) []string {
+	profilesDir := filepath.Join(home, "Library", "Application Support", "Firefox", "Profiles")
+	entries, err := os.ReadDir(profilesDir)
+	if err != nil {
+		return []string{profilesDir}
+	}
+
+	var paths []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		for _, name := range []string{"logins.json", "key4.db", "cookies.sqlite"} {
+			paths = append(paths, filepath.Join(profilesDir, e.Name(), name))
+		}
+	}
+	if len(paths) == 0 {
+		return []string{profilesDir}
+	}
+	return paths
+}
+
+// readCredFile opens path and reads it to completion, returning the bytes read.
+// The contents are discarded rather than retained: the goal is to generate the
+// open and read telemetry a real credential stealer would, not to collect
+// anything.
+func readCredFile(path string) (int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	if !fi.Mode().IsRegular() {
+		return 0, errNotRegularFile
+	}
+	return io.Copy(io.Discard, f)
+}
+
 func (f *fileBrowserCreds) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "file_browser_creds",
-		Description: "Probes known browser credential file paths via stat to generate browser credential access telemetry",
+		Description: "Reads known browser credential files to generate browser credential access telemetry",
 		Category:    module.CategoryFile,
 		Tags:        []string{"browser", "credentials", "chromium", "firefox", "safari"},
 		Privileges:  module.PrivilegeNone,
@@ -69,12 +123,7 @@ func browserTargets() ([]browserTarget, error) {
 		{name: "vivaldi", paths: chromiumCredPaths(filepath.Join(appSupport, "Vivaldi"))},
 		{name: "opera", paths: chromiumCredPaths(filepath.Join(appSupport, "com.operasoftware.Opera"))},
 		{name: "operagx", paths: chromiumCredPaths(filepath.Join(appSupport, "com.operasoftware.OperaGX"))},
-		{
-			name: "firefox",
-			paths: []string{
-				filepath.Join(home, "Library", "Application Support", "Firefox", "Profiles"),
-			},
-		},
+		{name: "firefox", paths: firefoxCredPaths(home)},
 		{
 			name: "safari",
 			paths: []string{
@@ -112,25 +161,44 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 		}
 
 		for _, path := range browser.paths {
-			ev := output.NewEvent(info, "browser_cred_probe", false, fmt.Sprintf("probing %s: %s", browser.name, path))
-			fi, statErr := os.Stat(path)
-			if statErr != nil {
-				ev.Success = true
-				ev.Message = fmt.Sprintf("%s credential path not accessible: %s", browser.name, path)
+			n, readErr := readCredFile(path)
+
+			var ev module.TelemetryEvent
+			switch {
+			case os.IsNotExist(readErr) || errors.Is(readErr, errNotRegularFile):
+				ev = output.NewEvent(info, "browser_cred_probe", true,
+					fmt.Sprintf("%s credential path not present: %s", browser.name, path))
 				ev = output.WithDetails(ev, map[string]any{
 					"browser": browser.name,
 					"path":    path,
 					"exists":  false,
 				})
-			} else {
+
+			case readErr != nil:
+				// The file exists but could not be opened, which on macOS
+				// usually means TCC denied it. That refusal is the signal a
+				// detection is meant to see, so it is reported as a completed
+				// read attempt rather than a module failure.
+				ev = output.NewEvent(info, "browser_cred_read", true,
+					fmt.Sprintf("%s credential file read denied: %s", browser.name, path))
+				ev = output.WithError(ev, readErr)
 				ev.Success = true
-				ev.Message = fmt.Sprintf("%s credential file found: %s (%d bytes)", browser.name, path, fi.Size())
 				ev = output.WithDetails(ev, map[string]any{
-					"browser":  browser.name,
-					"path":     path,
-					"exists":   true,
-					"size":     fi.Size(),
-					"modified": fi.ModTime().UTC().Format("2006-01-02T15:04:05Z"),
+					"browser":    browser.name,
+					"path":       path,
+					"exists":     true,
+					"accessible": false,
+				})
+
+			default:
+				ev = output.NewEvent(info, "browser_cred_read", true,
+					fmt.Sprintf("%s credential file read: %s (%d bytes)", browser.name, path, n))
+				ev = output.WithDetails(ev, map[string]any{
+					"browser":    browser.name,
+					"path":       path,
+					"exists":     true,
+					"accessible": true,
+					"bytes_read": n,
 				})
 			}
 			emit(ev)
@@ -142,7 +210,7 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 func (f *fileBrowserCreds) DryRun(params module.Params) []string {
 	browsersParam := params.Get("browsers", "all")
 	return []string{
-		fmt.Sprintf("stat browser credential paths for: %s", browsersParam),
+		fmt.Sprintf("open and read browser credential files for: %s (contents discarded)", browsersParam),
 	}
 }
 

--- a/modules/file/browser_creds.go
+++ b/modules/file/browser_creds.go
@@ -56,16 +56,12 @@ func chromiumProfileDirs(base string) []string {
 // a Network subdirectory in newer Chromium releases, so both locations are
 // listed and whichever is absent simply reports as a probe.
 func chromiumCredPaths(base string) []string {
-	paths := []string{filepath.Join(base, "Local State")}
-	for _, profile := range chromiumProfileDirs(base) {
-		paths = append(paths,
-			filepath.Join(profile, "Login Data"),
-			filepath.Join(profile, "Cookies"),
-			filepath.Join(profile, "Network", "Cookies"),
-			filepath.Join(profile, "Web Data"),
-		)
+	_ = chromiumProfileDirs
+	return []string{
+		filepath.Join(base, "Default", "Login Data"),
+		filepath.Join(base, "Default", "Cookies"),
+		filepath.Join(base, "Default", "Web Data"),
 	}
-	return paths
 }
 
 // firefoxCredPaths expands each profile directory into its credential files.
@@ -100,20 +96,15 @@ func firefoxCredPaths(home string) []string {
 // open and read telemetry a real credential stealer would, not to collect
 // anything.
 func readCredFile(path string) (int64, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = f.Close() }()
-
-	fi, err := f.Stat()
+	_ = io.Discard
+	fi, err := os.Stat(path)
 	if err != nil {
 		return 0, err
 	}
 	if !fi.Mode().IsRegular() {
 		return 0, errNotRegularFile
 	}
-	return io.Copy(io.Discard, f)
+	return fi.Size(), nil
 }
 
 func (f *fileBrowserCreds) Info() module.ModuleInfo {
@@ -153,15 +144,13 @@ func browserTargets() ([]browserTarget, error) {
 	appSupport := filepath.Join(home, "Library", "Application Support")
 	return []browserTarget{
 		{name: "chrome", paths: chromiumCredPaths(filepath.Join(appSupport, "Google", "Chrome"))},
-		{name: "chromecanary", paths: chromiumCredPaths(filepath.Join(appSupport, "Google", "Chrome Canary"))},
 		{name: "brave", paths: chromiumCredPaths(filepath.Join(appSupport, "BraveSoftware", "Brave-Browser"))},
 		{name: "edge", paths: chromiumCredPaths(filepath.Join(appSupport, "Microsoft Edge"))},
 		{name: "arc", paths: chromiumCredPaths(filepath.Join(appSupport, "Arc", "User Data"))},
 		{name: "vivaldi", paths: chromiumCredPaths(filepath.Join(appSupport, "Vivaldi"))},
 		{name: "opera", paths: chromiumCredPaths(filepath.Join(appSupport, "com.operasoftware.Opera"))},
 		{name: "operagx", paths: chromiumCredPaths(filepath.Join(appSupport, "com.operasoftware.OperaGX"))},
-		{name: "yandex", paths: chromiumCredPaths(filepath.Join(appSupport, "Yandex", "YandexBrowser"))},
-		{name: "firefox", paths: firefoxCredPaths(home)},
+		{name: "firefox", paths: []string{filepath.Join(home, "Library", "Application Support", "Firefox", "Profiles")}},
 		{
 			name: "safari",
 			paths: []string{

--- a/modules/file/browser_creds.go
+++ b/modules/file/browser_creds.go
@@ -24,12 +24,48 @@ type browserTarget struct {
 // so it is reported as a probe rather than a denied read.
 var errNotRegularFile = errors.New("not a regular file")
 
-func chromiumCredPaths(profileBase string) []string {
-	return []string{
-		filepath.Join(profileBase, "Default", "Login Data"),
-		filepath.Join(profileBase, "Default", "Cookies"),
-		filepath.Join(profileBase, "Default", "Web Data"),
+// chromiumProfileDirs enumerates the profile directories under base. Chromium
+// keeps the first profile in "Default" and any additional ones in "Profile 1",
+// "Profile 2", and so on, so assuming a single profile misses every credential
+// store belonging to secondary profiles. When none are found "Default" is
+// returned so an absent browser still produces a probe event.
+func chromiumProfileDirs(base string) []string {
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return []string{filepath.Join(base, "Default")}
 	}
+
+	var dirs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if name := e.Name(); name == "Default" || name == "Guest Profile" || strings.HasPrefix(name, "Profile ") {
+			dirs = append(dirs, filepath.Join(base, name))
+		}
+	}
+	if len(dirs) == 0 {
+		return []string{filepath.Join(base, "Default")}
+	}
+	return dirs
+}
+
+// chromiumCredPaths lists the credential stores across every profile under
+// base. Local State is included because it holds the key that decrypts Login
+// Data, making it part of the set a real stealer collects. Cookies moved into
+// a Network subdirectory in newer Chromium releases, so both locations are
+// listed and whichever is absent simply reports as a probe.
+func chromiumCredPaths(base string) []string {
+	paths := []string{filepath.Join(base, "Local State")}
+	for _, profile := range chromiumProfileDirs(base) {
+		paths = append(paths,
+			filepath.Join(profile, "Login Data"),
+			filepath.Join(profile, "Cookies"),
+			filepath.Join(profile, "Network", "Cookies"),
+			filepath.Join(profile, "Web Data"),
+		)
+	}
+	return paths
 }
 
 // firefoxCredPaths expands each profile directory into its credential files.
@@ -117,12 +153,14 @@ func browserTargets() ([]browserTarget, error) {
 	appSupport := filepath.Join(home, "Library", "Application Support")
 	return []browserTarget{
 		{name: "chrome", paths: chromiumCredPaths(filepath.Join(appSupport, "Google", "Chrome"))},
+		{name: "chromecanary", paths: chromiumCredPaths(filepath.Join(appSupport, "Google", "Chrome Canary"))},
 		{name: "brave", paths: chromiumCredPaths(filepath.Join(appSupport, "BraveSoftware", "Brave-Browser"))},
 		{name: "edge", paths: chromiumCredPaths(filepath.Join(appSupport, "Microsoft Edge"))},
 		{name: "arc", paths: chromiumCredPaths(filepath.Join(appSupport, "Arc", "User Data"))},
 		{name: "vivaldi", paths: chromiumCredPaths(filepath.Join(appSupport, "Vivaldi"))},
 		{name: "opera", paths: chromiumCredPaths(filepath.Join(appSupport, "com.operasoftware.Opera"))},
 		{name: "operagx", paths: chromiumCredPaths(filepath.Join(appSupport, "com.operasoftware.OperaGX"))},
+		{name: "yandex", paths: chromiumCredPaths(filepath.Join(appSupport, "Yandex", "YandexBrowser"))},
 		{name: "firefox", paths: firefoxCredPaths(home)},
 		{
 			name: "safari",

--- a/modules/file/browser_creds.go
+++ b/modules/file/browser_creds.go
@@ -56,12 +56,16 @@ func chromiumProfileDirs(base string) []string {
 // a Network subdirectory in newer Chromium releases, so both locations are
 // listed and whichever is absent simply reports as a probe.
 func chromiumCredPaths(base string) []string {
-	_ = chromiumProfileDirs
-	return []string{
-		filepath.Join(base, "Default", "Login Data"),
-		filepath.Join(base, "Default", "Cookies"),
-		filepath.Join(base, "Default", "Web Data"),
+	paths := []string{filepath.Join(base, "Local State")}
+	for _, profile := range chromiumProfileDirs(base) {
+		paths = append(paths,
+			filepath.Join(profile, "Login Data"),
+			filepath.Join(profile, "Cookies"),
+			filepath.Join(profile, "Network", "Cookies"),
+			filepath.Join(profile, "Web Data"),
+		)
 	}
+	return paths
 }
 
 // firefoxCredPaths expands each profile directory into its credential files.
@@ -96,15 +100,20 @@ func firefoxCredPaths(home string) []string {
 // open and read telemetry a real credential stealer would, not to collect
 // anything.
 func readCredFile(path string) (int64, error) {
-	_ = io.Discard
-	fi, err := os.Stat(path)
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	fi, err := f.Stat()
 	if err != nil {
 		return 0, err
 	}
 	if !fi.Mode().IsRegular() {
 		return 0, errNotRegularFile
 	}
-	return fi.Size(), nil
+	return io.Copy(io.Discard, f)
 }
 
 func (f *fileBrowserCreds) Info() module.ModuleInfo {
@@ -144,13 +153,15 @@ func browserTargets() ([]browserTarget, error) {
 	appSupport := filepath.Join(home, "Library", "Application Support")
 	return []browserTarget{
 		{name: "chrome", paths: chromiumCredPaths(filepath.Join(appSupport, "Google", "Chrome"))},
+		{name: "chromecanary", paths: chromiumCredPaths(filepath.Join(appSupport, "Google", "Chrome Canary"))},
 		{name: "brave", paths: chromiumCredPaths(filepath.Join(appSupport, "BraveSoftware", "Brave-Browser"))},
 		{name: "edge", paths: chromiumCredPaths(filepath.Join(appSupport, "Microsoft Edge"))},
 		{name: "arc", paths: chromiumCredPaths(filepath.Join(appSupport, "Arc", "User Data"))},
 		{name: "vivaldi", paths: chromiumCredPaths(filepath.Join(appSupport, "Vivaldi"))},
 		{name: "opera", paths: chromiumCredPaths(filepath.Join(appSupport, "com.operasoftware.Opera"))},
 		{name: "operagx", paths: chromiumCredPaths(filepath.Join(appSupport, "com.operasoftware.OperaGX"))},
-		{name: "firefox", paths: []string{filepath.Join(home, "Library", "Application Support", "Firefox", "Profiles")}},
+		{name: "yandex", paths: chromiumCredPaths(filepath.Join(appSupport, "Yandex", "YandexBrowser"))},
+		{name: "firefox", paths: firefoxCredPaths(home)},
 		{
 			name: "safari",
 			paths: []string{

--- a/modules/file/browser_creds_test.go
+++ b/modules/file/browser_creds_test.go
@@ -1,0 +1,214 @@
+//go:build integration && darwin
+
+package file
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// writeCredFixture creates path and its parents with the given contents.
+func writeCredFixture(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+func eventsByPath(events []module.TelemetryEvent) map[string]module.TelemetryEvent {
+	byPath := map[string]module.TelemetryEvent{}
+	for _, ev := range events {
+		if p, ok := ev.Details["path"].(string); ok {
+			byPath[p] = ev
+		}
+	}
+	return byPath
+}
+
+// The module reads $HOME-relative paths, and os.UserHomeDir resolves $HOME on
+// darwin, so pointing HOME at a fixture tree exercises the real read path
+// without touching the running user's actual browser data.
+func TestBrowserCreds_ReadsRealFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	loginData := filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default", "Login Data")
+	writeCredFixture(t, loginData, "fake chrome login db payload")
+
+	f := &fileBrowserCreds{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	if err := f.Generate(context.Background(), module.Params{"browsers": "chrome"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	ev, ok := eventsByPath(events)[loginData]
+	if !ok {
+		t.Fatalf("no event emitted for %s", loginData)
+	}
+	if ev.EventType != "browser_cred_read" {
+		t.Errorf("EventType = %q, want browser_cred_read", ev.EventType)
+	}
+	if got := ev.Details["bytes_read"]; got != int64(len("fake chrome login db payload")) {
+		t.Errorf("bytes_read = %v, want %d", got, len("fake chrome login db payload"))
+	}
+	if ev.Details["accessible"] != true {
+		t.Errorf("accessible = %v, want true", ev.Details["accessible"])
+	}
+}
+
+func TestBrowserCreds_MissingPathIsProbeNotRead(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	f := &fileBrowserCreds{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	if err := f.Generate(context.Background(), module.Params{"browsers": "chrome"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected probe events for absent chrome paths")
+	}
+	for _, ev := range events {
+		if ev.EventType != "browser_cred_probe" {
+			t.Errorf("EventType = %q, want browser_cred_probe for absent path %v", ev.EventType, ev.Details["path"])
+		}
+		if ev.Details["exists"] != false {
+			t.Errorf("exists = %v, want false", ev.Details["exists"])
+		}
+	}
+}
+
+// An unreadable file must be reported as an attempted read, since a TCC or
+// POSIX refusal is the signal detections key on - not skipped as if absent.
+func TestBrowserCreds_UnreadableFileIsDeniedRead(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, mode bits do not deny access")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cookies := filepath.Join(home, "Library", "Cookies", "Cookies.binarycookies")
+	writeCredFixture(t, cookies, "fake safari cookies")
+	if err := os.Chmod(cookies, 0o000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	f := &fileBrowserCreds{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	if err := f.Generate(context.Background(), module.Params{"browsers": "safari"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	ev, ok := eventsByPath(events)[cookies]
+	if !ok {
+		t.Fatalf("no event emitted for %s", cookies)
+	}
+	if ev.EventType != "browser_cred_read" {
+		t.Errorf("EventType = %q, want browser_cred_read", ev.EventType)
+	}
+	if ev.Details["accessible"] != false {
+		t.Errorf("accessible = %v, want false", ev.Details["accessible"])
+	}
+	if ev.Error == "" {
+		t.Error("expected the denial reason to be recorded in Error")
+	}
+	if !ev.Success {
+		t.Error("Success = false, want true: a denied read is expected telemetry, not a module failure")
+	}
+}
+
+// The AMOS scenario claims Firefox coverage of logins.json and key4.db, which
+// requires enumerating the randomly-named profile directories.
+func TestBrowserCreds_EnumeratesFirefoxProfiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	profile := filepath.Join(home, "Library", "Application Support", "Firefox", "Profiles", "abc123.default-release")
+	logins := filepath.Join(profile, "logins.json")
+	key4 := filepath.Join(profile, "key4.db")
+	writeCredFixture(t, logins, `{"logins":[]}`)
+	writeCredFixture(t, key4, "fake key4 db")
+
+	f := &fileBrowserCreds{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	if err := f.Generate(context.Background(), module.Params{"browsers": "firefox"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	byPath := eventsByPath(events)
+	for _, want := range []string{logins, key4} {
+		ev, ok := byPath[want]
+		if !ok {
+			t.Errorf("no event emitted for %s", want)
+			continue
+		}
+		if ev.EventType != "browser_cred_read" {
+			t.Errorf("%s: EventType = %q, want browser_cred_read", want, ev.EventType)
+		}
+	}
+}
+
+// With Firefox absent the profiles directory itself must still produce a probe,
+// so a missing browser is visible in telemetry rather than silently skipped.
+func TestBrowserCreds_AbsentFirefoxStillProbes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	f := &fileBrowserCreds{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	if err := f.Generate(context.Background(), module.Params{"browsers": "firefox"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 probe event for absent firefox, got %d", len(events))
+	}
+	if events[0].EventType != "browser_cred_probe" {
+		t.Errorf("EventType = %q, want browser_cred_probe", events[0].EventType)
+	}
+}
+
+// A directory sitting where a credential file is expected must not be reported
+// as a denied read: nothing was there to read in the first place.
+func TestBrowserCreds_DirectoryTargetIsProbe(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	loginData := filepath.Join(home, "Library", "Application Support", "Google", "Chrome", "Default", "Login Data")
+	if err := os.MkdirAll(loginData, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	f := &fileBrowserCreds{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	if err := f.Generate(context.Background(), module.Params{"browsers": "chrome"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	ev, ok := eventsByPath(events)[loginData]
+	if !ok {
+		t.Fatalf("no event emitted for %s", loginData)
+	}
+	if ev.EventType != "browser_cred_probe" {
+		t.Errorf("EventType = %q, want browser_cred_probe for a directory", ev.EventType)
+	}
+}

--- a/modules/file/browser_creds_test.go
+++ b/modules/file/browser_creds_test.go
@@ -131,6 +131,69 @@ func TestBrowserCreds_UnreadableFileIsDeniedRead(t *testing.T) {
 	}
 }
 
+// Chromium keeps secondary profiles in "Profile N" directories, so covering
+// only "Default" would miss every credential store they hold.
+func TestBrowserCreds_EnumeratesChromiumProfiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	chrome := filepath.Join(home, "Library", "Application Support", "Google", "Chrome")
+	defaultLogins := filepath.Join(chrome, "Default", "Login Data")
+	secondLogins := filepath.Join(chrome, "Profile 1", "Login Data")
+	guestCookies := filepath.Join(chrome, "Guest Profile", "Network", "Cookies")
+	localState := filepath.Join(chrome, "Local State")
+	writeCredFixture(t, defaultLogins, "default profile logins")
+	writeCredFixture(t, secondLogins, "second profile logins")
+	writeCredFixture(t, guestCookies, "guest cookies")
+	writeCredFixture(t, localState, `{"os_crypt":{"encrypted_key":"fake"}}`)
+
+	f := &fileBrowserCreds{}
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	if err := f.Generate(context.Background(), module.Params{"browsers": "chrome"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	byPath := eventsByPath(events)
+	for _, want := range []string{defaultLogins, secondLogins, guestCookies, localState} {
+		ev, ok := byPath[want]
+		if !ok {
+			t.Errorf("no event emitted for %s", want)
+			continue
+		}
+		if ev.EventType != "browser_cred_read" {
+			t.Errorf("%s: EventType = %q, want browser_cred_read", want, ev.EventType)
+		}
+	}
+}
+
+// Every Chromium-family browser the AMOS scenario names must be covered, not
+// just the ones that happen to be installed.
+func TestBrowserCreds_CoversAllChromiumFamilies(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	want := []string{"chrome", "chromecanary", "brave", "arc", "edge", "vivaldi", "yandex", "opera", "operagx"}
+
+	f := &fileBrowserCreds{}
+	seen := map[string]bool{}
+	emit := func(ev module.TelemetryEvent) {
+		if b, ok := ev.Details["browser"].(string); ok {
+			seen[b] = true
+		}
+	}
+
+	if err := f.Generate(context.Background(), module.Params{}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	for _, b := range want {
+		if !seen[b] {
+			t.Errorf("no events emitted for browser %q", b)
+		}
+	}
+}
+
 // The AMOS scenario claims Firefox coverage of logins.json and key4.db, which
 // requires enumerating the randomly-named profile directories.
 func TestBrowserCreds_EnumeratesFirefoxProfiles(t *testing.T) {


### PR DESCRIPTION
file_browser_creds only called os.Stat, so it generated none of the open/read telemetry T1555.003 detections key on, and it covered a single hardcoded Chromium profile, missed Chrome Canary and Yandex, and pointed Firefox at the Profiles directory rather than the logins.json and key4.db the AMOS scenario claimed. It now opens and reads each file with contents discarded, enumerates every Chromium and Firefox profile, adds Local State and the newer Network/Cookies location, and reports denied reads separately from absent paths.