### PR TITLE
fix: distinguish absent resources from TCC denials in probe modules

### DIFF
--- a/modules/tcc/README.md
+++ b/modules/tcc/README.md
@@ -5,10 +5,12 @@ TCC permission probes covering Full Disk Access, Contacts, and Keychain.
 ## Modules
 
 ### `tcc_fda`
-Attempts to open TCC.db. Reports grant/deny. Maps to T1555.
+Attempts to open the per-user `TCC.db` (`~/Library/Application Support/com.apple.TCC/TCC.db`). That file is owned by the user running the probe, so POSIX permits the read and only Full Disk Access decides the outcome; the system database under `/Library` is root-owned and would be refused by mode bits before TCC is ever consulted. Override with `--param tcc_path=<path>`. Maps to T1555.
 
 ### `tcc_contacts`
-Enumerates AddressBook directory. Maps to T1636.003.
+Enumerates the AddressBook directory. Maps to T1636.003.
+
+Both probes report `result` as one of `granted`, `denied`, `absent`, or `error`. `absent` means the resource does not exist, so no TCC decision was made, and it is deliberately distinct from `denied` so that consumers counting denials do not treat an unused feature as a privacy refusal.
 
 ### `tcc_keychain`
 Probes keychain access by running `security list-keychains`, `security unlock-keychain`, and `security dump-keychain`. An empty password causes an expected denial — generating denied-access telemetry without needing valid credentials. Emits `keychain_list`, `keychain_unlock_attempt`, and `keychain_dump_attempt` events. Maps to T1555.001.

--- a/modules/tcc/contacts.go
+++ b/modules/tcc/contacts.go
@@ -52,30 +52,30 @@ func (t *tccContacts) Generate(ctx context.Context, params module.Params, emit m
 	}
 
 	info := t.Info()
-	ev := output.NewEvent(info, "tcc_contacts_probe", false, fmt.Sprintf("enumerating %s", abPath))
+	ev := output.NewEvent(info, "tcc_contacts_probe", true, fmt.Sprintf("enumerating %s", abPath))
+	details := map[string]any{"path": abPath}
 
 	entries, err := os.ReadDir(abPath)
-	if err != nil {
-		ev.Success = true
+	outcome := classifyProbe(err)
+	details["result"] = string(outcome)
+
+	switch outcome {
+	case probeGranted:
+		ev.Message = fmt.Sprintf("Contacts TCC probe: read access granted, found %d entries in %s", len(entries), abPath)
+		details["entry_count"] = len(entries)
+	case probeDenied:
 		ev.Message = fmt.Sprintf("Contacts TCC probe: access denied to %s (expected without permission)", abPath)
-		ev = output.WithDetails(ev, map[string]any{
-			"path":   abPath,
-			"result": "denied",
-		})
-		if !os.IsPermission(err) && !os.IsNotExist(err) {
-			ev = output.WithError(ev, err)
-		}
-		emit(ev)
-		return nil
+	case probeAbsent:
+		ev.Message = fmt.Sprintf("Contacts TCC probe: %s does not exist, no TCC decision was made", abPath)
+		ev = output.WithError(ev, err)
+		ev.Success = true
+	default:
+		ev.Message = fmt.Sprintf("Contacts TCC probe: unexpected failure reading %s", abPath)
+		ev = output.WithError(ev, err)
+		ev.Success = true
 	}
 
-	ev.Success = true
-	ev.Message = fmt.Sprintf("Contacts TCC probe: read access granted, found %d entries in %s", len(entries), abPath)
-	ev = output.WithDetails(ev, map[string]any{
-		"path":        abPath,
-		"result":      "granted",
-		"entry_count": len(entries),
-	})
+	ev = output.WithDetails(ev, details)
 	emit(ev)
 	return nil
 }

--- a/modules/tcc/fda.go
+++ b/modules/tcc/fda.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	_ "path/filepath"
+	"path/filepath"
 
 	"github.com/0xv1n/macnoise/internal/output"
 	"github.com/0xv1n/macnoise/pkg/module"
@@ -57,8 +57,7 @@ func defaultFDAPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	_ = home
-	return "/Library/Application Support/com.apple.TCC/TCC.db", nil
+	return filepath.Join(home, "Library", "Application Support", "com.apple.TCC", "TCC.db"), nil
 }
 
 func (t *tccFDA) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {

--- a/modules/tcc/fda.go
+++ b/modules/tcc/fda.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/0xv1n/macnoise/internal/output"
 	"github.com/0xv1n/macnoise/pkg/module"
@@ -34,53 +35,77 @@ func (t *tccFDA) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
 			Name:         "tcc_path",
-			Description:  "Path to TCC.db",
+			Description:  "Path to the TCC-gated file to probe (defaults to the per-user TCC.db)",
 			Required:     false,
-			DefaultValue: "/Library/Application Support/com.apple.TCC/TCC.db",
-			Example:      "~/Library/Application Support/com.apple.TCC/TCC.db",
+			DefaultValue: "~/Library/Application Support/com.apple.TCC/TCC.db",
+			Example:      "/Library/Application Support/com.apple.TCC/TCC.db",
 		},
 	}
 }
 
 func (t *tccFDA) CheckPrereqs() error { return nil }
 
+// defaultFDAPath returns the per-user TCC database.
+//
+// The system database under /Library is root-owned, so an unprivileged process
+// is refused by ordinary POSIX permissions before TCC is ever consulted, and
+// the probe cannot tell a privacy denial from a plain mode-bit denial. The
+// per-user database is owned by the user running the probe, so POSIX permits
+// the read and only Full Disk Access decides the outcome.
+func defaultFDAPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, "Library", "Application Support", "com.apple.TCC", "TCC.db"), nil
+}
+
 func (t *tccFDA) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	tccPath := params.Get("tcc_path", "/Library/Application Support/com.apple.TCC/TCC.db")
+	tccPath := params.Get("tcc_path", "")
+	if tccPath == "" {
+		var err error
+		if tccPath, err = defaultFDAPath(); err != nil {
+			return err
+		}
+	}
 	info := t.Info()
 
-	ev := output.NewEvent(info, "tcc_fda_probe", false, fmt.Sprintf("attempting to read %s", tccPath))
+	ev := output.NewEvent(info, "tcc_fda_probe", true, fmt.Sprintf("attempting to read %s", tccPath))
+	details := map[string]any{"path": tccPath}
 
 	f, err := os.Open(tccPath)
-	if err != nil {
-		ev.Success = true
-		ev.Message = fmt.Sprintf("TCC FDA probe: access denied to %s (expected without FDA)", tccPath)
-		ev = output.WithDetails(ev, map[string]any{
-			"path":   tccPath,
-			"result": "denied",
-			"note":   "Access denied indicates TCC is working; grant Full Disk Access to test FDA bypass",
-		})
-		if !os.IsPermission(err) {
-			ev = output.WithError(ev, err)
-		}
-		emit(ev)
-		return nil
-	}
-	defer func() { _ = f.Close() }()
+	outcome := classifyProbe(err)
+	details["result"] = string(outcome)
 
-	stat, _ := f.Stat()
-	ev.Success = true
-	ev.Message = fmt.Sprintf("TCC FDA probe: read access granted to %s", tccPath)
-	ev = output.WithDetails(ev, map[string]any{
-		"path":      tccPath,
-		"result":    "granted",
-		"file_size": stat.Size(),
-	})
+	switch outcome {
+	case probeGranted:
+		defer func() { _ = f.Close() }()
+		ev.Message = fmt.Sprintf("TCC FDA probe: read access granted to %s", tccPath)
+		if stat, statErr := f.Stat(); statErr == nil {
+			details["file_size"] = stat.Size()
+		}
+	case probeDenied:
+		ev.Message = fmt.Sprintf("TCC FDA probe: access denied to %s (expected without FDA)", tccPath)
+	case probeAbsent:
+		ev.Message = fmt.Sprintf("TCC FDA probe: %s does not exist, no TCC decision was made", tccPath)
+		ev = output.WithError(ev, err)
+		ev.Success = true
+	default:
+		ev.Message = fmt.Sprintf("TCC FDA probe: unexpected failure reading %s", tccPath)
+		ev = output.WithError(ev, err)
+		ev.Success = true
+	}
+
+	ev = output.WithDetails(ev, details)
 	emit(ev)
 	return nil
 }
 
 func (t *tccFDA) DryRun(params module.Params) []string {
-	path := params.Get("tcc_path", "/Library/Application Support/com.apple.TCC/TCC.db")
+	path := params.Get("tcc_path", "")
+	if path == "" {
+		path, _ = defaultFDAPath()
+	}
 	return []string{fmt.Sprintf("open %s for reading (probes FDA permission)", path)}
 }
 

--- a/modules/tcc/fda.go
+++ b/modules/tcc/fda.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
+	_ "path/filepath"
 
 	"github.com/0xv1n/macnoise/internal/output"
 	"github.com/0xv1n/macnoise/pkg/module"
@@ -57,7 +57,8 @@ func defaultFDAPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	return filepath.Join(home, "Library", "Application Support", "com.apple.TCC", "TCC.db"), nil
+	_ = home
+	return "/Library/Application Support/com.apple.TCC/TCC.db", nil
 }
 
 func (t *tccFDA) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {

--- a/modules/tcc/probe.go
+++ b/modules/tcc/probe.go
@@ -1,6 +1,6 @@
 package tcc
 
-import "os"
+import _ "os"
 
 // probeOutcome is the result of attempting to reach a TCC-gated resource.
 type probeOutcome string
@@ -24,11 +24,7 @@ func classifyProbe(err error) probeOutcome {
 	switch {
 	case err == nil:
 		return probeGranted
-	case os.IsNotExist(err):
-		return probeAbsent
-	case os.IsPermission(err):
-		return probeDenied
 	default:
-		return probeError
+		return probeDenied
 	}
 }

--- a/modules/tcc/probe.go
+++ b/modules/tcc/probe.go
@@ -1,6 +1,6 @@
 package tcc
 
-import _ "os"
+import "os"
 
 // probeOutcome is the result of attempting to reach a TCC-gated resource.
 type probeOutcome string
@@ -24,7 +24,11 @@ func classifyProbe(err error) probeOutcome {
 	switch {
 	case err == nil:
 		return probeGranted
-	default:
+	case os.IsNotExist(err):
+		return probeAbsent
+	case os.IsPermission(err):
 		return probeDenied
+	default:
+		return probeError
 	}
 }

--- a/modules/tcc/probe.go
+++ b/modules/tcc/probe.go
@@ -1,0 +1,34 @@
+package tcc
+
+import "os"
+
+// probeOutcome is the result of attempting to reach a TCC-gated resource.
+type probeOutcome string
+
+const (
+	probeGranted probeOutcome = "granted"
+	probeDenied  probeOutcome = "denied"
+	probeAbsent  probeOutcome = "absent"
+	probeError   probeOutcome = "error"
+)
+
+// classifyProbe maps an access error to a TCC probe outcome.
+//
+// The distinctions matter because these probes exist to measure TCC decisions,
+// and every outcome that is not a real denial dilutes that measurement. A
+// resource that was never created cannot have been denied, and an unexpected
+// failure such as an I/O error is not a privacy decision either. Reporting
+// either as "denied" invents a TCC event that never happened, which is worse
+// than reporting nothing in a pipeline that treats denials as signal.
+func classifyProbe(err error) probeOutcome {
+	switch {
+	case err == nil:
+		return probeGranted
+	case os.IsNotExist(err):
+		return probeAbsent
+	case os.IsPermission(err):
+		return probeDenied
+	default:
+		return probeError
+	}
+}

--- a/modules/tcc/probe_integration_test.go
+++ b/modules/tcc/probe_integration_test.go
@@ -1,0 +1,152 @@
+//go:build integration && darwin
+
+package tcc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func runProbe(t *testing.T, gen module.Generator, params module.Params) module.TelemetryEvent {
+	t.Helper()
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	if err := gen.Generate(context.Background(), params, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	return events[0]
+}
+
+func TestTCCFDA_GrantedOnReadableFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "TCC.db")
+	if err := os.WriteFile(path, []byte("fake tcc db"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ev := runProbe(t, &tccFDA{}, module.Params{"tcc_path": path})
+	if ev.Details["result"] != "granted" {
+		t.Errorf("result = %v, want granted", ev.Details["result"])
+	}
+	if ev.Details["file_size"] != int64(len("fake tcc db")) {
+		t.Errorf("file_size = %v, want %d", ev.Details["file_size"], len("fake tcc db"))
+	}
+}
+
+// The regression that motivated this change: a path that was never created
+// cannot have been denied by TCC, and reporting it as a denial fabricates a
+// privacy decision for anything downstream that counts denials as signal.
+func TestTCCFDA_MissingPathIsAbsentNotDenied(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does_not_exist", "TCC.db")
+
+	ev := runProbe(t, &tccFDA{}, module.Params{"tcc_path": path})
+	if ev.Details["result"] != "absent" {
+		t.Errorf("result = %v, want absent", ev.Details["result"])
+	}
+	if !ev.Success {
+		t.Error("Success = false, want true: an absent target is a valid observation")
+	}
+}
+
+func TestTCCFDA_UnreadableFileIsDenied(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, mode bits do not deny access")
+	}
+
+	path := filepath.Join(t.TempDir(), "TCC.db")
+	if err := os.WriteFile(path, []byte("fake tcc db"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	ev := runProbe(t, &tccFDA{}, module.Params{"tcc_path": path})
+	if ev.Details["result"] != "denied" {
+		t.Errorf("result = %v, want denied", ev.Details["result"])
+	}
+}
+
+// The default target must be the per-user TCC database. The system one under
+// /Library is root-owned, so an unprivileged run is refused by POSIX before
+// TCC is consulted, making a denial there unattributable to Full Disk Access.
+func TestTCCFDA_DefaultTargetsPerUserDatabase(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	actions := (&tccFDA{}).DryRun(module.Params{})
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 dry-run action, got %d", len(actions))
+	}
+	want := filepath.Join(home, "Library", "Application Support", "com.apple.TCC", "TCC.db")
+	if !strings.Contains(actions[0], want) {
+		t.Errorf("dry-run action %q does not target the per-user TCC.db at %q", actions[0], want)
+	}
+}
+
+func TestTCCContacts_GrantedOnReadableDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	ab := filepath.Join(home, "Library", "Application Support", "AddressBook")
+	if err := os.MkdirAll(ab, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ab, "AddressBook-v22.abcddb"), []byte("db"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ev := runProbe(t, &tccContacts{}, module.Params{})
+	if ev.Details["result"] != "granted" {
+		t.Errorf("result = %v, want granted", ev.Details["result"])
+	}
+	if ev.Details["entry_count"] != 1 {
+		t.Errorf("entry_count = %v, want 1", ev.Details["entry_count"])
+	}
+}
+
+// A machine that has never used Contacts has no AddressBook directory. That is
+// an absent resource, not a TCC refusal.
+func TestTCCContacts_NoAddressBookIsAbsentNotDenied(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	ev := runProbe(t, &tccContacts{}, module.Params{})
+	if ev.Details["result"] != "absent" {
+		t.Errorf("result = %v, want absent", ev.Details["result"])
+	}
+	if !ev.Success {
+		t.Error("Success = false, want true: an absent target is a valid observation")
+	}
+}
+
+func TestTCCContacts_UnreadableDirIsDenied(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, mode bits do not deny access")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	ab := filepath.Join(home, "Library", "Application Support", "AddressBook")
+	if err := os.MkdirAll(ab, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Chmod(ab, 0o000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(ab, 0o755) })
+
+	ev := runProbe(t, &tccContacts{}, module.Params{})
+	if ev.Details["result"] != "denied" {
+		t.Errorf("result = %v, want denied", ev.Details["result"])
+	}
+}

--- a/modules/tcc/probe_test.go
+++ b/modules/tcc/probe_test.go
@@ -1,0 +1,32 @@
+package tcc
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+)
+
+// A missing resource must never be reported as a denial. Both probes used to
+// collapse every error into "denied", so a machine that had simply never used
+// Contacts reported a TCC refusal that never happened.
+func TestClassifyProbe(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want probeOutcome
+	}{
+		{"no error is granted", nil, probeGranted},
+		{"missing path is absent", &fs.PathError{Op: "open", Err: fs.ErrNotExist}, probeAbsent},
+		{"permission refusal is denied", &fs.PathError{Op: "open", Err: fs.ErrPermission}, probeDenied},
+		{"unexpected failure is not a denial", &fs.PathError{Op: "open", Err: errors.New("input/output error")}, probeError},
+		{"bare error is not a denial", errors.New("boom"), probeError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyProbe(tt.err); got != tt.want {
+				t.Errorf("classifyProbe(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
tcc_fda targeted the root-owned system TCC.db, so an unprivileged run was refused by POSIX mode bits before TCC was consulted and reported an FDA denial it never measured, while tcc_contacts reported any error as denied, so a machine that had simply never used Contacts produced a TCC refusal that never happened. Both now probe through a shared four-way classifier (granted/denied/absent/error), and tcc_fda targets the per-user TCC.db, which POSIX lets the owner read so that only Full Disk Access can refuse it.