### PR TITLE
fix: use launchctl bootstrap/bootout instead of legacy load/unload

### DIFF
--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -5,10 +5,12 @@ LaunchAgent/Daemon persistence, cron job installation, and shell profile modific
 ## Modules
 
 ### `svc_launch_agent`
-Creates and loads a LaunchAgent plist. Maps to T1543.001. Cleanup unloads and removes.
+Creates a LaunchAgent plist and registers it with `launchctl bootstrap gui/<uid>`. Maps to T1543.001. Cleanup boots it out and removes the plist.
 
 ### `svc_launch_daemon`
-Creates and loads a LaunchDaemon plist (root required). Maps to T1543.004. Cleanup unloads and removes.
+Creates a LaunchDaemon plist and registers it with `launchctl bootstrap system` (root required). Maps to T1543.004. Cleanup boots it out and removes the plist.
+
+Both use `bootstrap`/`bootout` rather than the legacy `load`/`unload`, since detection content increasingly keys on the modern subcommands. Bootstrapping a LaunchAgent needs a GUI session, so it fails on a headless host; that failure is reported as telemetry rather than a module error, and cleanup only attempts a bootout when the bootstrap actually succeeded.
 
 ### `svc_cron`
 Lists the current crontab, then appends a clearly-marked entry (`# macnoise`). Emits `cron_job_list` and `cron_job_create` events. Maps to T1053.003. Cleanup filters the added entry back out of the crontab.

--- a/modules/service/launch_agent.go
+++ b/modules/service/launch_agent.go
@@ -18,6 +18,7 @@ import (
 type svcLaunchAgent struct {
 	plistPath string
 	label     string
+	loaded    bool
 }
 
 func (s *svcLaunchAgent) Info() module.ModuleInfo {
@@ -94,17 +95,19 @@ func (s *svcLaunchAgent) Generate(ctx context.Context, params module.Params, emi
 	createEv = output.WithDetails(createEv, map[string]any{"path": plistPath, "label": label, "program": program})
 	emit(createEv)
 
-	loadEv := output.NewEvent(info, "launchagent_load", false, fmt.Sprintf("loading %s via launchctl", label))
-	loadCmd := exec.CommandContext(ctx, "launchctl", "load", plistPath)
+	domain := guiDomain()
+	loadEv := output.NewEvent(info, "launchagent_load", false, fmt.Sprintf("bootstrapping %s into %s", label, domain))
+	loadCmd := exec.CommandContext(ctx, "launchctl", bootstrapArgs(domain, plistPath)...)
 	out, err := loadCmd.CombinedOutput()
 	if err != nil {
 		loadEv = output.WithError(loadEv, fmt.Errorf("%v: %s", err, out))
 		emit(loadEv)
 		return nil
 	}
+	s.loaded = true
 	loadEv.Success = true
-	loadEv.Message = fmt.Sprintf("loaded LaunchAgent %s", label)
-	loadEv = output.WithDetails(loadEv, map[string]any{"label": label, "plist": plistPath})
+	loadEv.Message = fmt.Sprintf("bootstrapped LaunchAgent %s into %s", label, domain)
+	loadEv = output.WithDetails(loadEv, map[string]any{"label": label, "plist": plistPath, "domain": domain})
 	emit(loadEv)
 
 	return nil
@@ -115,18 +118,30 @@ func (s *svcLaunchAgent) DryRun(params module.Params) []string {
 	program := params.Get("program", "/usr/bin/true")
 	return []string{
 		fmt.Sprintf("create ~/Library/LaunchAgents/%s.plist with Program=%s", label, program),
-		fmt.Sprintf("launchctl load ~/Library/LaunchAgents/%s.plist", label),
+		fmt.Sprintf("launchctl bootstrap %s ~/Library/LaunchAgents/%s.plist", guiDomain(), label),
 	}
 }
 
+// Cleanup boots the agent out before removing its plist. A bootout failure is
+// only reported when Generate actually loaded the agent: if the bootstrap
+// never succeeded there is nothing registered to remove, and launchctl's
+// failure there says nothing about whether cleanup worked. Reporting it
+// anyway would mark every run on a host without a GUI session as a cleanup
+// error while leaving nothing behind.
 func (s *svcLaunchAgent) Cleanup() error {
-	if s.label != "" {
-		exec.Command("launchctl", "unload", s.plistPath).Run() //nolint:errcheck
+	var bootoutErr error
+	if s.loaded {
+		out, err := exec.Command("launchctl", bootoutArgs(guiDomain(), s.label)...).CombinedOutput()
+		if err != nil {
+			bootoutErr = fmt.Errorf("launchctl bootout %s: %v: %s", s.label, err, out)
+		}
 	}
 	if s.plistPath != "" {
-		return os.Remove(s.plistPath)
+		if err := os.Remove(s.plistPath); err != nil {
+			return err
+		}
 	}
-	return nil
+	return bootoutErr
 }
 
 func init() {

--- a/modules/service/launch_agent_test.go
+++ b/modules/service/launch_agent_test.go
@@ -58,9 +58,9 @@ func TestSvcLaunchAgent_GenerateAndCleanup(t *testing.T) {
 		t.Error("expected a successful launchagent_create event")
 	}
 
-	// launchctl load is deliberately not asserted: it needs a GUI (Aqua)
+	// launchctl bootstrap is deliberately not asserted: it needs a GUI (Aqua)
 	// session, which a CI runner has no guarantee of, and the module already
-	// treats a load failure as valid telemetry rather than an error.
+	// treats a bootstrap failure as valid telemetry rather than an error.
 
 	if err := s.Cleanup(); err != nil {
 		t.Fatalf("Cleanup: %v", err)

--- a/modules/service/launch_daemon.go
+++ b/modules/service/launch_daemon.go
@@ -16,6 +16,7 @@ import (
 type svcLaunchDaemon struct {
 	plistPath string
 	label     string
+	loaded    bool
 }
 
 func (s *svcLaunchDaemon) Info() module.ModuleInfo {
@@ -84,17 +85,18 @@ func (s *svcLaunchDaemon) Generate(ctx context.Context, params module.Params, em
 	createEv = output.WithDetails(createEv, map[string]any{"path": plistPath, "label": label, "program": program})
 	emit(createEv)
 
-	loadEv := output.NewEvent(info, "launchdaemon_load", false, fmt.Sprintf("loading %s via launchctl", label))
-	loadCmd := exec.CommandContext(ctx, "launchctl", "load", plistPath)
+	loadEv := output.NewEvent(info, "launchdaemon_load", false, fmt.Sprintf("bootstrapping %s into %s", label, systemDomain))
+	loadCmd := exec.CommandContext(ctx, "launchctl", bootstrapArgs(systemDomain, plistPath)...)
 	out, err := loadCmd.CombinedOutput()
 	if err != nil {
 		loadEv = output.WithError(loadEv, fmt.Errorf("%v: %s", err, out))
 		emit(loadEv)
 		return nil
 	}
+	s.loaded = true
 	loadEv.Success = true
-	loadEv.Message = fmt.Sprintf("loaded LaunchDaemon %s", label)
-	loadEv = output.WithDetails(loadEv, map[string]any{"label": label, "plist": plistPath})
+	loadEv.Message = fmt.Sprintf("bootstrapped LaunchDaemon %s into %s", label, systemDomain)
+	loadEv = output.WithDetails(loadEv, map[string]any{"label": label, "plist": plistPath, "domain": systemDomain})
 	emit(loadEv)
 
 	return nil
@@ -105,18 +107,26 @@ func (s *svcLaunchDaemon) DryRun(params module.Params) []string {
 	program := params.Get("program", "/usr/bin/true")
 	return []string{
 		fmt.Sprintf("create /Library/LaunchDaemons/%s.plist with Program=%s (requires root)", label, program),
-		fmt.Sprintf("launchctl load /Library/LaunchDaemons/%s.plist", label),
+		fmt.Sprintf("launchctl bootstrap %s /Library/LaunchDaemons/%s.plist", systemDomain, label),
 	}
 }
 
+// Cleanup boots the daemon out before removing its plist. As with the agent, a
+// bootout failure is only reported when Generate actually loaded it.
 func (s *svcLaunchDaemon) Cleanup() error {
-	if s.label != "" {
-		exec.Command("launchctl", "unload", s.plistPath).Run() //nolint:errcheck
+	var bootoutErr error
+	if s.loaded {
+		out, err := exec.Command("launchctl", bootoutArgs(systemDomain, s.label)...).CombinedOutput()
+		if err != nil {
+			bootoutErr = fmt.Errorf("launchctl bootout %s: %v: %s", s.label, err, out)
+		}
 	}
 	if s.plistPath != "" {
-		return os.Remove(s.plistPath)
+		if err := os.Remove(s.plistPath); err != nil {
+			return err
+		}
 	}
-	return nil
+	return bootoutErr
 }
 
 func init() {

--- a/modules/service/launchctl.go
+++ b/modules/service/launchctl.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"fmt"
+	"os"
+)
+
+// systemDomain is the launchd domain that holds LaunchDaemons.
+const systemDomain = "system"
+
+// guiDomain returns the launchd domain that holds the current user's
+// LaunchAgents. A LaunchAgent belongs to a per-user GUI session, so the
+// domain target carries the uid; daemons use the single system domain.
+func guiDomain() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+// bootstrapArgs builds the launchctl argv that registers plistPath in domain.
+//
+// This replaces `launchctl load`, which Apple documents as legacy. The
+// distinction matters for a telemetry generator specifically: detection
+// content increasingly keys on the `bootstrap` subcommand, so emitting the
+// legacy form generates activity that modern rules are not watching for.
+func bootstrapArgs(domain, plistPath string) []string {
+	return []string{"bootstrap", domain, plistPath}
+}
+
+// bootoutArgs builds the launchctl argv that removes label from domain. The
+// service-target form is used rather than the plist path so that unloading
+// still works once the plist has been deleted.
+func bootoutArgs(domain, label string) []string {
+	return []string{"bootout", domain + "/" + label}
+}

--- a/modules/service/launchctl_test.go
+++ b/modules/service/launchctl_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// launchctl load/unload are the legacy subcommands. Detection content keys on
+// bootstrap/bootout, so emitting the old form generates activity modern rules
+// are not watching for.
+func TestBootstrapArgs_UsesModernSubcommand(t *testing.T) {
+	got := bootstrapArgs("gui/501", "/Users/x/Library/LaunchAgents/com.example.plist")
+	want := []string{"bootstrap", "gui/501", "/Users/x/Library/LaunchAgents/com.example.plist"}
+
+	if len(got) != len(want) {
+		t.Fatalf("argv = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("argv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if got[0] == "load" {
+		t.Error("still using the legacy load subcommand")
+	}
+}
+
+// bootout takes a service target rather than a plist path, so unloading still
+// resolves after the plist has been deleted.
+func TestBootoutArgs_TargetsServiceNotPath(t *testing.T) {
+	got := bootoutArgs("system", "com.macnoise.testdaemon")
+	want := []string{"bootout", "system/com.macnoise.testdaemon"}
+
+	if len(got) != len(want) {
+		t.Fatalf("argv = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("argv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if strings.HasSuffix(got[len(got)-1], ".plist") {
+		t.Error("bootout target should be a service target, not a plist path")
+	}
+}
+
+// A LaunchAgent is registered per user, so the domain target must carry the
+// uid. Daemons use the single system domain instead.
+func TestGuiDomain_CarriesUID(t *testing.T) {
+	got := guiDomain()
+	want := fmt.Sprintf("gui/%d", os.Getuid())
+	if got != want {
+		t.Errorf("guiDomain() = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(got, "gui/") {
+		t.Errorf("guiDomain() = %q, want a gui/<uid> domain target", got)
+	}
+}
+
+func TestSystemDomain(t *testing.T) {
+	if systemDomain != "system" {
+		t.Errorf("systemDomain = %q, want system", systemDomain)
+	}
+}
+
+func TestDryRun_AdvertisesBootstrap(t *testing.T) {
+	tests := []struct {
+		name string
+		gen  module.Generator
+	}{
+		{"launch_agent", &svcLaunchAgent{}},
+		{"launch_daemon", &svcLaunchDaemon{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			joined := strings.Join(tt.gen.DryRun(module.Params{}), "\n")
+			if !strings.Contains(joined, "launchctl bootstrap") {
+				t.Errorf("dry-run does not mention launchctl bootstrap:\n%s", joined)
+			}
+			if strings.Contains(joined, "launchctl load") {
+				t.Errorf("dry-run still advertises the legacy load subcommand:\n%s", joined)
+			}
+		})
+	}
+}
+
+// Cleanup must not run bootout when Generate never loaded the service. A host
+// without a GUI session fails to bootstrap, and treating the resulting bootout
+// failure as a cleanup error would mark those runs failed while nothing was
+// actually left behind.
+func TestCleanup_SkipsBootoutWhenNeverLoaded(t *testing.T) {
+	if err := (&svcLaunchAgent{label: "com.macnoise.never", loaded: false}).Cleanup(); err != nil {
+		t.Errorf("agent Cleanup() = %v, want nil when the agent was never loaded", err)
+	}
+	if err := (&svcLaunchDaemon{label: "com.macnoise.never", loaded: false}).Cleanup(); err != nil {
+		t.Errorf("daemon Cleanup() = %v, want nil when the daemon was never loaded", err)
+	}
+}


### PR DESCRIPTION
svc_launch_agent and svc_launch_daemon registered persistence with launchctl load, which Apple documents as legacy, so the modules generated activity that detection content keying on bootstrap is not watching for, and both discarded the unload error in Cleanup so a service left registered against a deleted plist was reported as a clean teardown. Both now use bootstrap/bootout with the correct domain target, and Cleanup reports a bootout failure only when Generate actually loaded the service, so a headless host that cannot bootstrap is not marked as a cleanup error.