### PR TITLE
fix: derive dry-run command from the executed launchctl argv

### DIFF
--- a/modules/service/launch_agent.go
+++ b/modules/service/launch_agent.go
@@ -116,9 +116,10 @@ func (s *svcLaunchAgent) Generate(ctx context.Context, params module.Params, emi
 func (s *svcLaunchAgent) DryRun(params module.Params) []string {
 	label := params.Get("label", "com.macnoise.testagent")
 	program := params.Get("program", "/usr/bin/true")
+	plistPath := fmt.Sprintf("~/Library/LaunchAgents/%s.plist", label)
 	return []string{
-		fmt.Sprintf("create ~/Library/LaunchAgents/%s.plist with Program=%s", label, program),
-		fmt.Sprintf("launchctl bootstrap %s ~/Library/LaunchAgents/%s.plist", guiDomain(), label),
+		fmt.Sprintf("create %s with Program=%s", plistPath, program),
+		launchctlCmdLine(bootstrapArgs(guiDomain(), plistPath)),
 	}
 }
 

--- a/modules/service/launch_daemon.go
+++ b/modules/service/launch_daemon.go
@@ -107,7 +107,7 @@ func (s *svcLaunchDaemon) DryRun(params module.Params) []string {
 	program := params.Get("program", "/usr/bin/true")
 	return []string{
 		fmt.Sprintf("create /Library/LaunchDaemons/%s.plist with Program=%s (requires root)", label, program),
-		fmt.Sprintf("launchctl bootstrap %s /Library/LaunchDaemons/%s.plist", systemDomain, label),
+		launchctlCmdLine(bootstrapArgs(systemDomain, fmt.Sprintf("/Library/LaunchDaemons/%s.plist", label))),
 	}
 }
 

--- a/modules/service/launchctl.go
+++ b/modules/service/launchctl.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // systemDomain is the launchd domain that holds LaunchDaemons.
@@ -30,4 +31,11 @@ func bootstrapArgs(domain, plistPath string) []string {
 // still works once the plist has been deleted.
 func bootoutArgs(domain, label string) []string {
 	return []string{"bootout", domain + "/" + label}
+}
+
+// launchctlCmdLine renders argv as the command line a dry-run advertises.
+// DryRun builds its description from the same argv the module executes, so the
+// two cannot drift into advertising one subcommand while running another.
+func launchctlCmdLine(args []string) string {
+	return "launchctl " + strings.Join(args, " ")
 }


### PR DESCRIPTION
DryRun built its launchctl command line as a separate hardcoded string from the argv the module actually executes, so the two could drift into advertising bootstrap while running something else. Both modules now render the dry-run line from the same bootstrapArgs call they exec, which is the tail end of #30 that missed the merge.