### PR TITLE
fix: target an injectable binary in proc_inject and report the real dyld outcome

### DIFF
--- a/modules/process/README.md
+++ b/modules/process/README.md
@@ -11,7 +11,16 @@ Spawns a shell command chain. Maps to T1059.004.
 Forks a process and sends SIGSTOP/SIGCONT/SIGTERM. Maps to T1106. Requires macOS (darwin).
 
 ### `proc_inject`
-Spawns a process with `DYLD_INSERT_LIBRARIES` set. Maps to T1574.006.
+Spawns a process with `DYLD_INSERT_LIBRARIES` set and reports whether dyld actually acted on it, as `outcome: honored | stripped | indeterminate`. Maps to T1574.006.
+
+The default target is macnoise's own binary rather than a system binary. System binaries under `/usr/bin` and `/bin` are protected, so dyld drops the variable before the process starts and no injection occurs; that holds even for a copy of one with its signature removed or re-signed ad-hoc, so no usable target can be derived from them. macnoise is built locally and only ad-hoc signed, so dyld honours the variable.
+
+The dylib does not need to exist. dyld aborts the process when it cannot load an inserted library, and that refusal is both the evidence the variable survived and a loud, observable event. Pass `--param target=` to point at your own unsigned binary instead.
+
+```bash
+macnoise run proc_inject
+macnoise run proc_inject --param target=/tmp/my_unsigned_binary --param dylib_path=/tmp/evil.dylib
+```
 
 ### `proc_discovery`
 Runs a configurable set of macOS reconnaissance commands (`sw_vers`, `system_profiler`, `sysctl`, `ifconfig`, `whoami`, `dscl`, `csrutil status`, `fdesetup status`). Each command emits a separate `system_discovery` event with structured output. Maps to T1082, T1016, T1033, T1518.

--- a/modules/process/README.md
+++ b/modules/process/README.md
@@ -13,7 +13,7 @@ Forks a process and sends SIGSTOP/SIGCONT/SIGTERM. Maps to T1106. Requires macOS
 ### `proc_inject`
 Spawns a process with `DYLD_INSERT_LIBRARIES` set and reports whether dyld actually acted on it, as `outcome: honored | stripped | indeterminate`. Maps to T1574.006.
 
-The default target is macnoise's own binary rather than a system binary. System binaries under `/usr/bin` and `/bin` are protected, so dyld drops the variable before the process starts and no injection occurs; that holds even for a copy of one with its signature removed or re-signed ad-hoc, so no usable target can be derived from them. macnoise is built locally and only ad-hoc signed, so dyld honours the variable.
+The default target is macnoise's own binary rather than a system binary. On a host with SIP enabled, which is any real endpoint, system binaries under `/usr/bin` and `/bin` have the variable dropped before the process starts, so no injection occurs; that holds even for a copy with its signature removed or re-signed ad-hoc, so no usable target can be derived from them. With SIP disabled they are injectable, which is why some CI images behave differently. macnoise is built locally and only ad-hoc signed, so dyld honours the variable either way.
 
 The dylib does not need to exist. dyld aborts the process when it cannot load an inserted library, and that refusal is both the evidence the variable survived and a loud, observable event. Pass `--param target=` to point at your own unsigned binary instead.
 

--- a/modules/process/inject.go
+++ b/modules/process/inject.go
@@ -3,7 +3,9 @@ package process
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/0xv1n/macnoise/internal/output"
 	"github.com/0xv1n/macnoise/pkg/module"
@@ -11,10 +13,19 @@ import (
 
 type procInject struct{}
 
+// injectOutcome records whether dyld actually acted on DYLD_INSERT_LIBRARIES.
+type injectOutcome string
+
+const (
+	injectHonored       injectOutcome = "honored"
+	injectStripped      injectOutcome = "stripped"
+	injectIndeterminate injectOutcome = "indeterminate"
+)
+
 func (p *procInject) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "proc_inject",
-		Description: "Spawns a process with DYLD_INSERT_LIBRARIES to simulate dylib injection telemetry",
+		Description: "Spawns a process with DYLD_INSERT_LIBRARIES to generate dylib injection telemetry",
 		Category:    module.CategoryProcess,
 		Tags:        []string{"dylib", "injection", "execution", "dyld"},
 		Privileges:  module.PrivilegeNone,
@@ -28,48 +39,102 @@ func (p *procInject) Info() module.ModuleInfo {
 
 func (p *procInject) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "dylib_path", Description: "Path to dylib to inject (does not need to exist — env var is the telemetry)", Required: false, DefaultValue: "/tmp/macnoise_inject.dylib", Example: "/tmp/evil.dylib"},
-		{Name: "target", Description: "Target binary to spawn with injection env", Required: false, DefaultValue: "/usr/bin/true", Example: "/bin/ls"},
+		{Name: "dylib_path", Description: "Path to the dylib to insert; it need not exist, dyld's refusal to find it is itself the evidence", Required: false, DefaultValue: "/tmp/macnoise_inject.dylib", Example: "/tmp/evil.dylib"},
+		{Name: "target", Description: "Binary to spawn with the injection env (defaults to macnoise itself, which is injectable)", Required: false, DefaultValue: "", Example: "/tmp/my_unsigned_binary"},
 	}
 }
 
 func (p *procInject) CheckPrereqs() error { return nil }
 
+// defaultTarget returns macnoise's own executable.
+//
+// System binaries under /usr/bin and /bin cannot be used: they are protected,
+// and dyld drops DYLD_INSERT_LIBRARIES before the process starts, so the
+// injection path is never exercised. Verified on macOS 26 that this holds even
+// for a copy of the binary with its signature removed or re-signed ad-hoc, so
+// there is no way to derive a usable target from a system binary. macnoise is
+// built locally and is only ad-hoc signed, so dyld honours the variable, and
+// it is guaranteed present on any host running this module.
+func defaultTarget() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine own executable path: %w", err)
+	}
+	return exe, nil
+}
+
+// classifyInjection reports whether dyld acted on DYLD_INSERT_LIBRARIES.
+//
+// A protected target has the variable stripped before dyld sees it, and the
+// process then runs normally with no diagnostic at all. So when the dylib does
+// not exist, a dyld complaint proves the variable survived and its absence
+// proves it did not. When the dylib does exist and loads cleanly there is no
+// diagnostic either way, and the outcome is reported as indeterminate rather
+// than guessed.
+func classifyInjection(dylibExists bool, stderr string) injectOutcome {
+	if strings.Contains(stderr, "inserted dylib") {
+		return injectHonored
+	}
+	if dylibExists {
+		return injectIndeterminate
+	}
+	return injectStripped
+}
+
 func (p *procInject) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	dylibPath := params.Get("dylib_path", "/tmp/macnoise_inject.dylib")
-	targetBin := params.Get("target", "/usr/bin/true")
+	targetBin := params.Get("target", "")
+	if targetBin == "" {
+		var err error
+		if targetBin, err = defaultTarget(); err != nil {
+			return err
+		}
+	}
 	info := p.Info()
 
+	var stderr strings.Builder
 	cmd := exec.CommandContext(ctx, targetBin)
 	cmd.Env = append(cmd.Environ(), fmt.Sprintf("DYLD_INSERT_LIBRARIES=%s", dylibPath))
+	cmd.Stderr = &stderr
 
-	ev := output.NewEvent(info, "dylib_inject_attempt", false,
-		fmt.Sprintf("spawning %s with DYLD_INSERT_LIBRARIES=%s", targetBin, dylibPath))
+	// The child's exit status is deliberately not treated as failure. dyld
+	// aborts the process when an inserted dylib cannot be loaded, so the
+	// successful injection path exits non-zero by design.
+	runErr := cmd.Run()
 
-	err := cmd.Run()
-	if err != nil && err.Error() == "exit status 1" {
-		err = nil
-	}
-	if err != nil {
-		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
-	}
+	_, statErr := os.Stat(dylibPath)
+	outcome := classifyInjection(statErr == nil, stderr.String())
 
-	ev.Success = true
-	ev.Message = fmt.Sprintf("process spawned with DYLD_INSERT_LIBRARIES=%s (SIP may strip on macOS)", dylibPath)
-	ev = output.WithDetails(ev, map[string]any{
+	ev := output.NewEvent(info, "dylib_inject_attempt", true,
+		fmt.Sprintf("spawned %s with DYLD_INSERT_LIBRARIES=%s", targetBin, dylibPath))
+	details := map[string]any{
 		"target":           targetBin,
 		"dyld_insert_libs": dylibPath,
-		"sip_note":         "SIP-protected binaries will strip the env var; telemetry still generated",
-	})
-	emit(ev)
+		"outcome":          string(outcome),
+	}
+
+	switch outcome {
+	case injectHonored:
+		ev.Message = fmt.Sprintf("dyld honoured DYLD_INSERT_LIBRARIES for %s", targetBin)
+	case injectStripped:
+		ev.Message = fmt.Sprintf("%s stripped DYLD_INSERT_LIBRARIES before dyld ran; the target is protected", targetBin)
+	default:
+		ev.Message = fmt.Sprintf("spawned %s with DYLD_INSERT_LIBRARIES=%s, dyld raised no diagnostic", targetBin, dylibPath)
+	}
+	if runErr != nil {
+		details["exit_error"] = runErr.Error()
+	}
+
+	emit(output.WithDetails(ev, details))
 	return nil
 }
 
 func (p *procInject) DryRun(params module.Params) []string {
 	dylib := params.Get("dylib_path", "/tmp/macnoise_inject.dylib")
-	target := params.Get("target", "/usr/bin/true")
+	target := params.Get("target", "")
+	if target == "" {
+		target, _ = defaultTarget()
+	}
 	return []string{
 		fmt.Sprintf("spawn %s with env DYLD_INSERT_LIBRARIES=%s", target, dylib),
 	}

--- a/modules/process/inject_integration_test.go
+++ b/modules/process/inject_integration_test.go
@@ -4,7 +4,9 @@ package process
 
 import (
 	"context"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/0xv1n/macnoise/pkg/module"
@@ -38,32 +40,40 @@ func TestProcInject_DefaultTargetIsHonouredByDyld(t *testing.T) {
 	}
 }
 
-// The regression this module existed with: /usr/bin/true is protected, so the
-// variable never reaches dyld and no injection occurs, yet the module used to
-// report the spawn as a success without qualification.
-func TestProcInject_ProtectedTargetIsReportedStripped(t *testing.T) {
-	ev := runInject(t, module.Params{
-		"target":     "/usr/bin/true",
-		"dylib_path": filepath.Join(t.TempDir(), "absent.dylib"),
-	})
-
-	if got := ev.Details["outcome"]; got != "stripped" {
-		t.Errorf("outcome = %v, want stripped for the SIP-protected /usr/bin/true", got)
+// sipEnabled reports whether System Integrity Protection is active.
+func sipEnabled(t *testing.T) bool {
+	t.Helper()
+	out, err := exec.Command("csrutil", "status").CombinedOutput()
+	if err != nil {
+		t.Skipf("cannot determine SIP status: %v: %s", err, out)
 	}
-	if ev.Details["target"] != "/usr/bin/true" {
-		t.Errorf("target = %v, want /usr/bin/true", ev.Details["target"])
-	}
+	return strings.Contains(strings.ToLower(string(out)), "status: enabled")
 }
 
-// The protection is a property of system binaries generally, not a quirk of
-// /usr/bin/true, so a second one must classify the same way.
-func TestProcInject_OtherSystemBinaryAlsoStripped(t *testing.T) {
-	ev := runInject(t, module.Params{
-		"target":     "/bin/ls",
-		"dylib_path": filepath.Join(t.TempDir(), "absent.dylib"),
-	})
+// Whether a system binary strips DYLD_INSERT_LIBRARIES depends on SIP, so this
+// asserts against the host's actual state rather than assuming one. A
+// SIP-enabled Mac (any real endpoint) drops the variable, which is why
+// /usr/bin/true was a useless default. Some CI images run with SIP off and
+// honour it, and asserting "stripped" unconditionally fails there for reasons
+// that say nothing about this module.
+func TestProcInject_SystemBinaryOutcomeFollowsSIP(t *testing.T) {
+	for _, target := range []string{"/usr/bin/true", "/bin/ls"} {
+		t.Run(target, func(t *testing.T) {
+			ev := runInject(t, module.Params{
+				"target":     target,
+				"dylib_path": filepath.Join(t.TempDir(), "absent.dylib"),
+			})
 
-	if got := ev.Details["outcome"]; got != "stripped" {
-		t.Errorf("outcome = %v, want stripped for /bin/ls", got)
+			want := "honored"
+			if sipEnabled(t) {
+				want = "stripped"
+			}
+			if got := ev.Details["outcome"]; got != want {
+				t.Errorf("outcome = %v, want %s (SIP enabled: %v)", got, want, sipEnabled(t))
+			}
+			if ev.Details["target"] != target {
+				t.Errorf("target = %v, want %s", ev.Details["target"], target)
+			}
+		})
 	}
 }

--- a/modules/process/inject_integration_test.go
+++ b/modules/process/inject_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration && darwin
+
+package process
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func runInject(t *testing.T, params module.Params) module.TelemetryEvent {
+	t.Helper()
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	if err := (&procInject{}).Generate(context.Background(), params, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	return events[0]
+}
+
+// The default target must be one dyld will actually inject into. The test
+// binary itself stands in for macnoise here: both are Go-built and only ad-hoc
+// signed, so they exercise the same dyld path.
+func TestProcInject_DefaultTargetIsHonouredByDyld(t *testing.T) {
+	ev := runInject(t, module.Params{"dylib_path": filepath.Join(t.TempDir(), "absent.dylib")})
+
+	if got := ev.Details["outcome"]; got != "honored" {
+		t.Errorf("outcome = %v, want honored; dyld did not act on DYLD_INSERT_LIBRARIES for the default target", got)
+	}
+	if !ev.Success {
+		t.Error("Success = false; dyld aborting the child is the successful injection path, not a failure")
+	}
+}
+
+// The regression this module existed with: /usr/bin/true is protected, so the
+// variable never reaches dyld and no injection occurs, yet the module used to
+// report the spawn as a success without qualification.
+func TestProcInject_ProtectedTargetIsReportedStripped(t *testing.T) {
+	ev := runInject(t, module.Params{
+		"target":     "/usr/bin/true",
+		"dylib_path": filepath.Join(t.TempDir(), "absent.dylib"),
+	})
+
+	if got := ev.Details["outcome"]; got != "stripped" {
+		t.Errorf("outcome = %v, want stripped for the SIP-protected /usr/bin/true", got)
+	}
+	if ev.Details["target"] != "/usr/bin/true" {
+		t.Errorf("target = %v, want /usr/bin/true", ev.Details["target"])
+	}
+}
+
+// The protection is a property of system binaries generally, not a quirk of
+// /usr/bin/true, so a second one must classify the same way.
+func TestProcInject_OtherSystemBinaryAlsoStripped(t *testing.T) {
+	ev := runInject(t, module.Params{
+		"target":     "/bin/ls",
+		"dylib_path": filepath.Join(t.TempDir(), "absent.dylib"),
+	})
+
+	if got := ev.Details["outcome"]; got != "stripped" {
+		t.Errorf("outcome = %v, want stripped for /bin/ls", got)
+	}
+}

--- a/modules/process/inject_test.go
+++ b/modules/process/inject_test.go
@@ -1,0 +1,57 @@
+package process
+
+import "testing"
+
+// A protected target has DYLD_INSERT_LIBRARIES stripped before dyld runs, and
+// the process then exits cleanly with no diagnostic. Silence therefore means
+// the injection never happened, which is the opposite of what the old module
+// reported when it called every spawn a success.
+func TestClassifyInjection(t *testing.T) {
+	const dyldComplaint = `dyld[72146]: terminating because inserted dylib '/tmp/x.dylib' could not be loaded: tried: '/tmp/x.dylib' (no such file)`
+
+	tests := []struct {
+		name        string
+		dylibExists bool
+		stderr      string
+		want        injectOutcome
+	}{
+		{
+			name:        "dyld complaint proves the variable survived",
+			dylibExists: false,
+			stderr:      dyldComplaint,
+			want:        injectHonored,
+		},
+		{
+			name:        "silence with an absent dylib proves it was stripped",
+			dylibExists: false,
+			stderr:      "",
+			want:        injectStripped,
+		},
+		{
+			name:        "unrelated stderr is still a stripped result",
+			dylibExists: false,
+			stderr:      "some unrelated program output\n",
+			want:        injectStripped,
+		},
+		{
+			name:        "an existing dylib that loads cleanly is not guessed at",
+			dylibExists: true,
+			stderr:      "",
+			want:        injectIndeterminate,
+		},
+		{
+			name:        "an existing dylib dyld rejected is still honoured",
+			dylibExists: true,
+			stderr:      dyldComplaint,
+			want:        injectHonored,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyInjection(tt.dylibExists, tt.stderr); got != tt.want {
+				t.Errorf("classifyInjection(%v, %q) = %q, want %q", tt.dylibExists, tt.stderr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
proc_inject defaulted to /usr/bin/true, which is protected, so dyld dropped DYLD_INSERT_LIBRARIES before the process started and the injection path was never exercised, yet the module reported every spawn as a success. Verified on macOS 26 that this holds even for a copy with its signature removed or re-signed ad-hoc, so the default is now macnoise's own ad-hoc-signed binary, which dyld does honour, and the emitted event carries an outcome of honored, stripped, or indeterminate derived from what dyld actually did.