### PR TITLE
feat: add --no-cleanup and clear a batch of CLI and telemetry paper cuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,22 @@ macnoise version                              Print version
 | `--output` | (none) | Write output to file (in addition to stdout) |
 | `--verbose` | false | Verbose output including cleanup errors |
 | `--dry-run` | false | Preview actions without executing |
+| `--no-cleanup` | false | Leave module artifacts in place (see below) |
 | `--timeout` | `30` | Per-module timeout in seconds |
 | `--audit-log` | (none) | Write OCSF 1.7.0 audit records to a JSONL file |
 | `--config` | (none) | Load defaults from a YAML config file |
+
+## Leaving Artifacts In Place
+
+By default every module reverses itself when it finishes. That is usually what you want, but it means a detection only ever sees the *install* event. To validate that your stack detects the persistence itself - a LaunchAgent sitting in `~/Library/LaunchAgents`, a cron entry, a modified shell profile - the artifact has to still be there when the scan runs:
+
+```bash
+./macnoise run svc_launch_agent --no-cleanup
+```
+
+Each module that skips cleanup prints a line naming itself, and the audit log records `cleanup_result: skipped` rather than `ok`, so a run that left persistence behind is never mistaken for one that tidied up. Use `macnoise info <module>` to see what a given module creates.
+
+**You are responsible for removing these yourself.** Re-running the same module without the flag will clean up only what that run created, not what a previous `--no-cleanup` run left behind.
 
 ## Audit Logging
 

--- a/cmd/macnoise/format_test.go
+++ b/cmd/macnoise/format_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/0xv1n/macnoise/internal/output"
+)
+
+// An unrecognised --format used to fall through the emitter's switch to human
+// output, so anyone who mistyped it while piping to a parser silently got the
+// wrong format instead of an error.
+func TestParseFormat(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    output.Format
+		wantErr bool
+	}{
+		{in: "human", want: output.FormatHuman},
+		{in: "jsonl", want: output.FormatJSONL},
+		{in: "garbage", wantErr: true},
+		{in: "JSONL", wantErr: true},
+		{in: "json", wantErr: true},
+		{in: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := parseFormat(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseFormat(%q) = %q, want an error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseFormat(%q): unexpected error %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseFormat(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/macnoise/main.go
+++ b/cmd/macnoise/main.go
@@ -29,13 +29,14 @@ import (
 )
 
 var (
-	globalFormat   string
-	globalOutput   string
-	globalVerbose  bool
-	globalDryRun   bool
-	globalTimeout  int
-	globalAuditLog string
-	globalConfig   string
+	globalFormat    string
+	globalOutput    string
+	globalVerbose   bool
+	globalDryRun    bool
+	globalNoCleanup bool
+	globalTimeout   int
+	globalAuditLog  string
+	globalConfig    string
 )
 
 var loadedConfig config.Config
@@ -73,6 +74,7 @@ EDR validation, and detection engineering.`,
 	root.PersistentFlags().StringVar(&globalOutput, "output", "", "Write output to file (in addition to stdout)")
 	root.PersistentFlags().BoolVarP(&globalVerbose, "verbose", "v", false, "Verbose output")
 	root.PersistentFlags().BoolVar(&globalDryRun, "dry-run", false, "Preview actions without executing")
+	root.PersistentFlags().BoolVar(&globalNoCleanup, "no-cleanup", false, "Leave module artifacts in place so the persistence itself can be detected")
 	root.PersistentFlags().IntVar(&globalTimeout, "timeout", 30, "Per-module timeout in seconds (0 = no timeout)")
 	root.PersistentFlags().StringVar(&globalAuditLog, "audit-log", "", "Write OCSF 1.7.0 JSONL audit records to file")
 	root.PersistentFlags().StringVar(&globalConfig, "config", "", "Config YAML file (default: none)")
@@ -161,10 +163,11 @@ func signalContext() (context.Context, context.CancelFunc) {
 func buildRunOpts(auditLogger *audit.Logger) runner.Options {
 	timeout := time.Duration(globalTimeout) * time.Second
 	return runner.Options{
-		DryRun:   globalDryRun,
-		Timeout:  timeout,
-		Verbose:  globalVerbose,
-		AuditLog: auditLogger,
+		DryRun:    globalDryRun,
+		NoCleanup: globalNoCleanup,
+		Timeout:   timeout,
+		Verbose:   globalVerbose,
+		AuditLog:  auditLogger,
 	}
 }
 

--- a/cmd/macnoise/main.go
+++ b/cmd/macnoise/main.go
@@ -66,6 +66,9 @@ EDR validation, and detection engineering.`,
 			if !cmd.Flags().Changed("timeout") && cfg.DefaultTimeout > 0 {
 				globalTimeout = cfg.DefaultTimeout
 			}
+			if !cmd.Flags().Changed("output") && cfg.OutputFile != "" {
+				globalOutput = cfg.OutputFile
+			}
 			return nil
 		},
 	}
@@ -90,8 +93,23 @@ EDR validation, and detection engineering.`,
 	return root
 }
 
+// parseFormat rejects an unknown --format instead of letting the emitter fall
+// back to human output, which silently produced the wrong format for anyone
+// who mistyped it while piping to a parser.
+func parseFormat(s string) (output.Format, error) {
+	switch f := output.Format(s); f {
+	case output.FormatHuman, output.FormatJSONL:
+		return f, nil
+	default:
+		return "", fmt.Errorf("invalid --format %q: must be %q or %q", s, output.FormatHuman, output.FormatJSONL)
+	}
+}
+
 func buildEmitter() (*output.Emitter, func(), error) {
-	format := output.Format(globalFormat)
+	format, err := parseFormat(globalFormat)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	em := output.NewEmitter(format, os.Stdout)
 	closeFile := func() {}
@@ -181,6 +199,10 @@ func buildRun() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run [module]",
 		Short: "Run one or more telemetry modules",
+		// Without this, `macnoise run a b` fell through to the catch-all
+		// "specify a module name" error, which is confusing advice when the
+		// user did specify one.
+		Args: cobra.MaximumNArgs(1),
 		Example: `  macnoise run net_connect --param target=127.0.0.1 --param port=8080
   macnoise run --category network
   macnoise run --all --format jsonl`,

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -289,9 +289,12 @@ func epochMS(t time.Time) int64 {
 }
 
 func currentActor() *OCSFActor {
+	// cmd_line is declared by OCSF and was never populated. It is what an
+	// analyst needs to tell one macnoise run from another in a shared log.
 	proc := &OCSFProcess{
-		PID:  os.Getpid(),
-		Name: "MacNoise",
+		PID:     os.Getpid(),
+		Name:    "MacNoise",
+		CmdLine: strings.Join(os.Args, " "),
 	}
 	if u, err := user.Current(); err == nil {
 		proc.User = &OCSFUser{Name: u.Username}

--- a/internal/output/event.go
+++ b/internal/output/event.go
@@ -2,9 +2,13 @@ package output
 
 import (
 	"os"
+	"os/exec"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/0xv1n/macnoise/pkg/module"
 )
@@ -31,10 +35,35 @@ func CurrentProcessContext() module.ProcessContext {
 	return currentProcessContext()
 }
 
+// parentProcessName resolves the parent's executable name, which is what EDR
+// correlation keys on: a pid alone says nothing about whether macnoise was
+// launched from a shell, a scheduler, or another process.
+//
+// Resolved once per run rather than per event. currentProcessContext runs for
+// every emitted event, so spawning ps each time would be slow and would inject
+// spurious process telemetry into the very stream this tool exists to produce.
+// An empty result is left empty rather than guessed at.
+func parentProcessName() string {
+	parentNameOnce.Do(func() {
+		out, err := exec.Command("ps", "-p", strconv.Itoa(os.Getppid()), "-o", "comm=").Output()
+		if err != nil {
+			return
+		}
+		parentName = filepath.Base(strings.TrimSpace(string(out)))
+	})
+	return parentName
+}
+
+var (
+	parentNameOnce sync.Once
+	parentName     string
+)
+
 func currentProcessContext() module.ProcessContext {
 	pc := module.ProcessContext{
 		PID:        os.Getpid(),
 		PPID:       os.Getppid(),
+		ParentName: parentProcessName(),
 		Executable: executablePath(),
 	}
 	if u, err := user.Current(); err == nil {

--- a/internal/runner/nocleanup_test.go
+++ b/internal/runner/nocleanup_test.go
@@ -1,0 +1,101 @@
+package runner_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/internal/audit"
+	"github.com/0xv1n/macnoise/internal/runner"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestRunSingle_CleanupRunsByDefault(t *testing.T) {
+	gen := &mockGen{name: "mock_default_cleanup"}
+
+	if err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{}); err != nil {
+		t.Fatalf("RunSingle: %v", err)
+	}
+	if !gen.cleanedUp {
+		t.Error("Cleanup was not called; it must run unless --no-cleanup is given")
+	}
+}
+
+// The artifact has to survive the run, otherwise there is nothing installed
+// for a detection to find and the flag is pointless.
+func TestRunSingle_NoCleanupLeavesArtifacts(t *testing.T) {
+	gen := &mockGen{name: "mock_no_cleanup"}
+
+	opts := runner.Options{NoCleanup: true}
+	if err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, opts); err != nil {
+		t.Fatalf("RunSingle: %v", err)
+	}
+	if gen.cleanedUp {
+		t.Error("Cleanup ran despite NoCleanup being set, so the artifact did not persist")
+	}
+}
+
+// A skipped cleanup must be distinguishable in the audit log from one that ran
+// and succeeded. Recording it as "ok" would claim the host was returned to its
+// prior state when persistence is still installed.
+func TestRunSingle_NoCleanupIsRecordedAsSkipped(t *testing.T) {
+	tests := []struct {
+		name      string
+		noCleanup bool
+		want      string
+	}{
+		{"cleanup ran", false, "ok"},
+		{"cleanup skipped", true, "skipped"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+			logger, err := audit.NewLogger(auditPath, "test")
+			if err != nil {
+				t.Fatalf("new audit logger: %v", err)
+			}
+
+			gen := &mockGen{name: "mock_audit_cleanup"}
+			opts := runner.Options{NoCleanup: tt.noCleanup, AuditLog: logger}
+			if err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, opts); err != nil {
+				t.Fatalf("RunSingle: %v", err)
+			}
+			if err := logger.Close(); err != nil {
+				t.Fatalf("close audit logger: %v", err)
+			}
+
+			got := cleanupResultFromAudit(t, auditPath)
+			if got != tt.want {
+				t.Errorf("cleanup_result = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func cleanupResultFromAudit(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("audit line is not valid JSON: %v", err)
+		}
+		unmapped, ok := rec["unmapped"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if result, ok := unmapped["cleanup_result"].(string); ok {
+			return result
+		}
+	}
+	t.Fatal("no lifecycle record with a cleanup_result was written")
+	return ""
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -16,10 +16,14 @@ import (
 
 // Options controls module execution behaviour in RunSingle, RunMany, and RunScenario.
 type Options struct {
-	DryRun   bool
-	Timeout  time.Duration
-	Verbose  bool
-	AuditLog *audit.Logger
+	DryRun bool
+	// NoCleanup leaves module artifacts in place after Generate. Validation
+	// workflows need the installed artifact to persist so the persistence
+	// itself can be detected, not just the install event.
+	NoCleanup bool
+	Timeout   time.Duration
+	Verbose   bool
+	AuditLog  *audit.Logger
 }
 
 // RunSingle executes one module through its full lifecycle (prereqs → generate → cleanup).
@@ -71,11 +75,20 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 	defer func() {
 		cleanupResult := "ok"
 		cleanupErrStr := ""
-		if err := gen.Cleanup(); err != nil {
-			cleanupResult = "error"
-			cleanupErrStr = err.Error()
-			if opts.Verbose {
-				fmt.Printf("[%s] cleanup error: %v\n", info.Name, err)
+		switch {
+		case opts.NoCleanup:
+			// Always announced, not gated behind --verbose: leaving real
+			// persistence installed is the kind of thing an operator must not
+			// discover later by accident.
+			cleanupResult = "skipped"
+			fmt.Printf("[%s] cleanup skipped (--no-cleanup); artifacts left in place, see 'macnoise info %s'\n", info.Name, info.Name)
+		default:
+			if err := gen.Cleanup(); err != nil {
+				cleanupResult = "error"
+				cleanupErrStr = err.Error()
+				if opts.Verbose {
+					fmt.Printf("[%s] cleanup error: %v\n", info.Name, err)
+				}
 			}
 		}
 		if opts.AuditLog != nil {

--- a/modules/network/beacon.go
+++ b/modules/network/beacon.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -33,7 +34,29 @@ func (c *c2Beacon) ParamSpecs() []module.ParamSpec {
 		{Name: "target", Description: "Target URL or host", Required: false, DefaultValue: "http://example.com", Example: "http://10.0.0.1"},
 		{Name: "count", Description: "Number of beacon attempts", Required: false, DefaultValue: "3", Example: "5"},
 		{Name: "interval", Description: "Seconds between beacons", Required: false, DefaultValue: "2", Example: "10"},
+		{Name: "jitter", Description: "Percent to randomise each interval by, 0-100 (0 = fixed)", Required: false, DefaultValue: "0", Example: "30"},
 	}
+}
+
+// jitterInterval randomises base by up to jitterPct percent in either
+// direction. A perfectly fixed beacon interval is one of the easiest C2
+// signals to fingerprint, so real implants jitter and detections look for the
+// absence of it. The result is clamped at zero so a large percentage cannot
+// produce a negative delay.
+func jitterInterval(base time.Duration, jitterPct int, rnd *rand.Rand) time.Duration {
+	if jitterPct <= 0 || base <= 0 {
+		return base
+	}
+	if jitterPct > 100 {
+		jitterPct = 100
+	}
+	span := float64(base) * float64(jitterPct) / 100.0
+	offset := (rnd.Float64()*2 - 1) * span
+	out := time.Duration(float64(base) + offset)
+	if out < 0 {
+		return 0
+	}
+	return out
 }
 
 func (c *c2Beacon) CheckPrereqs() error { return nil }
@@ -42,12 +65,16 @@ func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit modu
 	target := params.Get("target", "http://example.com")
 	countStr := params.Get("count", "3")
 	intervalStr := params.Get("interval", "2")
+	jitterStr := params.Get("jitter", "0")
 
 	count := 3
 	fmt.Sscanf(countStr, "%d", &count) //nolint:errcheck
 	intervalSecs := 2
 	fmt.Sscanf(intervalStr, "%d", &intervalSecs) //nolint:errcheck
 	interval := time.Duration(intervalSecs) * time.Second
+	jitterPct := 0
+	fmt.Sscanf(jitterStr, "%d", &jitterPct)                //nolint:errcheck
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // jitter timing, not security
 
 	info := c.Info()
 	client := &http.Client{Timeout: 5 * time.Second}
@@ -77,7 +104,7 @@ func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit modu
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(interval):
+			case <-time.After(jitterInterval(interval, jitterPct, rnd)):
 			}
 		}
 	}
@@ -88,8 +115,9 @@ func (c *c2Beacon) DryRun(params module.Params) []string {
 	target := params.Get("target", "http://example.com")
 	countStr := params.Get("count", "3")
 	intervalStr := params.Get("interval", "2")
+	jitterStr := params.Get("jitter", "0")
 	return []string{
-		fmt.Sprintf("send %s HTTP GET requests to %s with %ss interval", countStr, target, intervalStr),
+		fmt.Sprintf("send %s HTTP GET requests to %s with %ss interval (jitter %s%%)", countStr, target, intervalStr, jitterStr),
 	}
 }
 

--- a/modules/network/beacon_test.go
+++ b/modules/network/beacon_test.go
@@ -1,0 +1,57 @@
+package network
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// A perfectly fixed beacon interval is trivially fingerprinted, so jitter has
+// to actually vary the delay, stay within the requested bound, and never go
+// negative.
+func TestJitterInterval(t *testing.T) {
+	base := 10 * time.Second
+	rnd := rand.New(rand.NewSource(1)) //nolint:gosec // deterministic test input
+
+	t.Run("zero jitter is exact", func(t *testing.T) {
+		if got := jitterInterval(base, 0, rnd); got != base {
+			t.Errorf("jitterInterval(%v, 0) = %v, want %v unchanged", base, got, base)
+		}
+	})
+
+	t.Run("negative jitter is treated as zero", func(t *testing.T) {
+		if got := jitterInterval(base, -20, rnd); got != base {
+			t.Errorf("jitterInterval(%v, -20) = %v, want %v unchanged", base, got, base)
+		}
+	})
+
+	t.Run("stays within the requested bound", func(t *testing.T) {
+		const pct = 30
+		lo := time.Duration(float64(base) * 0.70)
+		hi := time.Duration(float64(base) * 1.30)
+		for range 500 {
+			got := jitterInterval(base, pct, rnd)
+			if got < lo || got > hi {
+				t.Fatalf("jitterInterval(%v, %d) = %v, outside [%v, %v]", base, pct, got, lo, hi)
+			}
+		}
+	})
+
+	t.Run("actually varies the delay", func(t *testing.T) {
+		seen := map[time.Duration]bool{}
+		for range 50 {
+			seen[jitterInterval(base, 50, rnd)] = true
+		}
+		if len(seen) < 2 {
+			t.Errorf("jitter produced %d distinct delay(s); the interval is still fixed", len(seen))
+		}
+	})
+
+	t.Run("over-100 percent does not go negative", func(t *testing.T) {
+		for range 500 {
+			if got := jitterInterval(base, 400, rnd); got < 0 {
+				t.Fatalf("jitterInterval(%v, 400) = %v, want a non-negative delay", base, got)
+			}
+		}
+	})
+}

--- a/pkg/module/interface.go
+++ b/pkg/module/interface.go
@@ -61,6 +61,7 @@ func (p Params) Get(key, defaultVal string) string {
 type ProcessContext struct {
 	PID        int    `json:"pid"`
 	PPID       int    `json:"ppid"`
+	ParentName string `json:"parent_name,omitempty"`
 	Executable string `json:"executable"`
 	Username   string `json:"username"`
 }


### PR DESCRIPTION
Modules always reversed themselves, so a detection only ever saw the install event and never the persistence on disk; --no-cleanup skips Cleanup() so the artifact survives, announces every module that skipped, and records cleanup_result as skipped rather than ok. Bundled with it are six verified paper cuts: an invalid --format silently fell back to human instead of erroring, config output_file was parsed but never applied, `run a b` gave the confusing "specify a module name" error, net_beacon had no jitter so its interval was trivially fingerprinted, and OCSF cmd_line plus a parent process name were both absent from the audit records EDR correlation depends on.