### PR TITLE
feat: add event outcome to distinguish a refused action from a broken tool

### DIFF
--- a/AI-GUIDANCE.md
+++ b/AI-GUIDANCE.md
@@ -80,7 +80,7 @@ MacNoise is structured in five distinct layers. When reasoning about where a cha
 | File | Purpose |
 |------|---------|
 | `internal/output/emitter.go` | `Emitter` — wraps one or more `io.Writer` targets; `Format` type (`human` / `jsonl`); `NewEmitter`, `Emit`, `EmitFunc` |
-| `internal/output/event.go` | `NewEvent` — constructs a `TelemetryEvent` pre-populated with module metadata and `ProcessContext`; `WithDetails`, `WithError`, `DetailStr`, `DetailInt` helpers; `SchemaVersion = "1.0"`; `CurrentProcessContext` |
+| `internal/output/event.go` | `NewEvent` — constructs a `TelemetryEvent` pre-populated with module metadata and `ProcessContext`; `WithDetails`, `WithError`, `WithOutcome`, `DetailStr`, `DetailInt` helpers; `SchemaVersion = "1.1"`; `CurrentProcessContext` |
 
 ### Runner
 
@@ -182,14 +182,21 @@ ev.Success = true
 ev.Message = "final message"
 ev = output.WithDetails(ev, map[string]any{"key": "value"})
 
-// Decorate — error path
+// Decorate — macnoise itself failed
 ev = output.WithError(ev, err)
+
+// Decorate — the action ran but the environment refused or did not answer it
+ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 
 // Emit
 emit(ev)
 ```
 
-`output.NewEvent` populates `SchemaVersion`, `Module`, `Category`, `EventType`, `MITRE`, and `ProcessContext` automatically. Modules only set `Success`, `Message`, `Details`, and `Error`.
+`output.NewEvent` populates `SchemaVersion`, `Module`, `Category`, `EventType`, `MITRE`, and `ProcessContext` automatically. Modules only set `Success`, `Message`, `Details`, `Error`, and where it matters `Outcome`.
+
+**Picking between `WithError` and `WithOutcome`.** `Success` answers "did macnoise work"; `Outcome` answers "what happened to the action". A refused TCC probe, a connection to a closed port, and a missing target are all telemetry this tool exists to produce, not faults, and `WithError` would file them alongside a broken module. Reach for `WithOutcome` with `OutcomeDenied` when the environment refused, `OutcomeIndeterminate` when nothing can be concluded, and keep `WithError` for macnoise itself failing.
+
+Most events set no outcome at all. The field is resolved from `Success` at the output boundary the same way `Timestamp` is, so emitted records always carry one and the two fields can never disagree - see `TelemetryEvent.ResolvedOutcome`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ MacNoise writes two separate streams. Telemetry events - what your EDR/SIEM actu
 ./macnoise scenario configs/scenarios/amos_atomic_stealer.yaml --audit-log /tmp/audit.jsonl
 ```
 
+Every telemetry event carries an `outcome` alongside `success` (schema 1.1). `success` says whether MacNoise worked; `outcome` says what happened to the action it attempted:
+
+| `outcome` | Meaning | Human marker |
+|---|---|---|
+| `executed` | The action ran and did what the module claims | `[+]` |
+| `denied` | The action ran and the environment refused it | `[-]` |
+| `indeterminate` | The action ran, but nothing can be concluded | `[?]` |
+| `error` | MacNoise itself failed to carry the action out | `[!]` |
+
+A denied TCC probe or a beacon to a dead C2 is the telemetry this tool exists to generate, so those stay `success: true` and are told apart by `outcome`. Only `error` sets `success: false`. In the audit log the same value appears at `unmapped.outcome`, since OCSF `status` records a refused action and a broken tool identically.
+
 The audit log opens in append mode, so records from multiple runs pile up in one file for batch analysis. If you're adding a module and want to know how a new event type gets classified into OCSF, see [CONTRIBUTING.md](CONTRIBUTING.md#audit-logging-ocsf).
 
 ## Module Reference

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -1,5 +1,39 @@
 package audit
 
+import "github.com/0xv1n/macnoise/pkg/module"
+
+// OutcomeStatus holds the OCSF severity and status identifiers implied by an
+// event outcome.
+type OutcomeStatus struct {
+	SeverityID int
+	Severity   string
+	StatusID   int
+	Status     string
+}
+
+// statusForOutcome maps an event outcome to OCSF severity and status.
+//
+// OCSF status describes the activity being reported rather than macnoise's own
+// health, so a denied read is a failed read: denied and error both map to
+// Failure. Their distinction is preserved in unmapped.outcome, where a consumer
+// that needs it can read it without OCSF semantics having to bend.
+//
+// Severity is where the two do diverge. Only a genuine macnoise fault is
+// elevated; a refused probe is the expected result this tool exists to produce,
+// and raising its severity would bury real faults under routine denials.
+func statusForOutcome(o module.Outcome) OutcomeStatus {
+	switch o {
+	case module.OutcomeDenied:
+		return OutcomeStatus{1, "Informational", 2, "Failure"}
+	case module.OutcomeIndeterminate:
+		return OutcomeStatus{1, "Informational", 0, "Unknown"}
+	case module.OutcomeError:
+		return OutcomeStatus{3, "Medium", 2, "Failure"}
+	default:
+		return OutcomeStatus{1, "Informational", 1, "Success"}
+	}
+}
+
 // Classification holds the OCSF class, category, and activity identifiers for an event.
 type Classification struct {
 	ClassUID     int

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -82,16 +82,8 @@ func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, para
 	cl := Classify(ev.Category, ev.EventType)
 	now := epochMS(time.Now())
 
-	severityID := 1
-	severity := "Informational"
-	statusID := 1
-	status := "Success"
-	if !ev.Success {
-		severityID = 3
-		severity = "Medium"
-		statusID = 2
-		status = "Failure"
-	}
+	outcome := ev.ResolvedOutcome()
+	st := statusForOutcome(outcome)
 
 	rec := Record{
 		ActivityID:   cl.ActivityID,
@@ -100,14 +92,14 @@ func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, para
 		CategoryName: cl.CategoryName,
 		ClassUID:     cl.ClassUID,
 		ClassName:    cl.ClassName,
-		SeverityID:   severityID,
-		Severity:     severity,
+		SeverityID:   st.SeverityID,
+		Severity:     st.Severity,
 		Time:         now,
 		TypeUID:      cl.ClassUID*100 + cl.ActivityID,
 		TypeName:     fmt.Sprintf("%s: %s", cl.ClassName, cl.ActivityName),
 		Message:      ev.Message,
-		StatusID:     statusID,
-		Status:       status,
+		StatusID:     st.StatusID,
+		Status:       st.Status,
 		Metadata:     l.metadata(),
 		Actor:        l.actor,
 		Device:       l.device,
@@ -117,6 +109,7 @@ func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, para
 			ModuleCategory: string(info.Category),
 			Params:         map[string]string(params),
 			Privileges:     string(info.Privileges),
+			Outcome:        string(outcome),
 		},
 	}
 

--- a/internal/audit/outcome_test.go
+++ b/internal/audit/outcome_test.go
@@ -1,0 +1,129 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestStatusForOutcome(t *testing.T) {
+	cases := []struct {
+		outcome    module.Outcome
+		severityID int
+		severity   string
+		statusID   int
+		status     string
+	}{
+		{module.OutcomeExecuted, 1, "Informational", 1, "Success"},
+		{module.OutcomeDenied, 1, "Informational", 2, "Failure"},
+		{module.OutcomeIndeterminate, 1, "Informational", 0, "Unknown"},
+		{module.OutcomeError, 3, "Medium", 2, "Failure"},
+	}
+
+	for _, tc := range cases {
+		got := statusForOutcome(tc.outcome)
+		want := OutcomeStatus{tc.severityID, tc.severity, tc.statusID, tc.status}
+		if got != want {
+			t.Errorf("statusForOutcome(%q) = %+v, want %+v", tc.outcome, got, want)
+		}
+	}
+}
+
+// The bug this replaced: severity keyed off Success alone, and the TCC probes
+// set Success true on a genuine I/O failure, so a broken probe was written to
+// the audit log as Informational.
+func TestErrorOutcomeIsTheOnlyElevatedSeverity(t *testing.T) {
+	for _, o := range []module.Outcome{module.OutcomeExecuted, module.OutcomeDenied, module.OutcomeIndeterminate} {
+		if st := statusForOutcome(o); st.SeverityID != 1 {
+			t.Errorf("%q raised severity to %d; only a macnoise fault should", o, st.SeverityID)
+		}
+	}
+	if st := statusForOutcome(module.OutcomeError); st.SeverityID != 3 {
+		t.Errorf("error severity = %d, want 3", st.SeverityID)
+	}
+}
+
+// OCSF status describes the reported activity, so a refused action is a Failure
+// of that activity even though macnoise worked. The two are told apart by
+// severity and by unmapped.outcome, not by status.
+func TestDeniedAndErrorShareStatusButNotOutcome(t *testing.T) {
+	denied := statusForOutcome(module.OutcomeDenied)
+	failed := statusForOutcome(module.OutcomeError)
+
+	if denied.StatusID != failed.StatusID {
+		t.Errorf("denied status %d and error status %d should both be OCSF Failure", denied.StatusID, failed.StatusID)
+	}
+	if denied.SeverityID == failed.SeverityID {
+		t.Error("denied and error are indistinguishable: same status and same severity")
+	}
+}
+
+func TestLogEventRecordsOutcome(t *testing.T) {
+	cases := []struct {
+		name        string
+		ev          module.TelemetryEvent
+		wantOutcome string
+		wantStatus  string
+	}{
+		{
+			name:        "denial is not reported as a successful activity",
+			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Success: true, Outcome: module.OutcomeDenied},
+			wantOutcome: "denied",
+			wantStatus:  "Failure",
+		},
+		{
+			name:        "probe error is not reported as a success",
+			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Success: true, Outcome: module.OutcomeError},
+			wantOutcome: "error",
+			wantStatus:  "Failure",
+		},
+		{
+			name:        "absent target is unknown, not failed",
+			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Success: true, Outcome: module.OutcomeIndeterminate},
+			wantOutcome: "indeterminate",
+			wantStatus:  "Unknown",
+		},
+		{
+			name:        "an event with no outcome still records one",
+			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Success: true},
+			wantOutcome: "executed",
+			wantStatus:  "Success",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := recordFor(t, tc.ev)
+
+			if rec.Status != tc.wantStatus {
+				t.Errorf("status = %q, want %q", rec.Status, tc.wantStatus)
+			}
+			um, ok := rec.Unmapped.(map[string]any)
+			if !ok {
+				t.Fatalf("unmapped is %T, want an object", rec.Unmapped)
+			}
+			if um["outcome"] != tc.wantOutcome {
+				t.Errorf("unmapped.outcome = %v, want %q", um["outcome"], tc.wantOutcome)
+			}
+		})
+	}
+}
+
+// recordFor round-trips ev through a real Logger and returns the single record
+// it wrote, so the assertions run against serialised JSON rather than the
+// in-memory struct.
+func recordFor(t *testing.T, ev module.TelemetryEvent) Record {
+	t.Helper()
+
+	l, path := newTestLogger(t)
+	l.LogEvent(ev, module.ModuleInfo{Name: "tcc_fda", Category: module.CategoryTCC}, nil)
+	if err := l.Close(); err != nil {
+		t.Fatalf("close logger: %v", err)
+	}
+
+	records := readRecords(t, path)
+	if len(records) != 1 {
+		t.Fatalf("wrote %d records, want 1", len(records))
+	}
+	return records[0]
+}

--- a/internal/audit/record.go
+++ b/internal/audit/record.go
@@ -6,30 +6,32 @@ package audit
 
 // Record is a single OCSF 1.7.0-aligned audit log entry written to the audit JSONL file.
 type Record struct {
-	ActivityID   int          `json:"activity_id"`
-	ActivityName string       `json:"activity_name,omitempty"`
-	CategoryUID  int          `json:"category_uid"`
-	CategoryName string       `json:"category_name,omitempty"`
-	ClassUID     int          `json:"class_uid"`
-	ClassName    string       `json:"class_name,omitempty"`
-	SeverityID   int          `json:"severity_id"`
-	Severity     string       `json:"severity,omitempty"`
-	Time         int64        `json:"time"`
-	TypeUID      int          `json:"type_uid"`
-	TypeName     string       `json:"type_name,omitempty"`
-	Message      string       `json:"message,omitempty"`
-	StatusID     int          `json:"status_id,omitempty"`
-	Status       string       `json:"status,omitempty"`
-	StartTime    int64        `json:"start_time,omitempty"`
-	EndTime      int64        `json:"end_time,omitempty"`
-	Duration     int64        `json:"duration,omitempty"`
-	Metadata     OCSFMetadata `json:"metadata"`
-	Actor        *OCSFActor   `json:"actor,omitempty"`
-	Device       *OCSFDevice  `json:"device,omitempty"`
-	File         *OCSFFile    `json:"file,omitempty"`
-	Process      *OCSFProcess `json:"process,omitempty"`
-	Attacks      []OCSFAttack `json:"attacks,omitempty"`
-	Unmapped     any          `json:"unmapped,omitempty"`
+	ActivityID   int    `json:"activity_id"`
+	ActivityName string `json:"activity_name,omitempty"`
+	CategoryUID  int    `json:"category_uid"`
+	CategoryName string `json:"category_name,omitempty"`
+	ClassUID     int    `json:"class_uid"`
+	ClassName    string `json:"class_name,omitempty"`
+	SeverityID   int    `json:"severity_id"`
+	Severity     string `json:"severity,omitempty"`
+	Time         int64  `json:"time"`
+	TypeUID      int    `json:"type_uid"`
+	TypeName     string `json:"type_name,omitempty"`
+	Message      string `json:"message,omitempty"`
+	// StatusID carries no omitempty because OCSF status_id 0 is Unknown, a
+	// meaningful value for an indeterminate outcome rather than an absent one.
+	StatusID  int          `json:"status_id"`
+	Status    string       `json:"status,omitempty"`
+	StartTime int64        `json:"start_time,omitempty"`
+	EndTime   int64        `json:"end_time,omitempty"`
+	Duration  int64        `json:"duration,omitempty"`
+	Metadata  OCSFMetadata `json:"metadata"`
+	Actor     *OCSFActor   `json:"actor,omitempty"`
+	Device    *OCSFDevice  `json:"device,omitempty"`
+	File      *OCSFFile    `json:"file,omitempty"`
+	Process   *OCSFProcess `json:"process,omitempty"`
+	Attacks   []OCSFAttack `json:"attacks,omitempty"`
+	Unmapped  any          `json:"unmapped,omitempty"`
 }
 
 // OCSFDevice identifies the host macnoise is running on. Required by OCSF for
@@ -112,14 +114,18 @@ type UnmappedData struct {
 	ModuleCategory string            `json:"module_category"`
 	Params         map[string]string `json:"params,omitempty"`
 	Privileges     string            `json:"privileges"`
-	DryRun         bool              `json:"dry_run"`
-	PrereqResult   string            `json:"prereq_result,omitempty"`
-	PrereqError    string            `json:"prereq_error,omitempty"`
-	EventsEmitted  int               `json:"events_emitted,omitempty"`
-	CleanupResult  string            `json:"cleanup_result,omitempty"`
-	CleanupError   string            `json:"cleanup_error,omitempty"`
-	ScenarioName   string            `json:"scenario_name,omitempty"`
-	ScenarioFile   string            `json:"scenario_file,omitempty"`
+	// Outcome preserves the four-way event outcome that OCSF status collapses:
+	// status cannot tell a refused action apart from a broken tool, since both
+	// are a Failure of the reported activity.
+	Outcome       string `json:"outcome,omitempty"`
+	DryRun        bool   `json:"dry_run"`
+	PrereqResult  string `json:"prereq_result,omitempty"`
+	PrereqError   string `json:"prereq_error,omitempty"`
+	EventsEmitted int    `json:"events_emitted,omitempty"`
+	CleanupResult string `json:"cleanup_result,omitempty"`
+	CleanupError  string `json:"cleanup_error,omitempty"`
+	ScenarioName  string `json:"scenario_name,omitempty"`
+	ScenarioFile  string `json:"scenario_file,omitempty"`
 }
 
 // ScenarioUnmappedData holds scenario-level fields for Records written by LogScenario.

--- a/internal/output/emitter.go
+++ b/internal/output/emitter.go
@@ -42,6 +42,7 @@ func (e *Emitter) Emit(ev module.TelemetryEvent) {
 	if ev.Timestamp.IsZero() {
 		ev.Timestamp = time.Now().UTC()
 	}
+	ev.Outcome = ev.ResolvedOutcome()
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -65,11 +66,24 @@ func (e *Emitter) writeJSONL(w io.Writer, ev module.TelemetryEvent) {
 	_, _ = fmt.Fprintln(w, string(b))
 }
 
-func (e *Emitter) writeHuman(w io.Writer, ev module.TelemetryEvent) {
-	status := "+"
-	if !ev.Success {
-		status = "!"
+// humanMarker distinguishes the four outcomes at a glance. A denial and an
+// indeterminate result both used to print as [+], since neither is a macnoise
+// failure, which made a refused probe read as a clean success.
+func humanMarker(outcome module.Outcome) string {
+	switch outcome {
+	case module.OutcomeDenied:
+		return "-"
+	case module.OutcomeIndeterminate:
+		return "?"
+	case module.OutcomeError:
+		return "!"
+	default:
+		return "+"
 	}
+}
+
+func (e *Emitter) writeHuman(w io.Writer, ev module.TelemetryEvent) {
+	status := humanMarker(ev.ResolvedOutcome())
 	ts := ev.Timestamp.Format("15:04:05")
 	_, _ = fmt.Fprintf(w, "[%s] [%s] [%s/%s] %s\n", status, ts, ev.Category, ev.Module, ev.Message)
 	if ev.Error != "" {

--- a/internal/output/event.go
+++ b/internal/output/event.go
@@ -14,7 +14,8 @@ import (
 )
 
 // SchemaVersion is the telemetry event schema version embedded in every event.
-const SchemaVersion = "1.0"
+// 1.1 added the outcome field.
+const SchemaVersion = "1.1"
 
 // NewEvent constructs a TelemetryEvent pre-populated with module metadata and process context.
 func NewEvent(mod module.ModuleInfo, eventType string, success bool, message string) module.TelemetryEvent {
@@ -89,10 +90,30 @@ func WithDetails(ev module.TelemetryEvent, details map[string]any) module.Teleme
 	return ev
 }
 
-// WithError returns a copy of ev with Success set to false and Error populated from err.
+// WithError returns a copy of ev marked as a macnoise failure: Success false,
+// Outcome error, Error populated from err.
+//
+// Reach for WithOutcome instead when err describes the environment refusing or
+// not answering the action rather than macnoise breaking. A refused connection
+// or a TCC denial is the telemetry this tool exists to produce, not a fault,
+// and recording it here makes it indistinguishable from one.
 func WithError(ev module.TelemetryEvent, err error) module.TelemetryEvent {
 	ev.Error = err.Error()
 	ev.Success = false
+	ev.Outcome = module.OutcomeError
+	return ev
+}
+
+// WithOutcome returns a copy of ev with outcome set, keeping Success in sync so
+// the two fields can never disagree. Pass a non-nil err to record why the
+// action was refused or left undecided; unlike WithError that error does not
+// mark the event as a tool failure.
+func WithOutcome(ev module.TelemetryEvent, outcome module.Outcome, err error) module.TelemetryEvent {
+	ev.Outcome = outcome
+	ev.Success = outcome != module.OutcomeError
+	if err != nil {
+		ev.Error = err.Error()
+	}
 	return ev
 }
 

--- a/internal/output/outcome_test.go
+++ b/internal/output/outcome_test.go
@@ -1,0 +1,135 @@
+package output_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func outcomeModuleInfo() module.ModuleInfo {
+	return module.ModuleInfo{Name: "test_module", Category: module.CategoryTCC}
+}
+
+// A denied action and a broken tool must not look the same. Before the outcome
+// field the only way to express "the probe was refused" was Success plus prose,
+// which a consumer cannot filter on.
+func TestWithOutcomeKeepsSuccessInSync(t *testing.T) {
+	cases := []struct {
+		outcome     module.Outcome
+		wantSuccess bool
+	}{
+		{module.OutcomeExecuted, true},
+		{module.OutcomeDenied, true},
+		{module.OutcomeIndeterminate, true},
+		{module.OutcomeError, false},
+	}
+
+	for _, tc := range cases {
+		ev := output.NewEvent(outcomeModuleInfo(), "tcc_fda_probe", true, "probing")
+		ev = output.WithOutcome(ev, tc.outcome, nil)
+
+		if ev.Outcome != tc.outcome {
+			t.Errorf("%s: outcome = %q, want %q", tc.outcome, ev.Outcome, tc.outcome)
+		}
+		if ev.Success != tc.wantSuccess {
+			t.Errorf("%s: success = %v, want %v", tc.outcome, ev.Success, tc.wantSuccess)
+		}
+	}
+}
+
+// The error recorded alongside a denial explains the refusal. It must not flip
+// the event into a tool failure the way WithError does.
+func TestWithOutcomeErrorDoesNotMarkFailure(t *testing.T) {
+	ev := output.NewEvent(outcomeModuleInfo(), "tcc_fda_probe", true, "probing")
+	ev = output.WithOutcome(ev, module.OutcomeDenied, errors.New("permission denied"))
+
+	if ev.Error != "permission denied" {
+		t.Errorf("error = %q, want %q", ev.Error, "permission denied")
+	}
+	if !ev.Success {
+		t.Error("a denial recorded an error and was marked as a macnoise failure")
+	}
+	if ev.Outcome != module.OutcomeDenied {
+		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeDenied)
+	}
+}
+
+func TestWithErrorSetsErrorOutcome(t *testing.T) {
+	ev := output.NewEvent(outcomeModuleInfo(), "tcc_fda_probe", true, "probing")
+	ev = output.WithError(ev, errors.New("i/o error"))
+
+	if ev.Outcome != module.OutcomeError {
+		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeError)
+	}
+	if ev.Success {
+		t.Error("WithError left Success true")
+	}
+}
+
+// Modules overwhelmingly never set an outcome, so an emitted record has to
+// carry one anyway or a consumer cannot rely on the field being there.
+func TestEmittedJSONAlwaysCarriesOutcome(t *testing.T) {
+	cases := []struct {
+		name string
+		ev   module.TelemetryEvent
+		want string
+	}{
+		{"unset and successful", module.TelemetryEvent{Success: true}, "executed"},
+		{"unset and failed", module.TelemetryEvent{Success: false}, "error"},
+		{"explicitly denied", module.TelemetryEvent{Success: true, Outcome: module.OutcomeDenied}, "denied"},
+		{
+			"explicitly indeterminate",
+			module.TelemetryEvent{Success: true, Outcome: module.OutcomeIndeterminate},
+			"indeterminate",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			output.NewEmitter(output.FormatJSONL, &buf).Emit(tc.ev)
+
+			var m map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+				t.Fatalf("invalid JSON: %v", err)
+			}
+			if got := m["outcome"]; got != tc.want {
+				t.Errorf("outcome = %v, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHumanMarkerPerOutcome(t *testing.T) {
+	cases := []struct {
+		outcome module.Outcome
+		want    string
+	}{
+		{module.OutcomeExecuted, "[+]"},
+		{module.OutcomeDenied, "[-]"},
+		{module.OutcomeIndeterminate, "[?]"},
+		{module.OutcomeError, "[!]"},
+	}
+
+	for _, tc := range cases {
+		var buf bytes.Buffer
+		ev := sampleEvent()
+		ev.Outcome = tc.outcome
+		output.NewEmitter(output.FormatHuman, &buf).Emit(ev)
+
+		if !strings.Contains(buf.String(), tc.want) {
+			t.Errorf("%s: expected marker %s, got %q", tc.outcome, tc.want, buf.String())
+		}
+	}
+}
+
+func TestSchemaVersionBumped(t *testing.T) {
+	if output.SchemaVersion != "1.1" {
+		t.Errorf("SchemaVersion = %q, want 1.1 (outcome field added)", output.SchemaVersion)
+	}
+}

--- a/modules/file/browser_creds.go
+++ b/modules/file/browser_creds.go
@@ -206,6 +206,9 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 			case os.IsNotExist(readErr) || errors.Is(readErr, errNotRegularFile):
 				ev = output.NewEvent(info, "browser_cred_probe", true,
 					fmt.Sprintf("%s credential path not present: %s", browser.name, path))
+				// An absent path means no read was attempted and no access
+				// decision was made, the same distinction the TCC probes draw.
+				ev = output.WithOutcome(ev, module.OutcomeIndeterminate, nil)
 				ev = output.WithDetails(ev, map[string]any{
 					"browser": browser.name,
 					"path":    path,
@@ -219,8 +222,7 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 				// read attempt rather than a module failure.
 				ev = output.NewEvent(info, "browser_cred_read", true,
 					fmt.Sprintf("%s credential file read denied: %s", browser.name, path))
-				ev = output.WithError(ev, readErr)
-				ev.Success = true
+				ev = output.WithOutcome(ev, module.OutcomeDenied, readErr)
 				ev = output.WithDetails(ev, map[string]any{
 					"browser":    browser.name,
 					"path":       path,

--- a/modules/network/beacon.go
+++ b/modules/network/beacon.go
@@ -89,8 +89,7 @@ func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit modu
 		ev := output.NewEvent(info, "http_beacon", false, fmt.Sprintf("beacon %d/%d to %s", i, count, target))
 		resp, err := client.Get(target)
 		if err != nil {
-			ev = output.WithError(ev, err)
-			ev.Success = true
+			ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 			ev.Message = fmt.Sprintf("beacon %d/%d to %s (no response — telemetry generated)", i, count, target)
 		} else {
 			_ = resp.Body.Close()

--- a/modules/network/connect.go
+++ b/modules/network/connect.go
@@ -50,7 +50,10 @@ func (n *netConnect) Generate(ctx context.Context, params module.Params, emit mo
 	ev := output.NewEvent(info, "tcp_connect", false, fmt.Sprintf("dialing TCP %s", address))
 	conn, err := net.DialTimeout("tcp", address, 3*time.Second)
 	if err != nil {
-		ev = output.WithError(ev, err)
+		// A refused dial is the environment declining, not macnoise breaking,
+		// and the SYN that went out is the telemetry this module exists for.
+		// net_revshell already treats the identical case this way.
+		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		emit(ev)
 	} else {
 		_ = conn.Close()
@@ -65,8 +68,7 @@ func (n *netConnect) Generate(ctx context.Context, params module.Params, emit mo
 	client := http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {
-		httpEv = output.WithError(httpEv, err)
-		httpEv.Success = true
+		httpEv = output.WithOutcome(httpEv, module.OutcomeDenied, err)
 		httpEv.Message = fmt.Sprintf("HTTP GET %s generated telemetry (connection refused expected)", url)
 	} else {
 		_ = resp.Body.Close()

--- a/modules/network/dns.go
+++ b/modules/network/dns.go
@@ -55,8 +55,7 @@ func (n *netDNS) Generate(ctx context.Context, params module.Params, emit module
 		ev := output.NewEvent(info, "dns_lookup", false, fmt.Sprintf("resolving %s", domain))
 		addrs, err := resolver.LookupHost(ctx, domain)
 		if err != nil {
-			ev = output.WithError(ev, err)
-			ev.Success = true
+			ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 			ev.Message = fmt.Sprintf("DNS lookup %s failed (telemetry generated)", domain)
 		} else {
 			ev.Success = true

--- a/modules/network/revshell.go
+++ b/modules/network/revshell.go
@@ -48,8 +48,7 @@ func (n *netRevShell) Generate(ctx context.Context, params module.Params, emit m
 	var dialer net.Dialer
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
-		ev = output.WithError(ev, err)
-		ev.Success = true
+		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		ev.Message = fmt.Sprintf("reverse shell attempt to %s (connection refused — no listener)", address)
 		emit(ev)
 		return nil

--- a/modules/process/inject.go
+++ b/modules/process/inject.go
@@ -118,8 +118,10 @@ func (p *procInject) Generate(ctx context.Context, params module.Params, emit mo
 		ev.Message = fmt.Sprintf("dyld honoured DYLD_INSERT_LIBRARIES for %s", targetBin)
 	case injectStripped:
 		ev.Message = fmt.Sprintf("%s stripped DYLD_INSERT_LIBRARIES before dyld ran; the target is protected", targetBin)
+		ev = output.WithOutcome(ev, module.OutcomeDenied, nil)
 	default:
 		ev.Message = fmt.Sprintf("spawned %s with DYLD_INSERT_LIBRARIES=%s, dyld raised no diagnostic", targetBin, dylibPath)
+		ev = output.WithOutcome(ev, module.OutcomeIndeterminate, nil)
 	}
 	if runErr != nil {
 		details["exit_error"] = runErr.Error()

--- a/modules/tcc/contacts.go
+++ b/modules/tcc/contacts.go
@@ -67,14 +67,11 @@ func (t *tccContacts) Generate(ctx context.Context, params module.Params, emit m
 		ev.Message = fmt.Sprintf("Contacts TCC probe: access denied to %s (expected without permission)", abPath)
 	case probeAbsent:
 		ev.Message = fmt.Sprintf("Contacts TCC probe: %s does not exist, no TCC decision was made", abPath)
-		ev = output.WithError(ev, err)
-		ev.Success = true
 	default:
 		ev.Message = fmt.Sprintf("Contacts TCC probe: unexpected failure reading %s", abPath)
-		ev = output.WithError(ev, err)
-		ev.Success = true
 	}
 
+	ev = output.WithOutcome(ev, eventOutcome(outcome), err)
 	ev = output.WithDetails(ev, details)
 	emit(ev)
 	return nil

--- a/modules/tcc/fda.go
+++ b/modules/tcc/fda.go
@@ -88,14 +88,11 @@ func (t *tccFDA) Generate(ctx context.Context, params module.Params, emit module
 		ev.Message = fmt.Sprintf("TCC FDA probe: access denied to %s (expected without FDA)", tccPath)
 	case probeAbsent:
 		ev.Message = fmt.Sprintf("TCC FDA probe: %s does not exist, no TCC decision was made", tccPath)
-		ev = output.WithError(ev, err)
-		ev.Success = true
 	default:
 		ev.Message = fmt.Sprintf("TCC FDA probe: unexpected failure reading %s", tccPath)
-		ev = output.WithError(ev, err)
-		ev.Success = true
 	}
 
+	ev = output.WithOutcome(ev, eventOutcome(outcome), err)
 	ev = output.WithDetails(ev, details)
 	emit(ev)
 	return nil

--- a/modules/tcc/keychain.go
+++ b/modules/tcc/keychain.go
@@ -76,7 +76,7 @@ func (t *tccKeychain) Generate(ctx context.Context, params module.Params, emit m
 	unlockEv := output.NewEvent(info, "keychain_unlock_attempt", false, fmt.Sprintf("attempting keychain unlock: %s", keychainPath))
 	unlockOut, unlockErr := exec.CommandContext(ctx, "security", "unlock-keychain", "-p", password, keychainPath).CombinedOutput()
 	if unlockErr != nil {
-		unlockEv.Success = true
+		unlockEv = output.WithOutcome(unlockEv, module.OutcomeDenied, nil)
 		unlockEv.Message = fmt.Sprintf("keychain unlock denied for %s (expected without valid password)", keychainPath)
 		unlockEv = output.WithDetails(unlockEv, map[string]any{
 			"path":   keychainPath,
@@ -93,7 +93,7 @@ func (t *tccKeychain) Generate(ctx context.Context, params module.Params, emit m
 	dumpEv := output.NewEvent(info, "keychain_dump_attempt", false, fmt.Sprintf("probing keychain dump: %s", keychainPath))
 	dumpOut, dumpErr := exec.CommandContext(ctx, "security", "dump-keychain", keychainPath).CombinedOutput()
 	if dumpErr != nil {
-		dumpEv.Success = true
+		dumpEv = output.WithOutcome(dumpEv, module.OutcomeDenied, nil)
 		dumpEv.Message = fmt.Sprintf("keychain dump denied for %s (telemetry generated)", keychainPath)
 		dumpEv = output.WithDetails(dumpEv, map[string]any{
 			"path":   keychainPath,

--- a/modules/tcc/probe.go
+++ b/modules/tcc/probe.go
@@ -1,6 +1,10 @@
 package tcc
 
-import "os"
+import (
+	"os"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
 
 // probeOutcome is the result of attempting to reach a TCC-gated resource.
 type probeOutcome string
@@ -30,5 +34,25 @@ func classifyProbe(err error) probeOutcome {
 		return probeDenied
 	default:
 		return probeError
+	}
+}
+
+// eventOutcome lifts a probe result onto the telemetry event outcome, so the
+// distinction these probes work to establish survives into the schema instead
+// of living only in details["result"] where a generic consumer cannot see it.
+//
+// probeAbsent maps to indeterminate rather than denied for the same reason
+// classifyProbe separates them: no TCC decision was made, and calling it a
+// denial fabricates a privacy event.
+func eventOutcome(o probeOutcome) module.Outcome {
+	switch o {
+	case probeGranted:
+		return module.OutcomeExecuted
+	case probeDenied:
+		return module.OutcomeDenied
+	case probeAbsent:
+		return module.OutcomeIndeterminate
+	default:
+		return module.OutcomeError
 	}
 }

--- a/modules/tcc/probe_integration_test.go
+++ b/modules/tcc/probe_integration_test.go
@@ -54,6 +54,9 @@ func TestTCCFDA_MissingPathIsAbsentNotDenied(t *testing.T) {
 	if !ev.Success {
 		t.Error("Success = false, want true: an absent target is a valid observation")
 	}
+	if ev.Outcome != module.OutcomeIndeterminate {
+		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeIndeterminate)
+	}
 }
 
 func TestTCCFDA_UnreadableFileIsDenied(t *testing.T) {
@@ -72,6 +75,12 @@ func TestTCCFDA_UnreadableFileIsDenied(t *testing.T) {
 	ev := runProbe(t, &tccFDA{}, module.Params{"tcc_path": path})
 	if ev.Details["result"] != "denied" {
 		t.Errorf("result = %v, want denied", ev.Details["result"])
+	}
+	if ev.Outcome != module.OutcomeDenied {
+		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeDenied)
+	}
+	if !ev.Success {
+		t.Error("Success = false: a TCC denial is expected telemetry, not a macnoise failure")
 	}
 }
 
@@ -126,6 +135,9 @@ func TestTCCContacts_NoAddressBookIsAbsentNotDenied(t *testing.T) {
 	if !ev.Success {
 		t.Error("Success = false, want true: an absent target is a valid observation")
 	}
+	if ev.Outcome != module.OutcomeIndeterminate {
+		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeIndeterminate)
+	}
 }
 
 func TestTCCContacts_UnreadableDirIsDenied(t *testing.T) {
@@ -148,5 +160,8 @@ func TestTCCContacts_UnreadableDirIsDenied(t *testing.T) {
 	ev := runProbe(t, &tccContacts{}, module.Params{})
 	if ev.Details["result"] != "denied" {
 		t.Errorf("result = %v, want denied", ev.Details["result"])
+	}
+	if ev.Outcome != module.OutcomeDenied {
+		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeDenied)
 	}
 }

--- a/modules/tcc/probe_test.go
+++ b/modules/tcc/probe_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"io/fs"
 	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
 )
 
 // A missing resource must never be reported as a denial. Both probes used to
@@ -28,5 +30,26 @@ func TestClassifyProbe(t *testing.T) {
 				t.Errorf("classifyProbe(%v) = %q, want %q", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// The probe result has to reach the event schema, not just details["result"].
+// A consumer filtering on outcome should see a refusal as denied and a missing
+// resource as indeterminate, without knowing this module exists.
+func TestEventOutcome(t *testing.T) {
+	tests := []struct {
+		probe probeOutcome
+		want  module.Outcome
+	}{
+		{probeGranted, module.OutcomeExecuted},
+		{probeDenied, module.OutcomeDenied},
+		{probeAbsent, module.OutcomeIndeterminate},
+		{probeError, module.OutcomeError},
+	}
+
+	for _, tt := range tests {
+		if got := eventOutcome(tt.probe); got != tt.want {
+			t.Errorf("eventOutcome(%q) = %q, want %q", tt.probe, got, tt.want)
+		}
 	}
 }

--- a/modules/xpc/enumerate.go
+++ b/modules/xpc/enumerate.go
@@ -97,8 +97,8 @@ func (x *xpcEnumerate) enumerateDomain(ctx context.Context, domain, filter strin
 
 	out, err := exec.CommandContext(ctx, "launchctl", "print", domain).CombinedOutput()
 	if err != nil {
-		ev = output.WithError(ev, fmt.Errorf("launchctl print %s: %v: %s", domain, err, out))
-		ev.Success = true
+		ev = output.WithOutcome(ev, module.OutcomeDenied,
+			fmt.Errorf("launchctl print %s: %v: %s", domain, err, out))
 		ev.Message = fmt.Sprintf("could not enumerate domain %s", domain)
 		details["accessible"] = false
 		emit(output.WithDetails(ev, details))

--- a/pkg/module/interface.go
+++ b/pkg/module/interface.go
@@ -66,19 +66,58 @@ type ProcessContext struct {
 	Username   string `json:"username"`
 }
 
+// Outcome describes what happened to the action a module attempted, which is a
+// different question from whether macnoise itself worked. A TCC probe that is
+// refused is expected, valid telemetry rather than a fault, and recording it
+// the same way as a broken tool leaves a consumer no way to tell the two apart
+// short of parsing the message text.
+type Outcome string
+
+// Outcome values. Everything except OutcomeError describes a working macnoise.
+const (
+	// OutcomeExecuted means the action ran and did what the module claims.
+	OutcomeExecuted Outcome = "executed"
+	// OutcomeDenied means the action ran and the environment refused it.
+	OutcomeDenied Outcome = "denied"
+	// OutcomeIndeterminate means the action ran but no conclusion can be
+	// drawn from it: the target was absent, or the technique leaves no
+	// evidence either way.
+	OutcomeIndeterminate Outcome = "indeterminate"
+	// OutcomeError means macnoise itself failed to carry the action out.
+	OutcomeError Outcome = "error"
+)
+
 // TelemetryEvent is the structured record emitted by a module for each action it performs.
 type TelemetryEvent struct {
-	SchemaVersion  string         `json:"schema_version"`
-	Timestamp      time.Time      `json:"timestamp"`
-	Module         string         `json:"module"`
-	Category       string         `json:"category"`
-	EventType      string         `json:"event_type"`
-	Success        bool           `json:"success"`
+	SchemaVersion string    `json:"schema_version"`
+	Timestamp     time.Time `json:"timestamp"`
+	Module        string    `json:"module"`
+	Category      string    `json:"category"`
+	EventType     string    `json:"event_type"`
+	Success       bool      `json:"success"`
+	// Outcome is left empty by NewEvent and set only by modules that need to
+	// say something Success cannot express. It is resolved to a concrete value
+	// at the output boundary, so emitted records always carry one.
+	Outcome        Outcome        `json:"outcome"`
 	Message        string         `json:"message"`
 	Details        map[string]any `json:"details,omitempty"`
 	Error          string         `json:"error,omitempty"`
 	MITRE          []MITRE        `json:"mitre,omitempty"`
 	ProcessContext ProcessContext `json:"process_context"`
+}
+
+// ResolvedOutcome returns ev.Outcome, falling back to Success for the majority
+// of events that never set one. It is the single definition of how the two
+// fields relate, so an outcome-aware consumer and a Success-only consumer can
+// never read the same event differently.
+func (ev TelemetryEvent) ResolvedOutcome() Outcome {
+	if ev.Outcome != "" {
+		return ev.Outcome
+	}
+	if ev.Success {
+		return OutcomeExecuted
+	}
+	return OutcomeError
 }
 
 // EventEmitter is a callback that receives a telemetry event from a module.


### PR DESCRIPTION
Adds `outcome` (`executed`/`denied`/`indeterminate`/`error`) to the telemetry schema, bumping it to 1.1. `success` says whether macnoise worked; `outcome` says what happened to the action it attempted, so a TCC denial or a beacon to a dead C2 is no longer indistinguishable from a broken module except by reading the message text.

Modules set no outcome by default - it resolves from `success` at the output boundary the way `Timestamp` already does, keeping the change to the sites whose semantics were actually in question. Audit records now derive OCSF status from the outcome, which fixes a probe hitting a real I/O error being written as `status: Success` and stops routine denials logging at Medium severity.