### PR TITLE
feat: add es_mount to emulate .dmg delivery

### DIFF
--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -152,7 +152,13 @@ func endpointSecurityActivity(eventType string) Classification {
 		return Classification{1001, "File System Activity", 1, "System Activity", 3, "Update"}
 	case "es_notify_unlink":
 		return Classification{1001, "File System Activity", 1, "System Activity", 4, "Delete"}
-	case "es_exec_chain":
+	case "es_dmg_create":
+		return Classification{1001, "File System Activity", 1, "System Activity", 1, "Create"}
+	case "es_notify_mount":
+		return Classification{1001, "File System Activity", 1, "System Activity", 12, "Mount"}
+	case "es_notify_unmount":
+		return Classification{1001, "File System Activity", 1, "System Activity", 13, "Unmount"}
+	case "es_exec_chain", "es_volume_exec":
 		return Classification{1007, "Process Activity", 1, "System Activity", 1, "Launch"}
 	}
 	return Classification{6003, "API Activity", 6, "Application Activity", 99, "Other"}

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -73,6 +73,10 @@ func TestClassify(t *testing.T) {
 		{"endpoint_security", "es_notify_create", 1001, 1},
 		{"endpoint_security", "es_notify_write", 1001, 3},
 		{"endpoint_security", "es_notify_unlink", 1001, 4},
+		{"endpoint_security", "es_dmg_create", 1001, 1},
+		{"endpoint_security", "es_notify_mount", 1001, 12},
+		{"endpoint_security", "es_notify_unmount", 1001, 13},
+		{"endpoint_security", "es_volume_exec", 1007, 1},
 
 		// unmapped category/event falls back to API Activity/Other
 		{"unknown_category", "unknown_event", 6003, 99},

--- a/modules/endpoint_security/README.md
+++ b/modules/endpoint_security/README.md
@@ -9,3 +9,8 @@ Creates, writes, and deletes a file (triggers ES_EVENT_TYPE_NOTIFY_CREATE/WRITE/
 
 ### `es_process`
 Executes nested process chain (triggers ES_EVENT_TYPE_NOTIFY_EXEC/FORK/EXIT). Maps to T1059.004.
+
+### `es_mount`
+Builds a disk image, mounts it, executes a payload from the mounted volume, then unmounts (triggers ES_EVENT_TYPE_NOTIFY_MOUNT/EXEC/UNMOUNT). Maps to T1204.002.
+
+Emulates the `.dmg` delivery vector the AMOS scenario lists as upstream of itself. The execution step is the point: a bare mount is weak signal, while a process launched from a `/Volumes` path is what fake-installer delivery looks like on a real endpoint. The mount point is read back from `hdiutil` rather than assumed, since macOS appends a suffix when a volume of the same name is already mounted.

--- a/modules/endpoint_security/es_mount.go
+++ b/modules/endpoint_security/es_mount.go
@@ -1,0 +1,258 @@
+package endpointsecurity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// volumeName is the label the disk image mounts under. macOS appends a suffix
+// when a volume of the same name is already mounted, which is why the real
+// mount point is read back from hdiutil rather than assumed to be
+// /Volumes/<volumeName>.
+const volumeName = "MacNoiseDelivery"
+
+// payloadName is the file executed from inside the mounted volume. AMOS-style
+// delivery ships a bash wrapper alongside a hidden Mach-O; the wrapper is the
+// half that matters here, because the detection signal is a process launched
+// from a mounted image rather than what that process goes on to do.
+const payloadName = "install.sh"
+
+type esMount struct {
+	dmgPath    string
+	mountPoint string
+	device     string
+}
+
+func (e *esMount) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "es_mount",
+		Description: "Mounts a disk image and executes a payload from it, triggering ES_EVENT_TYPE_NOTIFY_MOUNT/EXEC/UNMOUNT",
+		Category:    module.CategoryEndpointSecurity,
+		Tags:        []string{"endpoint-security", "mount", "dmg", "disk-image", "delivery"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			{Technique: "T1204", SubTech: ".002", Name: "User Execution: Malicious File"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "10.15",
+	}
+}
+
+func (e *esMount) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{Name: "work_dir", Description: "Directory to build the disk image in", Required: false, DefaultValue: "/tmp/macnoise_es", Example: "/var/tmp/es_test"},
+	}
+}
+
+func (e *esMount) CheckPrereqs() error { return nil }
+
+// attachResult is what hdiutil attach reports back about the image it mounted.
+type attachResult struct {
+	Device     string
+	MountPoint string
+}
+
+// parseAttachOutput reads the device node and mount point out of hdiutil
+// attach's output, which is tab-separated with a variable number of lines
+// depending on the image's partition scheme:
+//
+//	/dev/disk4          \tGUID_partition_scheme\t
+//	/dev/disk4s1        \tApple_HFS            \t/Volumes/MacNoiseDelivery
+//
+// Splitting on whitespace rather than tabs would truncate any mount point
+// containing a space, so the fields are split on tab only. The device returned
+// is the whole-disk node from the first line, since that is what detaches the
+// image as a whole rather than one of its slices.
+func parseAttachOutput(out string) attachResult {
+	var res attachResult
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Split(strings.TrimRight(line, "\r"), "\t")
+		for i := range fields {
+			fields[i] = strings.TrimSpace(fields[i])
+		}
+		if len(fields) == 0 || fields[0] == "" {
+			continue
+		}
+		if res.Device == "" && strings.HasPrefix(fields[0], "/dev/") {
+			res.Device = fields[0]
+		}
+		if last := fields[len(fields)-1]; res.MountPoint == "" && strings.HasPrefix(last, "/") && !strings.HasPrefix(last, "/dev/") {
+			res.MountPoint = last
+		}
+	}
+	return res
+}
+
+// The argv builders are shared by Generate and DryRun so the advertised
+// commands cannot drift from the executed ones.
+
+func createArgs(dmgPath string) []string {
+	return []string{"create", "-size", "10m", "-fs", "HFS+", "-volname", volumeName, "-ov", dmgPath}
+}
+
+func attachArgs(dmgPath string) []string {
+	return []string{"attach", dmgPath}
+}
+
+func detachArgs(target string) []string {
+	return []string{"detach", target, "-force"}
+}
+
+func (e *esMount) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	workDir := params.Get("work_dir", "/tmp/macnoise_es")
+	info := e.Info()
+
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", workDir, err)
+	}
+	dmgPath := path.Join(workDir, "macnoise_delivery.dmg")
+
+	createEv := output.NewEvent(info, "es_dmg_create", false, fmt.Sprintf("building disk image %s", dmgPath))
+	if out, err := exec.CommandContext(ctx, "hdiutil", createArgs(dmgPath)...).CombinedOutput(); err != nil {
+		createEv = output.WithError(createEv, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out))))
+		emit(createEv)
+		return fmt.Errorf("es_mount: hdiutil create: %w", err)
+	}
+	e.dmgPath = dmgPath
+	createEv.Success = true
+	createEv.Message = fmt.Sprintf("built disk image %s", dmgPath)
+	emit(output.WithDetails(createEv, map[string]any{"path": dmgPath, "volume_name": volumeName}))
+
+	mountEv := output.NewEvent(info, "es_notify_mount", false, fmt.Sprintf("mounting %s (triggers ES_EVENT_TYPE_NOTIFY_MOUNT)", dmgPath))
+	attachOut, err := exec.CommandContext(ctx, "hdiutil", attachArgs(dmgPath)...).CombinedOutput()
+	if err != nil {
+		mountEv = output.WithError(mountEv, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(attachOut))))
+		emit(mountEv)
+		return fmt.Errorf("es_mount: hdiutil attach: %w", err)
+	}
+	res := parseAttachOutput(string(attachOut))
+	e.device, e.mountPoint = res.Device, res.MountPoint
+
+	mountDetails := map[string]any{
+		"path":        dmgPath,
+		"device":      res.Device,
+		"mount_point": res.MountPoint,
+		"es_event":    "ES_EVENT_TYPE_NOTIFY_MOUNT",
+	}
+	if res.MountPoint == "" {
+		// hdiutil succeeded but nothing is mounted, so there is no volume to
+		// execute from and no mount point to report. Claiming a MOUNT event
+		// here would be asserting telemetry that was never produced.
+		mountEv.Message = fmt.Sprintf("attached %s but no volume was mounted", dmgPath)
+		mountEv = output.WithOutcome(mountEv, module.OutcomeIndeterminate, nil)
+		emit(output.WithDetails(mountEv, mountDetails))
+		return nil
+	}
+	mountEv.Success = true
+	mountEv.Message = fmt.Sprintf("mounted %s at %s (ES_EVENT_TYPE_NOTIFY_MOUNT)", dmgPath, res.MountPoint)
+	emit(output.WithDetails(mountEv, mountDetails))
+
+	e.emitVolumeExec(ctx, info, emit)
+
+	unmountEv := output.NewEvent(info, "es_notify_unmount", false, fmt.Sprintf("unmounting %s (triggers ES_EVENT_TYPE_NOTIFY_UNMOUNT)", res.MountPoint))
+	if out, err := exec.CommandContext(ctx, "hdiutil", detachArgs(res.MountPoint)...).CombinedOutput(); err != nil {
+		unmountEv = output.WithError(unmountEv, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out))))
+		emit(unmountEv)
+		return nil
+	}
+	e.mountPoint, e.device = "", ""
+	unmountEv.Success = true
+	unmountEv.Message = fmt.Sprintf("unmounted %s (ES_EVENT_TYPE_NOTIFY_UNMOUNT)", res.MountPoint)
+	emit(output.WithDetails(unmountEv, map[string]any{
+		"mount_point": res.MountPoint,
+		"es_event":    "ES_EVENT_TYPE_NOTIFY_UNMOUNT",
+	}))
+
+	return nil
+}
+
+// emitVolumeExec writes a payload into the mounted volume and runs it. This is
+// the half that makes T1204.002 accurate: a bare mount is weak signal, while a
+// process launched from a /Volumes path is what AMOS-style delivery actually
+// looks like on an endpoint.
+func (e *esMount) emitVolumeExec(ctx context.Context, info module.ModuleInfo, emit module.EventEmitter) {
+	payload := path.Join(e.mountPoint, payloadName)
+	ev := output.NewEvent(info, "es_volume_exec", false, fmt.Sprintf("executing %s (triggers ES_EVENT_TYPE_NOTIFY_EXEC)", payload))
+	details := map[string]any{"payload": payload, "mount_point": e.mountPoint, "es_event": "ES_EVENT_TYPE_NOTIFY_EXEC"}
+
+	script := "#!/bin/sh\necho macnoise_dmg_payload\n"
+	if err := os.WriteFile(payload, []byte(script), 0o755); err != nil {
+		ev = output.WithError(ev, err)
+		emit(output.WithDetails(ev, details))
+		return
+	}
+
+	out, err := exec.CommandContext(ctx, payload).CombinedOutput()
+	if err != nil {
+		// A disk image mounted noexec refuses the launch. That is the volume
+		// declining, not macnoise breaking, and it is worth reporting plainly
+		// because it means no EXEC event was generated to detect on.
+		ev.Message = fmt.Sprintf("%s could not be executed from the mounted volume", payload)
+		ev = output.WithOutcome(ev, module.OutcomeDenied, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out))))
+		emit(output.WithDetails(ev, details))
+		return
+	}
+
+	ev.Success = true
+	ev.Message = fmt.Sprintf("executed %s from mounted volume (ES_EVENT_TYPE_NOTIFY_EXEC)", payload)
+	details["stdout"] = strings.TrimSpace(string(out))
+	emit(output.WithDetails(ev, details))
+}
+
+func (e *esMount) DryRun(params module.Params) []string {
+	workDir := params.Get("work_dir", "/tmp/macnoise_es")
+	dmgPath := path.Join(workDir, "macnoise_delivery.dmg")
+	mountPoint := path.Join("/Volumes", volumeName)
+	return []string{
+		fmt.Sprintf("hdiutil %s", strings.Join(createArgs(dmgPath), " ")),
+		fmt.Sprintf("hdiutil %s → ES_EVENT_TYPE_NOTIFY_MOUNT", strings.Join(attachArgs(dmgPath), " ")),
+		fmt.Sprintf("execute %s → ES_EVENT_TYPE_NOTIFY_EXEC", path.Join(mountPoint, payloadName)),
+		fmt.Sprintf("hdiutil %s → ES_EVENT_TYPE_NOTIFY_UNMOUNT", strings.Join(detachArgs(mountPoint), " ")),
+	}
+}
+
+// Cleanup detaches the image only if Generate actually mounted one, so a run
+// that never got that far does not report a detach failure for a volume that
+// was never there.
+func (e *esMount) Cleanup() error {
+	var errs []error
+
+	if target := e.detachTarget(); target != "" {
+		if out, err := exec.Command("hdiutil", detachArgs(target)...).CombinedOutput(); err != nil {
+			errs = append(errs, fmt.Errorf("detach %s: %v: %s", target, err, strings.TrimSpace(string(out))))
+		} else {
+			e.mountPoint, e.device = "", ""
+		}
+	}
+
+	if e.dmgPath != "" {
+		if err := os.Remove(e.dmgPath); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("remove %s: %w", e.dmgPath, err))
+		} else {
+			e.dmgPath = ""
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// detachTarget prefers the mount point, falling back to the device node for an
+// image that attached without mounting a volume.
+func (e *esMount) detachTarget() string {
+	if e.mountPoint != "" {
+		return e.mountPoint
+	}
+	return e.device
+}
+
+func init() {
+	module.Register(&esMount{})
+}

--- a/modules/endpoint_security/es_mount_integration_test.go
+++ b/modules/endpoint_security/es_mount_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration && darwin
+
+package endpointsecurity
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func runMount(t *testing.T, e *esMount, workDir string) []module.TelemetryEvent {
+	t.Helper()
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	// Registered before Generate so a panic or an assertion failure part-way
+	// through still detaches the image, rather than leaving a mounted volume
+	// behind for every subsequent run on the same machine.
+	t.Cleanup(func() { _ = e.Cleanup() })
+
+	if err := e.Generate(context.Background(), module.Params{"work_dir": workDir}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	return events
+}
+
+func TestESMount_GenerateEmitsFullMountExecUnmountCycle(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "es")
+	events := runMount(t, &esMount{}, workDir)
+
+	want := []string{"es_dmg_create", "es_notify_mount", "es_volume_exec", "es_notify_unmount"}
+	if len(events) != len(want) {
+		t.Fatalf("expected %d events, got %d", len(want), len(events))
+	}
+	for i, evType := range want {
+		if events[i].EventType != evType {
+			t.Fatalf("event[%d] = %q, want %q", i, events[i].EventType, evType)
+		}
+		if !events[i].Success {
+			t.Errorf("event %q did not succeed: %s", evType, events[i].Error)
+		}
+	}
+}
+
+// The mount point has to be read back from hdiutil, not assumed. A machine that
+// already has a MacNoiseDelivery volume mounted gets "/Volumes/MacNoiseDelivery 1"
+// instead, and every later step would target the wrong path.
+func TestESMount_ReportsRealMountPoint(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "es")
+	events := runMount(t, &esMount{}, workDir)
+
+	mountEv := events[1]
+	mountPoint, _ := mountEv.Details["mount_point"].(string)
+	if !strings.HasPrefix(mountPoint, "/Volumes/") {
+		t.Fatalf("mount_point = %q, want a path under /Volumes", mountPoint)
+	}
+	if device, _ := mountEv.Details["device"].(string); !strings.HasPrefix(device, "/dev/disk") {
+		t.Errorf("device = %q, want a /dev/disk node", device)
+	}
+}
+
+// The payload must actually run from the mounted volume. If the image were
+// mounted noexec this reports denied instead, which is a real result but not
+// the telemetry the module claims to generate.
+func TestESMount_PayloadExecutesFromVolume(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "es")
+	events := runMount(t, &esMount{}, workDir)
+
+	execEv := events[2]
+	if execEv.Outcome == module.OutcomeDenied {
+		t.Fatalf("volume refused execution, no EXEC event was generated: %s", execEv.Error)
+	}
+	if got, _ := execEv.Details["stdout"].(string); got != "macnoise_dmg_payload" {
+		t.Errorf("payload stdout = %q, want %q", got, "macnoise_dmg_payload")
+	}
+	payload, _ := execEv.Details["payload"].(string)
+	if !strings.HasPrefix(payload, "/Volumes/") {
+		t.Errorf("payload = %q, want it executed from the mounted volume", payload)
+	}
+}
+
+// Generate detaches as part of the telemetry cycle, so nothing should still be
+// mounted even before Cleanup runs.
+func TestESMount_GenerateLeavesNothingMounted(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "es")
+	events := runMount(t, &esMount{}, workDir)
+
+	mountPoint, _ := events[1].Details["mount_point"].(string)
+	if _, err := os.Stat(mountPoint); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be unmounted by Generate, stat err = %v", mountPoint, err)
+	}
+
+	out, err := exec.Command("hdiutil", "info").CombinedOutput()
+	if err != nil {
+		t.Fatalf("hdiutil info: %v", err)
+	}
+	if strings.Contains(string(out), "macnoise_delivery.dmg") {
+		t.Errorf("disk image still attached after Generate:\n%s", out)
+	}
+}
+
+func TestESMount_CleanupRemovesTheDiskImage(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "es")
+	e := &esMount{}
+	runMount(t, e, workDir)
+
+	dmgPath := filepath.Join(workDir, "macnoise_delivery.dmg")
+	if _, err := os.Stat(dmgPath); err != nil {
+		t.Fatalf("expected %s to exist before Cleanup: %v", dmgPath, err)
+	}
+	if err := e.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(dmgPath); !os.IsNotExist(err) {
+		t.Errorf("Cleanup left %s in place, stat err = %v", dmgPath, err)
+	}
+}

--- a/modules/endpoint_security/es_mount_test.go
+++ b/modules/endpoint_security/es_mount_test.go
@@ -1,0 +1,123 @@
+package endpointsecurity
+
+import (
+	"strings"
+	"testing"
+)
+
+// hdiutil attach output is tab-separated with a variable number of lines and a
+// trailing empty column on the lines that mount nothing. The xpc parser shipped
+// broken for exactly this shape of input by assuming a fixed column, so each
+// real layout gets a case here.
+func TestParseAttachOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		out        string
+		device     string
+		mountPoint string
+	}{
+		{
+			name:       "guid scheme with one mounted slice",
+			out:        "/dev/disk4          \tGUID_partition_scheme          \t\n/dev/disk4s1        \tApple_HFS                      \t/Volumes/MacNoiseDelivery\n",
+			device:     "/dev/disk4",
+			mountPoint: "/Volumes/MacNoiseDelivery",
+		},
+		{
+			name:       "apple partition scheme with three lines",
+			out:        "/dev/disk6          \tApple_partition_scheme         \t\n/dev/disk6s1        \tApple_partition_map            \t\n/dev/disk6s2        \tApple_HFS                      \t/Volumes/MacNoiseDelivery\n",
+			device:     "/dev/disk6",
+			mountPoint: "/Volumes/MacNoiseDelivery",
+		},
+		{
+			// Splitting on whitespace instead of tab truncates this to
+			// "/Volumes/MacNoise", which would then fail to detach.
+			name:       "mount point containing a space is not truncated",
+			out:        "/dev/disk4          \tGUID_partition_scheme          \t\n/dev/disk4s1        \tApple_HFS                      \t/Volumes/MacNoise Delivery 1\n",
+			device:     "/dev/disk4",
+			mountPoint: "/Volumes/MacNoise Delivery 1",
+		},
+		{
+			name:       "attached with no filesystem mounted",
+			out:        "/dev/disk4          \tGUID_partition_scheme          \t\n",
+			device:     "/dev/disk4",
+			mountPoint: "",
+		},
+		{
+			name:       "empty output yields nothing",
+			out:        "",
+			device:     "",
+			mountPoint: "",
+		},
+		{
+			name:       "carriage returns are stripped",
+			out:        "/dev/disk4          \tGUID_partition_scheme          \t\r\n/dev/disk4s1        \tApple_HFS                      \t/Volumes/MacNoiseDelivery\r\n",
+			device:     "/dev/disk4",
+			mountPoint: "/Volumes/MacNoiseDelivery",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAttachOutput(tt.out)
+			if got.Device != tt.device {
+				t.Errorf("device = %q, want %q", got.Device, tt.device)
+			}
+			if got.MountPoint != tt.mountPoint {
+				t.Errorf("mount point = %q, want %q", got.MountPoint, tt.mountPoint)
+			}
+		})
+	}
+}
+
+// The device must be the whole-disk node. Detaching a slice leaves the image
+// attached, so a parser that returned /dev/disk4s1 would leak a mounted volume
+// on every run.
+func TestParseAttachOutputReturnsWholeDiskNode(t *testing.T) {
+	out := "/dev/disk4          \tGUID_partition_scheme          \t\n/dev/disk4s1        \tApple_HFS                      \t/Volumes/MacNoiseDelivery\n"
+
+	if got := parseAttachOutput(out).Device; got != "/dev/disk4" {
+		t.Errorf("device = %q, want the whole-disk node /dev/disk4", got)
+	}
+}
+
+// DryRun must render the commands the module actually runs. The launchctl
+// modules drifted here because the two were built independently.
+func TestDryRunMatchesExecutedArgv(t *testing.T) {
+	lines := (&esMount{}).DryRun(nil)
+	joined := strings.Join(lines, "\n")
+
+	dmgPath := "/tmp/macnoise_es/macnoise_delivery.dmg"
+	for _, want := range []string{
+		"hdiutil " + strings.Join(createArgs(dmgPath), " "),
+		"hdiutil " + strings.Join(attachArgs(dmgPath), " "),
+		"hdiutil " + strings.Join(detachArgs("/Volumes/"+volumeName), " "),
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("dry run does not advertise %q\ngot:\n%s", want, joined)
+		}
+	}
+}
+
+// Cleanup must not shell out for an image that was never mounted, or a run that
+// failed before attaching reports a detach error for a volume that never
+// existed.
+func TestCleanupIsNoOpWhenNothingWasMounted(t *testing.T) {
+	if target := (&esMount{}).detachTarget(); target != "" {
+		t.Errorf("detach target = %q, want empty when nothing was mounted", target)
+	}
+	if err := (&esMount{}).Cleanup(); err != nil {
+		t.Errorf("Cleanup on an untouched module returned %v", err)
+	}
+}
+
+func TestDetachTargetPrefersMountPoint(t *testing.T) {
+	e := &esMount{device: "/dev/disk4", mountPoint: "/Volumes/MacNoiseDelivery"}
+	if got := e.detachTarget(); got != "/Volumes/MacNoiseDelivery" {
+		t.Errorf("detach target = %q, want the mount point", got)
+	}
+
+	e = &esMount{device: "/dev/disk4"}
+	if got := e.detachTarget(); got != "/dev/disk4" {
+		t.Errorf("detach target = %q, want the device node as fallback", got)
+	}
+}


### PR DESCRIPTION
Adds `es_mount`, which builds a disk image, mounts it, executes a payload from the mounted volume, then unmounts - producing `ES_EVENT_TYPE_NOTIFY_MOUNT`/`EXEC`/`UNMOUNT`. Closes the `.dmg` delivery vector the AMOS scenario lists as upstream of itself and does not emulate.

The execution step is what makes the T1204.002 mapping accurate: a bare mount is weak signal, while a process launched from a `/Volumes` path is what fake-installer delivery looks like on a real endpoint. T1553.005 was the obvious mapping and is wrong - it is Windows-only and names `.iso`/`.vhd`, never `.dmg`.

Verified end to end on a real Mac (macOS 26.5.2, SIP enabled), not just CI: all four events emitted, OCSF 1001/12 Mount and 1001/13 Unmount, nothing left attached and no image left on disk.