### PR TITLE
feat: add svc_login_item for Login Items / BTM persistence

### DIFF
--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -123,7 +123,7 @@ func fileActivity(eventType string) (int, string) {
 
 func serviceActivity(eventType string) (int, string) {
 	switch eventType {
-	case "cron_job_create", "launchagent_create", "launchdaemon_create":
+	case "cron_job_create", "launchagent_create", "launchdaemon_create", "login_item_add":
 		return 1, "Create"
 	case "shell_profile_modify":
 		return 2, "Update"

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -58,6 +58,7 @@ func TestClassify(t *testing.T) {
 		{"service", "launchagent_load", 1006, 6},
 		{"service", "launchdaemon_create", 1006, 1},
 		{"service", "launchdaemon_load", 1006, 6},
+		{"service", "login_item_add", 1006, 1},
 		{"service", "shell_profile_modify", 1006, 2},
 
 		// tcc / xpc

--- a/modules/service/README.md
+++ b/modules/service/README.md
@@ -12,6 +12,18 @@ Creates a LaunchDaemon plist and registers it with `launchctl bootstrap system` 
 
 Both use `bootstrap`/`bootout` rather than the legacy `load`/`unload`, since detection content increasingly keys on the modern subcommands. Bootstrapping a LaunchAgent needs a GUI session, so it fails on a headless host; that failure is reported as telemetry rather than a module error, and cleanup only attempts a bootout when the bootstrap actually succeeded.
 
+### `svc_login_item`
+Adds a Login Item via `osascript` driving System Events (`make login item`), the shared-file-list route T1547.015 names for scripting languages. On macOS 13+ this registers through Background Task Management and triggers `ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD` - the dominant modern persistence surface, which no other module covers. Maps to T1547.015. Cleanup deletes the item by name, and only when Generate actually added one.
+
+Adding a login item needs a GUI (Aqua) session plus Automation consent to control System Events. The module distinguishes the outcomes it cannot control from a real fault: no GUI session reports `indeterminate`, a refused Automation grant reports `denied`, and only a genuine failure reports `error`. Over ssh or on a headless runner it will report `indeterminate` rather than failing.
+
+```bash
+macnoise run svc_login_item
+macnoise run svc_login_item --param name=com.corp.helper --param path=/Applications/Helper.app
+```
+
+`SMAppService` (the other route T1547.015 names) is deliberately not used: it requires a signed app bundle registering itself, which a standalone binary cannot do. The System Events route produces the same BTM event without one.
+
 ### `svc_cron`
 Lists the current crontab, then appends a clearly-marked entry (`# macnoise`). Emits `cron_job_list` and `cron_job_create` events. Maps to T1053.003. Cleanup filters the added entry back out of the crontab.
 

--- a/modules/service/login_item.go
+++ b/modules/service/login_item.go
@@ -1,0 +1,197 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+type svcLoginItem struct {
+	name  string
+	added bool
+}
+
+func (s *svcLoginItem) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "svc_login_item",
+		Description: "Adds a Login Item via System Events, triggering ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD",
+		Category:    module.CategoryService,
+		Tags:        []string{"login-item", "persistence", "btm", "osascript", "backgroundtaskmanagement"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			{Technique: "T1547", SubTech: ".015", Name: "Boot or Logon Autostart Execution: Login Items"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "13.0",
+	}
+}
+
+func (s *svcLoginItem) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{Name: "name", Description: "Login item name", Required: false, DefaultValue: "MacNoiseLoginItem", Example: "com.corp.helper"},
+		{Name: "path", Description: "POSIX path the login item points at", Required: false, DefaultValue: "/usr/bin/true", Example: "/Applications/Evil.app"},
+	}
+}
+
+func (s *svcLoginItem) CheckPrereqs() error { return nil }
+
+// The AppleScript builders are shared by Generate, Cleanup, and DryRun so the
+// advertised commands cannot drift from the executed ones.
+
+func makeLoginItemScript(name, path string) string {
+	return fmt.Sprintf(
+		`tell application "System Events" to make login item at end with properties {name:%s, path:%s, hidden:false}`,
+		appleScriptString(name), appleScriptString(path))
+}
+
+func listLoginItemsScript() string {
+	return `tell application "System Events" to get the name of every login item`
+}
+
+func deleteLoginItemScript(name string) string {
+	return fmt.Sprintf(
+		`tell application "System Events" to delete (every login item whose name is %s)`,
+		appleScriptString(name))
+}
+
+// appleScriptString renders a Go string as an AppleScript string literal,
+// escaping backslashes and quotes. Without this a name or path containing a
+// quote would break out of the literal and change the statement, the same
+// class of bug the es_process quoting fix addressed.
+func appleScriptString(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+	return `"` + r.Replace(s) + `"`
+}
+
+// loginItemOutcome classifies an osascript run into an event outcome, so a host
+// that refused or could not attempt the add is not reported as a broken tool.
+//
+// The osascript exit code alone cannot carry this: it exits non-zero for a TCC
+// refusal, a missing GUI session, and a real macnoise fault alike. The error
+// numbers System Events returns are the discriminator:
+//
+//   - -1743: the user has not granted Automation control of System Events, so
+//     the add was refused. That refusal is a real BTM-adjacent security event.
+//   - -10810: System Events could not be launched, which happens when there is
+//     no GUI (Aqua) session, e.g. over ssh. Nothing was attempted, so the
+//     outcome is indeterminate rather than a denial.
+//   - no error: the item was added.
+func loginItemOutcome(err error, combinedOutput string) module.Outcome {
+	if err == nil {
+		return module.OutcomeExecuted
+	}
+	switch {
+	case strings.Contains(combinedOutput, "-1743"), strings.Contains(combinedOutput, "Not authorized"):
+		return module.OutcomeDenied
+	case strings.Contains(combinedOutput, "-10810"):
+		return module.OutcomeIndeterminate
+	default:
+		return module.OutcomeError
+	}
+}
+
+// parseLoginItemNames splits the comma-separated list AppleScript returns for
+// "name of every login item" into individual names. AppleScript joins list
+// elements with ", ", so a name containing a comma cannot be recovered from
+// this output; that only affects the post-add verification, not the add
+// itself.
+func parseLoginItemNames(out string) []string {
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil
+	}
+	parts := strings.Split(out, ",")
+	names := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			names = append(names, p)
+		}
+	}
+	return names
+}
+
+func (s *svcLoginItem) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	name := params.Get("name", "MacNoiseLoginItem")
+	targetPath := params.Get("path", "/usr/bin/true")
+	info := s.Info()
+	s.name = name
+
+	ev := output.NewEvent(info, "login_item_add", false,
+		fmt.Sprintf("adding login item %q -> %s (triggers ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD)", name, targetPath))
+	details := map[string]any{
+		"name":     name,
+		"path":     targetPath,
+		"es_event": "ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD",
+		"method":   "osascript System Events make login item",
+	}
+
+	out, err := runOsascript(ctx, makeLoginItemScript(name, targetPath))
+	outcome := loginItemOutcome(err, out)
+	details["result"] = string(outcome)
+
+	switch outcome {
+	case module.OutcomeExecuted:
+		s.added = true
+		ev.Message = fmt.Sprintf("added login item %q -> %s (ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD)", name, targetPath)
+		if present, listErr := s.loginItemPresent(ctx, name); listErr == nil {
+			details["verified_present"] = present
+		}
+	case module.OutcomeDenied:
+		ev.Message = fmt.Sprintf("login item add refused for %q: Automation control of System Events not granted", name)
+	case module.OutcomeIndeterminate:
+		ev.Message = fmt.Sprintf("login item add could not be attempted for %q: no GUI session to run System Events", name)
+	default:
+		ev.Message = fmt.Sprintf("login item add failed for %q", name)
+	}
+
+	ev = output.WithOutcome(ev, outcome, err)
+	emit(output.WithDetails(ev, details))
+	return nil
+}
+
+// loginItemPresent verifies the add landed rather than trusting osascript's
+// exit code, the same way es_mount reads its mount point back from hdiutil.
+func (s *svcLoginItem) loginItemPresent(ctx context.Context, name string) (bool, error) {
+	out, err := runOsascript(ctx, listLoginItemsScript())
+	if err != nil {
+		return false, err
+	}
+	return slices.Contains(parseLoginItemNames(out), name), nil
+}
+
+func runOsascript(ctx context.Context, script string) (string, error) {
+	out, err := exec.CommandContext(ctx, "osascript", "-e", script).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func (s *svcLoginItem) DryRun(params module.Params) []string {
+	name := params.Get("name", "MacNoiseLoginItem")
+	targetPath := params.Get("path", "/usr/bin/true")
+	return []string{
+		fmt.Sprintf("osascript -e '%s' -> ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD", makeLoginItemScript(name, targetPath)),
+		fmt.Sprintf("osascript -e '%s'", deleteLoginItemScript(name)),
+	}
+}
+
+// Cleanup removes the login item only if Generate actually added one. A run
+// that was refused or could not reach a GUI session added nothing, so issuing
+// the delete would report a failure for an item that never existed.
+func (s *svcLoginItem) Cleanup() error {
+	if !s.added || s.name == "" {
+		return nil
+	}
+	if out, err := exec.Command("osascript", "-e", deleteLoginItemScript(s.name)).CombinedOutput(); err != nil {
+		return fmt.Errorf("delete login item %q: %v: %s", s.name, err, strings.TrimSpace(string(out)))
+	}
+	s.added = false
+	return nil
+}
+
+func init() {
+	module.Register(&svcLoginItem{})
+}

--- a/modules/service/login_item_integration_test.go
+++ b/modules/service/login_item_integration_test.go
@@ -1,0 +1,86 @@
+//go:build integration && darwin
+
+package service
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func runLoginItem(t *testing.T, e *svcLoginItem, params module.Params) module.TelemetryEvent {
+	t.Helper()
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	t.Cleanup(func() { _ = e.Cleanup() })
+
+	if err := e.Generate(context.Background(), params, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	return events[0]
+}
+
+// Adding a login item drives System Events, which needs a GUI (Aqua) session
+// and Automation consent that neither the ssh path to the test box nor a
+// headless CI runner is guaranteed to have. The contract that must hold
+// everywhere is that the module never reports a broken tool for an environment
+// that merely refused or could not be reached: the outcome is one of the four
+// known values, and Success tracks it.
+func TestLoginItem_ClassifiesEnvironmentWithoutFailing(t *testing.T) {
+	ev := runLoginItem(t, &svcLoginItem{}, module.Params{"name": "MacNoiseLoginItemTest"})
+
+	if ev.EventType != "login_item_add" {
+		t.Errorf("event type = %q, want login_item_add", ev.EventType)
+	}
+	switch ev.Outcome {
+	case module.OutcomeExecuted, module.OutcomeDenied, module.OutcomeIndeterminate:
+		if !ev.Success {
+			t.Errorf("outcome %q left Success false; only a real macnoise fault should", ev.Outcome)
+		}
+	case module.OutcomeError:
+		t.Errorf("adding a login item reported a macnoise failure: %s", ev.Error)
+	default:
+		t.Errorf("unexpected outcome %q", ev.Outcome)
+	}
+
+	if got := ev.Details["es_event"]; got != "ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD" {
+		t.Errorf("es_event = %v, want ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD", got)
+	}
+}
+
+// The full add -> verify -> cleanup cycle only works with a real GUI session
+// and Automation consent, so it is gated behind an opt-in env var and run
+// manually via the RustDesk GUI on the test box rather than over ssh or CI.
+func TestLoginItem_FullCycleWithGUISession(t *testing.T) {
+	if os.Getenv("MACNOISE_GUI_TESTS") == "" {
+		t.Skip("set MACNOISE_GUI_TESTS=1 to run in a real GUI session with Automation consent granted")
+	}
+
+	name := "MacNoiseLoginItemGUITest"
+	e := &svcLoginItem{}
+	ev := runLoginItem(t, e, module.Params{"name": name})
+
+	if ev.Outcome != module.OutcomeExecuted {
+		t.Fatalf("outcome = %q (%s); expected executed in a consented GUI session", ev.Outcome, ev.Error)
+	}
+	if present, ok := ev.Details["verified_present"].(bool); !ok || !present {
+		t.Errorf("login item %q was not found in the list after add", name)
+	}
+	if err := e.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	present, err := e.loginItemPresent(context.Background(), name)
+	if err != nil {
+		t.Fatalf("list after cleanup: %v", err)
+	}
+	if present {
+		t.Errorf("login item %q survived Cleanup", name)
+	}
+}

--- a/modules/service/login_item_test.go
+++ b/modules/service/login_item_test.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// A name or path with a quote must not break out of the AppleScript literal.
+// This is the es_process quoting failure in a different interpreter: an
+// unescaped quote silently changes the statement rather than erroring.
+func TestAppleScriptString(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{`plain`, `"plain"`},
+		{`with "quote"`, `"with \"quote\""`},
+		{`back\slash`, `"back\\slash"`},
+		{`/usr/bin/true`, `"/usr/bin/true"`},
+	}
+	for _, tt := range tests {
+		if got := appleScriptString(tt.in); got != tt.want {
+			t.Errorf("appleScriptString(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// The make command must name the login item and its target, and stay a single
+// System Events statement.
+func TestMakeLoginItemScript(t *testing.T) {
+	got := makeLoginItemScript("MacNoiseLoginItem", "/usr/bin/true")
+	for _, want := range []string{
+		`tell application "System Events"`,
+		`name:"MacNoiseLoginItem"`,
+		`path:"/usr/bin/true"`,
+		`hidden:false`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("make script missing %q\ngot: %s", want, got)
+		}
+	}
+}
+
+func TestDeleteLoginItemScriptTargetsByName(t *testing.T) {
+	got := deleteLoginItemScript("MacNoiseLoginItem")
+	if !strings.Contains(got, `whose name is "MacNoiseLoginItem"`) {
+		t.Errorf("delete script does not target by name\ngot: %s", got)
+	}
+}
+
+// The whole point of the module and of the day-18 outcome field: a refusal or a
+// missing GUI session is not a macnoise failure and must not be classified as
+// one.
+func TestLoginItemOutcome(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		output string
+		want   module.Outcome
+	}{
+		{"success", nil, "", module.OutcomeExecuted},
+		{
+			name:   "automation not authorized is denied",
+			err:    errors.New("exit status 1"),
+			output: "execution error: Not authorized to send Apple events to System Events. (-1743)",
+			want:   module.OutcomeDenied,
+		},
+		{
+			name:   "bare -1743 is denied",
+			err:    errors.New("exit status 1"),
+			output: "execution error: (-1743)",
+			want:   module.OutcomeDenied,
+		},
+		{
+			name:   "no GUI session is indeterminate",
+			err:    errors.New("exit status 1"),
+			output: "execution error: An error of type -10810 has occurred. (-10810)",
+			want:   module.OutcomeIndeterminate,
+		},
+		{
+			name:   "any other failure is a tool error",
+			err:    errors.New("exit status 1"),
+			output: "execution error: something unexpected (-2700)",
+			want:   module.OutcomeError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := loginItemOutcome(tt.err, tt.output); got != tt.want {
+				t.Errorf("loginItemOutcome(%v, %q) = %q, want %q", tt.err, tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseLoginItemNames(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "MacNoiseLoginItem", []string{"MacNoiseLoginItem"}},
+		{"multiple", "Dropbox, iTunesHelper, MacNoiseLoginItem", []string{"Dropbox", "iTunesHelper", "MacNoiseLoginItem"}},
+		{"trailing whitespace", "  Dropbox ,  Rectangle  ", []string{"Dropbox", "Rectangle"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseLoginItemNames(tt.out)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseLoginItemNames(%q) = %v, want %v", tt.out, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("name[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDryRunMatchesExecutedScripts(t *testing.T) {
+	lines := (&svcLoginItem{}).DryRun(nil)
+	joined := strings.Join(lines, "\n")
+
+	for _, want := range []string{
+		makeLoginItemScript("MacNoiseLoginItem", "/usr/bin/true"),
+		deleteLoginItemScript("MacNoiseLoginItem"),
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("dry run does not advertise %q\ngot:\n%s", want, joined)
+		}
+	}
+}
+
+// Cleanup must be a no-op when nothing was added, or a refused run on a headless
+// host reports a delete failure for an item that never existed.
+func TestCleanupIsNoOpWhenNothingAdded(t *testing.T) {
+	if err := (&svcLoginItem{}).Cleanup(); err != nil {
+		t.Errorf("Cleanup with nothing added returned %v", err)
+	}
+	if err := (&svcLoginItem{name: "X", added: false}).Cleanup(); err != nil {
+		t.Errorf("Cleanup with added=false returned %v", err)
+	}
+}


### PR DESCRIPTION
Adds `svc_login_item`, which adds a Login Item via `osascript` driving System Events - the shared-file-list route T1547.015 names for scripting languages. On macOS 13+ this registers through Background Task Management and triggers `ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD`, the dominant modern persistence surface that no module covered.

`SMAppService` (the other route the technique names) needs a signed app bundle registering itself and is impossible from a standalone binary; the System Events route produces the same BTM event without one.

Adding a login item needs a GUI session plus Automation consent, so the module uses the event-outcome field (#35) to keep an environment it cannot control apart from a real fault: no GUI -> `indeterminate`, refused Automation -> `denied`, genuine failure -> `error`. The osascript error classification, AppleScript escaping, and list parsing are pure functions tested cross-platform.

Verified against a real Mac (macOS 26.5.2): over ssh with no GUI it reports `indeterminate` with `success: true`, audited as OCSF 1006 Create with status Unknown. The full add/verify/cleanup cycle needs a consented GUI session and is gated behind `MACNOISE_GUI_TESTS` for manual console runs.