### PR TITLE
feat: add cred_files to probe non-browser credential files

### DIFF
--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -109,13 +109,13 @@ func fileActivity(eventType string) (int, string) {
 	case "file_create", "dir_create", "file_hide_dotfile", "archive_create",
 		"plist_create", "plist_create_launchagent":
 		return 1, "Create"
-	case "plist_read_prior", "browser_cred_read":
+	case "plist_read_prior", "browser_cred_read", "cred_file_read":
 		return 2, "Read"
 	case "file_modify", "plist_modify":
 		return 3, "Update"
 	case "file_hide_chflags":
 		return 6, "Set Attributes"
-	case "browser_cred_probe":
+	case "browser_cred_probe", "cred_file_probe":
 		return 8, "Get Attributes"
 	}
 	return 99, "Other"

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -27,6 +27,8 @@ func TestClassify(t *testing.T) {
 		{"file", "archive_create", 1001, 1},
 		{"file", "browser_cred_probe", 1001, 8},
 		{"file", "browser_cred_read", 1001, 2},
+		{"file", "cred_file_probe", 1001, 8},
+		{"file", "cred_file_read", 1001, 2},
 		{"file", "dir_create", 1001, 1},
 		{"file", "file_create", 1001, 1},
 		{"file", "file_hide_chflags", 1001, 6},

--- a/modules/file/README.md
+++ b/modules/file/README.md
@@ -18,6 +18,14 @@ macnoise run file_browser_creds
 macnoise run file_browser_creds --param browsers=chrome,firefox
 ```
 
+### `file_cred_files`
+Opens and reads well-known non-browser credential files, discarding the contents. Covers SSH private keys (`~/.ssh/id_*`, public `.pub` keys skipped since they are not secrets), `~/.aws/credentials`, `~/.kube/config`, `~/.docker/config.json`, and `~/.env`. The `paths` param adds extra targets, e.g. a project `.env`. Emits `cred_file_read` per file opened, carrying bytes read (executed) or the denial reason (denied), and `cred_file_probe` for paths that are not present (indeterminate). Maps to T1552.001. The read, not a stat, is deliberate: an unreadable file that `stat` would report as present is a real access denial, and the module records it as one.
+
+```bash
+macnoise run file_cred_files
+macnoise run file_cred_files --param paths=/Users/dev/project/.env
+```
+
 ### `file_archive`
 Creates a staging directory with three test files, then archives them using `zip` (default), `ditto`, or `tar`. Emits an `archive_create` event with path and size. Maps to T1560.001. Cleanup removes both the archive and staging directory. Requires the chosen tool in `PATH`.
 

--- a/modules/file/cred_files.go
+++ b/modules/file/cred_files.go
@@ -1,0 +1,203 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+type fileCredFiles struct{}
+
+// credTarget is a single credential file to probe, tagged with the class of
+// secret it holds so a consumer can act on the kind without parsing the path.
+type credTarget struct {
+	kind string
+	path string
+}
+
+func (f *fileCredFiles) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "file_cred_files",
+		Description: "Reads well-known credential files (SSH keys, cloud and container configs, .env) to generate credential-in-files access telemetry",
+		Category:    module.CategoryFile,
+		Tags:        []string{"credentials", "ssh", "aws", "kubernetes", "docker", "dotenv"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			{Technique: "T1552", SubTech: ".001", Name: "Unsecured Credentials: Credentials In Files"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "10.15",
+	}
+}
+
+func (f *fileCredFiles) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{
+			Name:         "paths",
+			Description:  "Comma-separated extra file paths to probe, e.g. a project .env",
+			Required:     false,
+			DefaultValue: "",
+			Example:      "/Users/dev/project/.env,/Users/dev/.netrc",
+		},
+	}
+}
+
+func (f *fileCredFiles) CheckPrereqs() error { return nil }
+
+// sshKeyPaths lists the SSH private keys to probe. The well-known names are
+// always included so an absent key still produces telemetry, and a glob catches
+// any non-standard key names actually present. Public keys are skipped: a .pub
+// file is not a secret, and reading it would be misleading credential-access
+// telemetry.
+func sshKeyPaths(home string) []string {
+	sshDir := filepath.Join(home, ".ssh")
+
+	seen := map[string]bool{}
+	var paths []string
+	add := func(p string) {
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+
+	for _, name := range []string{"id_rsa", "id_ed25519", "id_ecdsa", "id_dsa"} {
+		add(filepath.Join(sshDir, name))
+	}
+	// Glob failure only occurs on a bad pattern, which this is not, so an error
+	// here means no matches and is safe to ignore.
+	matches, _ := filepath.Glob(filepath.Join(sshDir, "id_*"))
+	for _, m := range matches {
+		if strings.HasSuffix(m, ".pub") {
+			continue
+		}
+		add(m)
+	}
+	return paths
+}
+
+// defaultCredTargets is the fixed set of well-known credential locations, built
+// relative to home so tests can point it at a temp directory.
+func defaultCredTargets(home string) []credTarget {
+	var targets []credTarget
+	for _, p := range sshKeyPaths(home) {
+		targets = append(targets, credTarget{kind: "ssh_private_key", path: p})
+	}
+	targets = append(targets,
+		credTarget{kind: "aws_credentials", path: filepath.Join(home, ".aws", "credentials")},
+		credTarget{kind: "kube_config", path: filepath.Join(home, ".kube", "config")},
+		credTarget{kind: "docker_config", path: filepath.Join(home, ".docker", "config.json")},
+		credTarget{kind: "dotenv", path: filepath.Join(home, ".env")},
+	)
+	return targets
+}
+
+// parseExtraPaths splits the user-supplied paths parameter, dropping empties so
+// a trailing comma or blank value does not produce a probe for "".
+func parseExtraPaths(param string) []string {
+	if param == "" {
+		return nil
+	}
+	var paths []string
+	for _, p := range strings.Split(param, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+func (f *fileCredFiles) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	info := f.Info()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home directory: %w", err)
+	}
+
+	targets := defaultCredTargets(home)
+	for _, p := range parseExtraPaths(params.Get("paths", "")) {
+		targets = append(targets, credTarget{kind: "custom", path: p})
+	}
+
+	for _, target := range targets {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		emit(credEvent(info, target))
+	}
+	return nil
+}
+
+// credEvent probes one target and builds its telemetry event. Kept separate
+// from Generate so the absent/denied/read classification is exercised
+// cross-platform against real temp files rather than only behind a darwin build
+// tag.
+func credEvent(info module.ModuleInfo, target credTarget) module.TelemetryEvent {
+	n, readErr := readCredFile(target.path)
+
+	switch {
+	case os.IsNotExist(readErr) || errors.Is(readErr, errNotRegularFile):
+		ev := output.NewEvent(info, "cred_file_probe", true,
+			fmt.Sprintf("%s not present: %s", target.kind, target.path))
+		// Absent target: nothing was read and no access decision was made, the
+		// same distinction the TCC probes and browser_creds draw.
+		ev = output.WithOutcome(ev, module.OutcomeIndeterminate, nil)
+		return output.WithDetails(ev, map[string]any{
+			"kind":   target.kind,
+			"path":   target.path,
+			"exists": false,
+		})
+
+	case readErr != nil:
+		// The file exists but could not be read. A permission denial is the
+		// signal a detection wants, not a module failure, so it is reported as
+		// a completed, refused read attempt. os.Open, not os.Stat, is what
+		// draws this line: Stat succeeds on a file the caller cannot open.
+		ev := output.NewEvent(info, "cred_file_read", true,
+			fmt.Sprintf("%s read denied: %s", target.kind, target.path))
+		ev = output.WithOutcome(ev, module.OutcomeDenied, readErr)
+		return output.WithDetails(ev, map[string]any{
+			"kind":       target.kind,
+			"path":       target.path,
+			"exists":     true,
+			"accessible": false,
+		})
+
+	default:
+		ev := output.NewEvent(info, "cred_file_read", true,
+			fmt.Sprintf("%s read: %s (%d bytes)", target.kind, target.path, n))
+		return output.WithDetails(ev, map[string]any{
+			"kind":       target.kind,
+			"path":       target.path,
+			"exists":     true,
+			"accessible": true,
+			"bytes_read": n,
+		})
+	}
+}
+
+func (f *fileCredFiles) DryRun(params module.Params) []string {
+	extra := parseExtraPaths(params.Get("paths", ""))
+	lines := []string{
+		"open and read ~/.ssh/id_* (private keys only), ~/.aws/credentials, ~/.kube/config, ~/.docker/config.json, ~/.env (contents discarded)",
+	}
+	if len(extra) > 0 {
+		lines = append(lines, fmt.Sprintf("open and read extra paths: %s (contents discarded)", strings.Join(extra, ", ")))
+	}
+	return lines
+}
+
+func (f *fileCredFiles) Cleanup() error { return nil }
+
+func init() {
+	module.Register(&fileCredFiles{})
+}

--- a/modules/file/cred_files_integration_test.go
+++ b/modules/file/cred_files_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration && darwin
+
+package file
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// A chmod-000 credential file exists but cannot be opened. That refusal is the
+// detection signal, and it must read as a denied access rather than a macnoise
+// failure or an absent file. os.Stat would succeed here where os.Open does not,
+// which is exactly why the module reads rather than stats.
+func TestCredFiles_UnreadableFileIsDeniedRead(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, mode bits do not deny access")
+	}
+
+	path := filepath.Join(t.TempDir(), "credentials")
+	if err := os.WriteFile(path, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	ev := credEvent(credInfo(), credTarget{kind: "aws_credentials", path: path})
+	if ev.Outcome != module.OutcomeDenied {
+		t.Errorf("outcome = %q, want denied", ev.Outcome)
+	}
+	if !ev.Success {
+		t.Error("Success = false: a permission denial is expected telemetry, not a macnoise fault")
+	}
+	if ev.Details["accessible"] != false {
+		t.Errorf("accessible = %v, want false", ev.Details["accessible"])
+	}
+}
+
+// End to end through a temp HOME: a planted AWS credentials file is read, an
+// absent kube config is a probe, and the run never fails.
+func TestCredFiles_GenerateOverTempHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	awsCreds := filepath.Join(awsDir, "credentials")
+	if err := os.WriteFile(awsCreds, []byte("[default]\naws_access_key_id = AKIA\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	if err := (&fileCredFiles{}).Generate(context.Background(), module.Params{}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var sawAWSRead, sawKubeProbe bool
+	for _, ev := range events {
+		kind, _ := ev.Details["kind"].(string)
+		path, _ := ev.Details["path"].(string)
+		switch {
+		case kind == "aws_credentials" && path == awsCreds:
+			if ev.EventType != "cred_file_read" || ev.ResolvedOutcome() != module.OutcomeExecuted {
+				t.Errorf("aws credentials: type %q outcome %q, want cred_file_read/executed", ev.EventType, ev.ResolvedOutcome())
+			}
+			sawAWSRead = true
+		case kind == "kube_config":
+			if ev.EventType != "cred_file_probe" || ev.Outcome != module.OutcomeIndeterminate {
+				t.Errorf("kube config: type %q outcome %q, want cred_file_probe/indeterminate", ev.EventType, ev.Outcome)
+			}
+			sawKubeProbe = true
+		}
+		if ev.Outcome == module.OutcomeError {
+			t.Errorf("event for %s reported a macnoise failure: %s", path, ev.Error)
+		}
+	}
+	if !sawAWSRead {
+		t.Error("no read event for the planted AWS credentials file")
+	}
+	if !sawKubeProbe {
+		t.Error("no probe event for the absent kube config")
+	}
+}

--- a/modules/file/cred_files_test.go
+++ b/modules/file/cred_files_test.go
@@ -1,0 +1,187 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func credInfo() module.ModuleInfo {
+	return (&fileCredFiles{}).Info()
+}
+
+// A public key is not a secret. Reading one and reporting it as credential
+// access would be misleading telemetry, so id_*.pub must be excluded while the
+// matching private key is still probed.
+func TestSSHKeyPathsSkipsPublicKeys(t *testing.T) {
+	home := t.TempDir()
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"id_rsa", "id_rsa.pub", "id_custom", "id_custom.pub", "known_hosts"} {
+		if err := os.WriteFile(filepath.Join(sshDir, name), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	paths := sshKeyPaths(home)
+	for _, p := range paths {
+		if strings.HasSuffix(p, ".pub") {
+			t.Errorf("public key was included: %s", p)
+		}
+		if strings.HasSuffix(p, "known_hosts") {
+			t.Errorf("non key file was included: %s", p)
+		}
+	}
+	// id_custom (present, non-standard) must be picked up by the glob.
+	if !containsPath(paths, filepath.Join(sshDir, "id_custom")) {
+		t.Errorf("non-standard private key id_custom was not probed: %v", paths)
+	}
+}
+
+// The well-known key names are probed even when absent, so a host with no keys
+// still emits credential-access telemetry rather than nothing.
+func TestSSHKeyPathsAlwaysProbesWellKnownNames(t *testing.T) {
+	home := t.TempDir() // no .ssh directory at all
+	paths := sshKeyPaths(home)
+
+	for _, name := range []string{"id_rsa", "id_ed25519", "id_ecdsa", "id_dsa"} {
+		if !containsPath(paths, filepath.Join(home, ".ssh", name)) {
+			t.Errorf("well-known key %s not probed when absent: %v", name, paths)
+		}
+	}
+}
+
+// A present standard key must not be probed twice: the explicit list and the
+// glob both name it, and a duplicate would double-count the read.
+func TestSSHKeyPathsDeduplicates(t *testing.T) {
+	home := t.TempDir()
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "id_rsa"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := sshKeyPaths(home)
+	seen := map[string]int{}
+	for _, p := range paths {
+		seen[p]++
+	}
+	if seen[filepath.Join(sshDir, "id_rsa")] != 1 {
+		t.Errorf("id_rsa probed %d times, want 1", seen[filepath.Join(sshDir, "id_rsa")])
+	}
+}
+
+func TestDefaultCredTargetsCoversEachKind(t *testing.T) {
+	home := t.TempDir()
+	targets := defaultCredTargets(home)
+
+	kinds := map[string]bool{}
+	for _, tg := range targets {
+		kinds[tg.kind] = true
+	}
+	for _, want := range []string{"ssh_private_key", "aws_credentials", "kube_config", "docker_config", "dotenv"} {
+		if !kinds[want] {
+			t.Errorf("kind %q missing from default targets", want)
+		}
+	}
+}
+
+func TestParseExtraPaths(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"/a/.env", []string{"/a/.env"}},
+		{"/a/.env, /b/.netrc", []string{"/a/.env", "/b/.netrc"}},
+		{"/a,,  ,/b", []string{"/a", "/b"}},
+	}
+	for _, tt := range tests {
+		got := parseExtraPaths(tt.in)
+		if len(got) != len(tt.want) {
+			t.Fatalf("parseExtraPaths(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("parseExtraPaths(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
+// The read path: a present, readable credential file is reported as an executed
+// read with a byte count. Works on any OS, no chmod needed.
+func TestCredEventReadsPresentFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials")
+	content := "[default]\naws_secret_access_key = AKIAEXAMPLE\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ev := credEvent(credInfo(), credTarget{kind: "aws_credentials", path: path})
+	if ev.EventType != "cred_file_read" {
+		t.Errorf("event type = %q, want cred_file_read", ev.EventType)
+	}
+	// The read path leaves Outcome unset by design; it resolves to executed at
+	// the emitter boundary from Success, the same as browser_creds.
+	if got := ev.ResolvedOutcome(); got != module.OutcomeExecuted {
+		t.Errorf("resolved outcome = %q, want executed", got)
+	}
+	if ev.Details["bytes_read"] != int64(len(content)) {
+		t.Errorf("bytes_read = %v, want %d", ev.Details["bytes_read"], len(content))
+	}
+	if ev.Details["accessible"] != true {
+		t.Errorf("accessible = %v, want true", ev.Details["accessible"])
+	}
+}
+
+// The absent path: a missing target is indeterminate, not a denial and not a
+// tool failure. No read was attempted, so no access decision was made.
+func TestCredEventAbsentTargetIsIndeterminate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does_not_exist", "config")
+
+	ev := credEvent(credInfo(), credTarget{kind: "kube_config", path: path})
+	if ev.EventType != "cred_file_probe" {
+		t.Errorf("event type = %q, want cred_file_probe", ev.EventType)
+	}
+	if ev.Outcome != module.OutcomeIndeterminate {
+		t.Errorf("outcome = %q, want indeterminate", ev.Outcome)
+	}
+	if !ev.Success {
+		t.Error("Success = false; an absent target is a valid observation")
+	}
+	if ev.Details["exists"] != false {
+		t.Errorf("exists = %v, want false", ev.Details["exists"])
+	}
+}
+
+func containsPath(paths []string, want string) bool {
+	return slices.Contains(paths, want)
+}
+
+// A directory at the target path is not a credential file. It exists but holds
+// nothing to read, so it is a probe rather than a denied read.
+func TestCredEventDirectoryIsProbe(t *testing.T) {
+	dir := t.TempDir()
+
+	ev := credEvent(credInfo(), credTarget{kind: "dotenv", path: dir})
+	if ev.Outcome != module.OutcomeIndeterminate {
+		t.Errorf("outcome = %q, want indeterminate for a directory", ev.Outcome)
+	}
+}
+
+func TestDryRunListsExtraPaths(t *testing.T) {
+	lines := (&fileCredFiles{}).DryRun(module.Params{"paths": "/proj/.env"})
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "/proj/.env") {
+		t.Errorf("dry run does not mention the extra path\ngot:\n%s", joined)
+	}
+}


### PR DESCRIPTION
Adds `file_cred_files`, which opens and reads well-known credential files and discards the contents (streamed to `io.Discard`, only the byte count is kept), generating the open/read telemetry T1552.001 detections key on: SSH private keys (`~/.ssh/id_*`, public `.pub` keys skipped since they are not secrets), `~/.aws/credentials`, `~/.kube/config`, `~/.docker/config.json`, `~/.env`, plus any extra `--param paths` for project `.env` files. Audited as OCSF 1001 File System Activity / Read, matching the browser_creds mapping.

Reuses browser_creds' `readCredFile` so the stat-versus-read distinction is shared and already proven: an unreadable file that `stat` reports as present is a real access denial, recorded as `denied` rather than absent. The three outcomes reuse the event-outcome field (#35): read -> `executed`, permission refusal -> `denied`, absent -> `indeterminate`.

Pure filesystem, no GUI or privilege dependency, so it verifies fully over ssh. Confirmed on a real Mac: planted `~/.aws/credentials` and a custom `.env` read as executed with byte counts, absent targets as indeterminate, audited 1001/Read/Success. The `.pub` skipping, well-known-name probing, dedup, path parsing, and absent/read classification are pure and tested cross-platform; the chmod-000 denied path is darwin-gated.