### PR TITLE
feat: add tcc_accessibility and tcc_screen_recording probes

### DIFF
--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -136,7 +136,7 @@ func serviceActivity(eventType string) (int, string) {
 func apiActivity(eventType string) (int, string) {
 	switch eventType {
 	case "keychain_list", "keychain_dump_attempt", "tcc_contacts_probe",
-		"tcc_fda_probe", "xpc_enumerate":
+		"tcc_fda_probe", "tcc_accessibility_probe", "screen_capture_attempt", "xpc_enumerate":
 		return 2, "Read"
 	case "keychain_unlock_attempt":
 		return 3, "Update"

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -65,8 +65,10 @@ func TestClassify(t *testing.T) {
 		{"tcc", "keychain_dump_attempt", 6003, 2},
 		{"tcc", "keychain_list", 6003, 2},
 		{"tcc", "keychain_unlock_attempt", 6003, 3},
+		{"tcc", "tcc_accessibility_probe", 6003, 2},
 		{"tcc", "tcc_contacts_probe", 6003, 2},
 		{"tcc", "tcc_fda_probe", 6003, 2},
+		{"tcc", "screen_capture_attempt", 6003, 2},
 		{"xpc", "xpc_enumerate", 6003, 2},
 
 		// endpoint_security

--- a/modules/tcc/README.md
+++ b/modules/tcc/README.md
@@ -1,6 +1,6 @@
 # tcc
 
-TCC permission probes covering Full Disk Access, Contacts, and Keychain.
+TCC permission probes covering Full Disk Access, Contacts, Keychain, Accessibility, and Screen Recording.
 
 ## Modules
 
@@ -19,3 +19,13 @@ Probes keychain access by running `security list-keychains`, `security unlock-ke
 macnoise run tcc_keychain
 macnoise run tcc_keychain --param keychain_path=/Users/victim/Library/Keychains/login.keychain-db
 ```
+
+### `tcc_accessibility`
+Reads UI elements through System Events via `osascript`, which requires the Accessibility permission. Returns data when granted, a specific authorization error (`-1719` / assistive access) when not. Emits `tcc_accessibility_probe` with `result` as `executed` (granted), `denied` (refused), or `indeterminate` (no GUI session to run System Events). Maps to T1056.001 — Accessibility is the permission that enables reading UI/secure-field contents as they are typed, a keylogging vector.
+
+### `tcc_screen_recording`
+Runs `screencapture` to a temp file, records the byte count, and deletes the file — the contents are never read or emitted. Emits `screen_capture_attempt`. Maps to T1113.
+
+Unlike the other TCC probes this is **not** a granted/denied classifier: command-line `screencapture` exits 0 and writes a valid image whether or not Screen Recording is granted (the desktop is always capturable, other apps' windows are silently excluded), and no CLI signal reveals the grant. Determining it would need `CGPreflightScreenCaptureAccess` via cgo, which this pure-Go tool avoids. So the module honestly reports only `executed` (the capture ran — itself the telemetry a detection keys on) or `indeterminate` (no display/GUI to attempt it), with `permission: indeterminate` in the details. It never fabricates a verdict it cannot determine.
+
+Both modules need a GUI (Aqua) session; over ssh or on a headless runner they report `indeterminate` rather than failing.

--- a/modules/tcc/accessibility.go
+++ b/modules/tcc/accessibility.go
@@ -1,0 +1,115 @@
+package tcc
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+type tccAccessibility struct{}
+
+func (t *tccAccessibility) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "tcc_accessibility",
+		Description: "Probes Accessibility permission by reading UI elements via System Events",
+		Category:    module.CategoryTCC,
+		Tags:        []string{"tcc", "accessibility", "keylogging", "privacy"},
+		Privileges:  module.PrivilegeTCC,
+		MITRE: []module.MITRE{
+			// Accessibility (kTCCServiceAccessibility) is the permission that
+			// lets a process read other apps' UI element contents - including
+			// secure text fields as they are typed - which is a keylogging
+			// vector. The mapping follows tcc_fda's convention of naming the
+			// technique the permission enables, not the probe itself. MITRE's
+			// T1056.001 macOS examples cite event taps; the AX route is the
+			// same capability by a different API.
+			{Technique: "T1056", SubTech: ".001", Name: "Input Capture: Keylogging"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "10.15",
+	}
+}
+
+func (t *tccAccessibility) ParamSpecs() []module.ParamSpec { return nil }
+
+func (t *tccAccessibility) CheckPrereqs() error { return nil }
+
+// accessibilityProbeScript reads the menu bar items of the frontmost process
+// through System Events. Reading any process's UI elements requires the
+// responsible app to hold Accessibility, so this returns data when granted and
+// a specific authorization error when not. The menu bar is used rather than a
+// window because every GUI app has one, so the probe does not depend on a
+// window being open.
+func accessibilityProbeScript() string {
+	return `tell application "System Events" to tell (first process whose frontmost is true) to get name of every menu bar item of menu bar 1`
+}
+
+// accessibilityOutcome classifies an osascript run into an event outcome, so a
+// host that refused or could not attempt the read is not reported as a broken
+// tool. The discriminator is the System Events error number:
+//
+//   - -1719 / -25211 / "assistive access": the responsible app is not trusted
+//     for Accessibility, so the read was refused. That refusal is the signal.
+//   - -10810: System Events could not launch, i.e. no GUI (Aqua) session, so
+//     nothing was attempted and the outcome is indeterminate.
+//   - no error: the UI was read, so Accessibility is granted.
+func accessibilityOutcome(err error, combinedOutput string) module.Outcome {
+	if err == nil {
+		return module.OutcomeExecuted
+	}
+	switch {
+	case strings.Contains(combinedOutput, "-1719"),
+		strings.Contains(combinedOutput, "-25211"),
+		strings.Contains(combinedOutput, "assistive access"),
+		strings.Contains(combinedOutput, "not allowed"):
+		return module.OutcomeDenied
+	case strings.Contains(combinedOutput, "-10810"):
+		return module.OutcomeIndeterminate
+	default:
+		return module.OutcomeError
+	}
+}
+
+func (t *tccAccessibility) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	info := t.Info()
+
+	out, err := exec.CommandContext(ctx, "osascript", "-e", accessibilityProbeScript()).CombinedOutput()
+	combined := strings.TrimSpace(string(out))
+	outcome := accessibilityOutcome(err, combined)
+
+	ev := output.NewEvent(info, "tcc_accessibility_probe", true, "probing Accessibility via System Events")
+	details := map[string]any{"result": string(outcome), "method": "osascript System Events UI read"}
+
+	switch outcome {
+	case module.OutcomeExecuted:
+		ev.Message = "Accessibility TCC probe: UI read succeeded, permission granted"
+	case module.OutcomeDenied:
+		ev.Message = "Accessibility TCC probe: read refused, permission not granted (expected without Accessibility)"
+	case module.OutcomeIndeterminate:
+		ev.Message = "Accessibility TCC probe: no GUI session to run System Events, no decision made"
+	default:
+		ev.Message = "Accessibility TCC probe: unexpected failure driving System Events"
+	}
+
+	var probeErr error
+	if err != nil {
+		probeErr = fmt.Errorf("osascript: %v: %s", err, combined)
+	}
+	ev = output.WithOutcome(ev, outcome, probeErr)
+	emit(output.WithDetails(ev, details))
+	return nil
+}
+
+func (t *tccAccessibility) DryRun(params module.Params) []string {
+	return []string{fmt.Sprintf("osascript -e '%s' (probes Accessibility permission)", accessibilityProbeScript())}
+}
+
+func (t *tccAccessibility) Cleanup() error { return nil }
+
+func init() {
+	module.Register(&tccAccessibility{})
+}

--- a/modules/tcc/perms_integration_test.go
+++ b/modules/tcc/perms_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration && darwin
+
+package tcc
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func runPerm(t *testing.T, gen module.Generator) module.TelemetryEvent {
+	t.Helper()
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	if err := gen.Generate(context.Background(), module.Params{}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	return events[0]
+}
+
+// The Accessibility probe drives System Events, which needs a GUI session and
+// consent that neither ssh nor a headless runner is guaranteed to have. The
+// contract everywhere is that it never reports a macnoise fault for an
+// environment that merely refused or could not be reached.
+func TestAccessibility_ClassifiesEnvironmentWithoutFailing(t *testing.T) {
+	ev := runPerm(t, &tccAccessibility{})
+
+	if ev.EventType != "tcc_accessibility_probe" {
+		t.Errorf("event type = %q, want tcc_accessibility_probe", ev.EventType)
+	}
+	switch ev.Outcome {
+	case module.OutcomeExecuted, module.OutcomeDenied, module.OutcomeIndeterminate:
+		if !ev.Success {
+			t.Errorf("outcome %q left Success false; only a real fault should", ev.Outcome)
+		}
+	default:
+		t.Errorf("adding reported an unexpected outcome %q: %s", ev.Outcome, ev.Error)
+	}
+}
+
+// Screen capture must never claim a permission verdict, only that the attempt
+// ran or could not be attempted. Over ssh there is no display, so this is
+// typically indeterminate; in a GUI session it is executed. Denied must never
+// appear.
+func TestScreenRecording_NeverClaimsAVerdict(t *testing.T) {
+	ev := runPerm(t, &tccScreenRecording{})
+
+	if ev.EventType != "screen_capture_attempt" {
+		t.Errorf("event type = %q, want screen_capture_attempt", ev.EventType)
+	}
+	if ev.Outcome != module.OutcomeExecuted && ev.Outcome != module.OutcomeIndeterminate {
+		t.Errorf("outcome = %q, want executed or indeterminate (never a grant verdict)", ev.Outcome)
+	}
+	if !ev.Success {
+		t.Errorf("Success = false; a capture attempt is not a macnoise fault: %s", ev.Error)
+	}
+	if ev.Details["permission"] != "indeterminate" {
+		t.Errorf("permission = %v, want indeterminate (the CLI cannot read the grant)", ev.Details["permission"])
+	}
+}
+
+// The granted and executed paths need a real GUI session with the permissions
+// actually granted to the responsible app, so they are gated behind an env var
+// and run manually in a console session rather than over ssh or CI.
+func TestPerms_GrantedPathsWithGUISession(t *testing.T) {
+	if os.Getenv("MACNOISE_GUI_TESTS") == "" {
+		t.Skip("set MACNOISE_GUI_TESTS=1 in a GUI session with Accessibility and Screen Recording granted")
+	}
+
+	ax := runPerm(t, &tccAccessibility{})
+	if ax.Outcome != module.OutcomeExecuted {
+		t.Errorf("accessibility outcome = %q (%s); expected executed with Accessibility granted", ax.Outcome, ax.Error)
+	}
+
+	sc := runPerm(t, &tccScreenRecording{})
+	if sc.Outcome != module.OutcomeExecuted {
+		t.Errorf("screen capture outcome = %q (%s); expected executed in a GUI session", sc.Outcome, sc.Error)
+	}
+	if b, _ := sc.Details["bytes_captured"].(int64); b <= 0 {
+		t.Errorf("bytes_captured = %v, want > 0", sc.Details["bytes_captured"])
+	}
+}

--- a/modules/tcc/perms_test.go
+++ b/modules/tcc/perms_test.go
@@ -1,0 +1,99 @@
+package tcc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// A refused Accessibility read and a missing GUI session are not macnoise
+// faults. The osascript error number is the discriminator, the same shape the
+// svc_login_item classifier uses for a different TCC gate.
+func TestAccessibilityOutcome(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		output string
+		want   module.Outcome
+	}{
+		{"granted", nil, "Apple, Finder, File, Edit", module.OutcomeExecuted},
+		{
+			name:   "not trusted for accessibility is denied",
+			err:    errors.New("exit status 1"),
+			output: "execution error: System Events got an error: osascript is not allowed assistive access. (-1719)",
+			want:   module.OutcomeDenied,
+		},
+		{
+			// No "assistive access" text, so this isolates the -1719 marker:
+			// break that check and this case falls through to error.
+			name:   "bare -1719 code is denied",
+			err:    errors.New("exit status 1"),
+			output: "execution error: (-1719)",
+			want:   module.OutcomeDenied,
+		},
+		{
+			name:   "newer assistive-access code is denied",
+			err:    errors.New("exit status 1"),
+			output: "execution error: ... (-25211)",
+			want:   module.OutcomeDenied,
+		},
+		{
+			name:   "no GUI session is indeterminate",
+			err:    errors.New("exit status 1"),
+			output: "execution error: An error of type -10810 has occurred. (-10810)",
+			want:   module.OutcomeIndeterminate,
+		},
+		{
+			name:   "any other failure is a tool error",
+			err:    errors.New("exit status 1"),
+			output: "execution error: something else (-2700)",
+			want:   module.OutcomeError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := accessibilityOutcome(tt.err, tt.output); got != tt.want {
+				t.Errorf("accessibilityOutcome(%v, %q) = %q, want %q", tt.err, tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+// Screen capture cannot be a granted/denied classifier from the CLI, so it must
+// only ever report that the attempt ran or could not be attempted - never a
+// permission verdict.
+func TestScreenCaptureOutcome(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   error
+		bytes int64
+		want  module.Outcome
+	}{
+		{"captured bytes", nil, 3494, module.OutcomeExecuted},
+		{"ran but wrote nothing", nil, 0, module.OutcomeIndeterminate},
+		{"command failed", errors.New("exit status 1"), 0, module.OutcomeIndeterminate},
+		{"failed despite a stale file", errors.New("no display"), 1024, module.OutcomeIndeterminate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := screenCaptureOutcome(tt.err, tt.bytes)
+			if got != tt.want {
+				t.Errorf("screenCaptureOutcome(%v, %d) = %q, want %q", tt.err, tt.bytes, got, tt.want)
+			}
+			// The invariant that keeps the module honest: it must never emit a
+			// granted or denied verdict for screen recording.
+			if got == module.OutcomeDenied {
+				t.Error("screen capture must not report a denied verdict it cannot determine")
+			}
+		})
+	}
+}
+
+func TestAccessibilityDryRunMatchesProbe(t *testing.T) {
+	lines := (&tccAccessibility{}).DryRun(nil)
+	if len(lines) != 1 || !strings.Contains(lines[0], accessibilityProbeScript()) {
+		t.Errorf("dry run does not advertise the probe script: %v", lines)
+	}
+}

--- a/modules/tcc/screen_recording.go
+++ b/modules/tcc/screen_recording.go
@@ -1,0 +1,112 @@
+package tcc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+type tccScreenRecording struct{}
+
+func (t *tccScreenRecording) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "tcc_screen_recording",
+		Description: "Attempts a screen capture via screencapture to generate screen-capture telemetry",
+		Category:    module.CategoryTCC,
+		Tags:        []string{"tcc", "screen-recording", "screencapture", "privacy"},
+		Privileges:  module.PrivilegeTCC,
+		MITRE: []module.MITRE{
+			{Technique: "T1113", Name: "Screen Capture"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "10.15",
+	}
+}
+
+func (t *tccScreenRecording) ParamSpecs() []module.ParamSpec { return nil }
+
+func (t *tccScreenRecording) CheckPrereqs() error { return nil }
+
+// screenCaptureOutcome classifies a screencapture run.
+//
+// Unlike the Accessibility probe, this cannot be a granted/denied classifier:
+// the command-line screencapture exits 0 and writes a valid image whether or
+// not Screen Recording is granted, because the desktop is always capturable
+// while other apps' windows are silently excluded. There is no exit code,
+// stderr, or output that reveals the grant, and determining it would need the
+// CGPreflightScreenCaptureAccess API via cgo, which this pure-Go tool avoids.
+//
+// So the module reports what it can honestly observe: the capture attempt ran
+// (executed) - which is itself the telemetry a detection keys on, a process
+// invoking the screen-capture path - or it could not be attempted at all
+// (indeterminate), e.g. no display or GUI session. It never claims a permission
+// verdict it cannot determine, per the same rule that gave proc_inject its
+// indeterminate outcome.
+func screenCaptureOutcome(err error, bytes int64) module.Outcome {
+	if err == nil && bytes > 0 {
+		return module.OutcomeExecuted
+	}
+	return module.OutcomeIndeterminate
+}
+
+func (t *tccScreenRecording) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	info := t.Info()
+
+	// The capture is written to a temp file, its size recorded, and the file
+	// deleted immediately. Contents are never read or emitted: the goal is to
+	// generate the screen-capture telemetry a real stealer would, not to
+	// collect the screen, the same discard posture as the credential modules.
+	f, err := os.CreateTemp("", "mn_screencap_*.png")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := f.Name()
+	_ = f.Close()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	out, runErr := exec.CommandContext(ctx, "screencapture", "-x", tmpPath).CombinedOutput()
+
+	var bytes int64
+	if fi, statErr := os.Stat(tmpPath); statErr == nil {
+		bytes = fi.Size()
+	}
+	outcome := screenCaptureOutcome(runErr, bytes)
+
+	ev := output.NewEvent(info, "screen_capture_attempt", true, "attempting screen capture via screencapture")
+	details := map[string]any{
+		"tool":            "screencapture",
+		"bytes_captured":  bytes,
+		"permission":      "indeterminate",
+		"permission_note": "the CLI cannot determine whether Screen Recording is granted; the capture attempt is the telemetry",
+	}
+
+	switch outcome {
+	case module.OutcomeExecuted:
+		ev.Message = fmt.Sprintf("screen capture ran, wrote %d bytes (Screen Recording grant not determinable from CLI)", bytes)
+	default:
+		ev.Message = "screen capture could not be attempted (no display or GUI session)"
+	}
+
+	var probeErr error
+	if runErr != nil {
+		probeErr = fmt.Errorf("screencapture: %v: %s", runErr, strings.TrimSpace(string(out)))
+	}
+	ev = output.WithOutcome(ev, outcome, probeErr)
+	emit(output.WithDetails(ev, details))
+	return nil
+}
+
+func (t *tccScreenRecording) DryRun(params module.Params) []string {
+	return []string{"screencapture -x <tempfile> then delete it (probes Screen Recording, contents discarded)"}
+}
+
+func (t *tccScreenRecording) Cleanup() error { return nil }
+
+func init() {
+	module.Register(&tccScreenRecording{})
+}


### PR DESCRIPTION
Covers the two TCC surfaces the category lacked. `tcc_accessibility` is a real granted/denied/indeterminate classifier via osascript System Events (T1056.001). `tcc_screen_recording` only reports executed/indeterminate, never a verdict - command-line `screencapture` succeeds whether or not the grant exists and reading it would need cgo, so claiming granted/denied would be fabricated (T1113).