### PR TITLE
feat: add file_keychain_copy to stage wholesale keychain copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make build
 |----------|-------------|---------|
 | `network` | Outbound connections, DNS, beaconing, listeners, reverse shells, exfiltration | net_connect, net_listen, net_beacon, net_revshell, net_dns, net_exfil |
 | `process` | Process spawning, signal delivery, dylib injection, discovery, Gatekeeper bypass, osascript | proc_spawn, proc_signal, proc_inject, proc_discovery, proc_gatekeeper, proc_osascript |
-| `file` | File creation, modification, browser credential reads, archiving, hiding | file_create, file_modify, file_browser_creds, file_archive, file_hide |
+| `file` | File creation, modification, credential file and keychain reads, archiving, hiding | file_create, file_modify, file_browser_creds, file_cred_files, file_keychain_copy, file_archive, file_hide |
 | `tcc` | TCC permission probes (FDA, Contacts, Keychain) | tcc_fda, tcc_contacts, tcc_keychain |
 | `endpoint_security` | ES framework event triggers | es_file, es_process |
 | `service` | LaunchAgent/Daemon persistence, cron, shell profile | svc_launch_agent, svc_launch_daemon, svc_cron, svc_shell_profile |

--- a/configs/scenarios/amos_atomic_stealer.yaml
+++ b/configs/scenarios/amos_atomic_stealer.yaml
@@ -155,9 +155,17 @@ steps:
   # T1555.001 — request Full Disk Access to reach ~/Library/Keychains/login.keychain-db
   - module: tcc_fda
 
-  # T1555.001 — unlock keychain with captured password and copy database
-  # AMOS: security unlock-keychain -p <pass> login.keychain-db, then cp to exfil/Keychain/kc.db
+  # T1555.001 — unlock and dump the keychain with the captured password
+  # AMOS: security unlock-keychain -p <pass> login.keychain-db
   - module: tcc_keychain
+
+  # T1555.001/T1074.001 — copy the keychain databases wholesale into a staging dir
+  # AMOS: cp login.keychain-db to exfil/Keychain/kc.db before archiving
+  # Staged separately from macnoise_amos_staging because each module cleans up its
+  # own directory as soon as it finishes, which would delete the archive source.
+  - module: file_keychain_copy
+    params:
+      stage_dir: /tmp/macnoise_amos_keychain
 
   # T1555.003 — read credential files for all browser families:
   # Chrome, ChromeCanary, Brave, Arc, Edge, Vivaldi, Yandex, Opera, OperaGX

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -107,9 +107,9 @@ func processActivity(eventType string) (int, string) {
 func fileActivity(eventType string) (int, string) {
 	switch eventType {
 	case "file_create", "dir_create", "file_hide_dotfile", "archive_create",
-		"plist_create", "plist_create_launchagent":
+		"plist_create", "plist_create_launchagent", "keychain_copy":
 		return 1, "Create"
-	case "plist_read_prior", "browser_cred_read", "cred_file_read":
+	case "plist_read_prior", "browser_cred_read", "cred_file_read", "keychain_read":
 		return 2, "Read"
 	case "file_modify", "plist_modify":
 		return 3, "Update"

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -34,6 +34,10 @@ func TestClassify(t *testing.T) {
 		{"file", "file_hide_chflags", 1001, 6},
 		{"file", "file_hide_dotfile", 1001, 1},
 		{"file", "file_modify", 1001, 3},
+		// A copy has no single OCSF activity, so it lands as the read of the
+		// source and the create of the staged destination.
+		{"file", "keychain_read", 1001, 2},
+		{"file", "keychain_copy", 1001, 1},
 
 		// plist (routed through the file/plist case)
 		{"plist", "plist_modify", 1001, 3},

--- a/modules/file/README.md
+++ b/modules/file/README.md
@@ -1,6 +1,6 @@
 # file
 
-File creation, modification, browser credential probing, archiving, and hiding.
+File creation, modification, credential and keychain reads, archiving, and hiding.
 
 ## Modules
 
@@ -24,6 +24,16 @@ Opens and reads well-known non-browser credential files, discarding the contents
 ```bash
 macnoise run file_cred_files
 macnoise run file_cred_files --param paths=/Users/dev/project/.env
+```
+
+### `file_keychain_copy`
+Copies the macOS keychain databases wholesale into a staging directory, the step AMOS performs before archiving and exfiltrating them. Targets the legacy `~/Library/Keychains/login.keychain-db`, the data-protection keychain under the per-user UUID directory (`~/Library/Keychains/<uuid>/keychain-2.db`, globbed since the UUID varies), `/Library/Keychains/System.keychain`, and the root-owned `/Library/Keychains/system-keychain-2.db`. Emits `keychain_read` and `keychain_copy` per store: a copy is a read of the source plus a create of the destination, and OCSF has no single activity covering both. A store that is absent is `indeterminate` (a GUI login creates `login.keychain-db`, so an ssh-only account has none), one that cannot be opened is `denied` (expected for the system data-protection keychain without root), and a failure to write the copy is `error` rather than either.
+
+Copies are written 0600 into a 0700 directory, deliberately tighter than the 0644/0755 the other file modules use: the staged file is a real credential store, and the conventional mode would leave it more exposed in `/tmp` than the original. Cleanup removes the staging directory; `--no-cleanup` keeps it and says so. Maps to T1555.001 and T1074.001.
+
+```bash
+macnoise run file_keychain_copy
+macnoise run file_keychain_copy --param stage_dir=/var/tmp/macnoise_kc
 ```
 
 ### `file_archive`

--- a/modules/file/keychain_copy.go
+++ b/modules/file/keychain_copy.go
@@ -1,0 +1,277 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+const (
+	defaultKeychainStageDir = "/tmp/macnoise_keychain"
+	// systemKeychainDir holds the machine-wide keychains. Named rather than
+	// inlined so the enumeration can be pointed at a temp directory in tests.
+	systemKeychainDir = "/Library/Keychains"
+)
+
+// errStageWrite marks a failure to write the staged copy, as opposed to a
+// failure to read the keychain. The two must stay distinguishable: a full disk
+// is a macnoise fault, while a refused read is the credential-access signal
+// this module exists to produce, and reporting one as the other would put a
+// privacy decision in the audit log that the host never made.
+var errStageWrite = errors.New("staging write failed")
+
+type fileKeychainCopy struct {
+	stageDir string
+}
+
+// keychainTarget is one keychain database to copy, tagged with which store it
+// is so a consumer can tell a user keychain from the system one without parsing
+// the path.
+type keychainTarget struct {
+	kind string
+	path string
+}
+
+func (f *fileKeychainCopy) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "file_keychain_copy",
+		Description: "Copies macOS keychain databases wholesale into a staging directory to generate keychain collection telemetry",
+		Category:    module.CategoryFile,
+		Tags:        []string{"credentials", "keychain", "collection", "staging"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			// T1555.001 covers reading the keychain database directly rather
+			// than through the security command, and names login.keychain-db in
+			// its own procedure examples. T1074.001 is the staging half: the
+			// copies are left in one directory so file_archive can zip them, the
+			// same order AMOS performs them in.
+			{Technique: "T1555", SubTech: ".001", Name: "Credentials from Password Stores: Keychain"},
+			{Technique: "T1074", SubTech: ".001", Name: "Data Staged: Local Data Staging"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "10.15",
+	}
+}
+
+func (f *fileKeychainCopy) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{
+			Name:         "stage_dir",
+			Description:  "Directory to stage the keychain copies in",
+			Required:     false,
+			DefaultValue: defaultKeychainStageDir,
+			Example:      "/var/tmp/macnoise_kc",
+		},
+	}
+}
+
+func (f *fileKeychainCopy) CheckPrereqs() error { return nil }
+
+// defaultKeychainTargets lists the keychain databases to copy. Both directories
+// are parameters so tests can point the enumeration at temp directories.
+//
+// The legacy login.keychain-db is what AMOS and most public reporting name, but
+// it is created by a GUI login and is simply absent on an account that has never
+// had one. The data-protection keychain that superseded it lives under a
+// per-user UUID directory, so it has to be globbed rather than named. Probing
+// every store means a host missing any one of them still produces signal, and
+// the root-owned system-keychain-2.db yields a clean denial when not root.
+func defaultKeychainTargets(home, systemDir string) []keychainTarget {
+	keychainDir := filepath.Join(home, "Library", "Keychains")
+
+	targets := []keychainTarget{
+		{kind: "login_keychain", path: filepath.Join(keychainDir, "login.keychain-db")},
+	}
+	// Glob only errors on a malformed pattern, which this is not, so an error
+	// here means no matches and is safe to ignore.
+	matches, _ := filepath.Glob(filepath.Join(keychainDir, "*", "keychain-2.db"))
+	for _, m := range matches {
+		targets = append(targets, keychainTarget{kind: "data_protection_keychain", path: m})
+	}
+	return append(targets,
+		keychainTarget{kind: "system_keychain", path: filepath.Join(systemDir, "System.keychain")},
+		keychainTarget{kind: "system_data_protection_keychain", path: filepath.Join(systemDir, "system-keychain-2.db")},
+	)
+}
+
+// stagedNames assigns each target a unique destination filename. Basenames are
+// not unique on their own - a host with more than one keychain directory has
+// several keychain-2.db - and a collision would mean one copy silently
+// overwriting another, so a repeat gets a numeric suffix.
+func stagedNames(targets []keychainTarget) []string {
+	seen := map[string]int{}
+	names := make([]string, len(targets))
+	for i, t := range targets {
+		name := t.kind + "_" + filepath.Base(t.path)
+		if n := seen[name]; n > 0 {
+			names[i] = fmt.Sprintf("%s.%d", name, n)
+		} else {
+			names[i] = name
+		}
+		seen[name]++
+	}
+	return names
+}
+
+// copyKeychain copies src to dst and returns the bytes written. A source error
+// is returned unwrapped so the caller can classify it as absent or denied; a
+// destination error is wrapped in errStageWrite.
+//
+// The 0600 mode, and the 0700 staging directory in Generate, are deliberately
+// tighter than the 0644/0755 the other file modules use. This writes a real
+// copy of a credential store into a world-writable /tmp, and inheriting the
+// conventional mode would leave the copy readable by everyone on the host when
+// the original was not.
+func copyKeychain(src, dst string) (int64, error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", errStageWrite, err)
+	}
+	defer func() { _ = out.Close() }()
+
+	n, err := io.Copy(out, in)
+	if err != nil {
+		return n, fmt.Errorf("%w: %w", errStageWrite, err)
+	}
+	return n, nil
+}
+
+// keychainEvents copies one target and returns the telemetry for it. Kept
+// separate from Generate, and taking plain paths, so the absent/denied/copied
+// classification runs against real temp files in the cross-platform test job
+// rather than only behind a darwin build tag.
+func keychainEvents(info module.ModuleInfo, t keychainTarget, dst string) []module.TelemetryEvent {
+	n, err := copyKeychain(t.path, dst)
+
+	switch {
+	case errors.Is(err, errStageWrite):
+		// macnoise could not write the copy. Nothing about the host's handling
+		// of the keychain can be concluded from that, so it is reported as the
+		// tool fault it is rather than as a read result.
+		ev := output.NewEvent(info, "keychain_copy", false,
+			fmt.Sprintf("staging %s to %s failed", t.kind, dst))
+		ev = output.WithDetails(ev, map[string]any{
+			"kind":        t.kind,
+			"source_path": t.path,
+			"staged_path": dst,
+		})
+		return []module.TelemetryEvent{output.WithError(ev, err)}
+
+	case os.IsNotExist(err):
+		// Absent store: nothing was read and no access decision was made, the
+		// same distinction cred_files and the TCC probes draw.
+		ev := output.NewEvent(info, "keychain_read", true,
+			fmt.Sprintf("%s not present: %s", t.kind, t.path))
+		ev = output.WithOutcome(ev, module.OutcomeIndeterminate, nil)
+		return []module.TelemetryEvent{output.WithDetails(ev, map[string]any{
+			"kind":   t.kind,
+			"path":   t.path,
+			"exists": false,
+		})}
+
+	case err != nil:
+		// The store exists but could not be opened. That refusal is the signal a
+		// detection keys on, not a module failure, so it is a completed and
+		// refused read rather than an error.
+		ev := output.NewEvent(info, "keychain_read", true,
+			fmt.Sprintf("%s read denied: %s", t.kind, t.path))
+		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
+		return []module.TelemetryEvent{output.WithDetails(ev, map[string]any{
+			"kind":       t.kind,
+			"path":       t.path,
+			"exists":     true,
+			"accessible": false,
+		})}
+
+	default:
+		// A copy is a read of the source and a create of the destination, and
+		// OCSF has no single activity covering both, so each half is emitted as
+		// what it actually was. Both matter to a consumer: the read of a
+		// keychain is the credential access, and a keychain-shaped file
+		// appearing in a staging directory is the collection.
+		readEv := output.NewEvent(info, "keychain_read", true,
+			fmt.Sprintf("%s read: %s (%d bytes)", t.kind, t.path, n))
+		readEv = output.WithDetails(readEv, map[string]any{
+			"kind":       t.kind,
+			"path":       t.path,
+			"exists":     true,
+			"accessible": true,
+			"bytes_read": n,
+		})
+
+		copyEv := output.NewEvent(info, "keychain_copy", true,
+			fmt.Sprintf("%s staged to %s (%d bytes)", t.kind, dst, n))
+		copyEv = output.WithDetails(copyEv, map[string]any{
+			"kind":         t.kind,
+			"source_path":  t.path,
+			"staged_path":  dst,
+			"bytes_copied": n,
+		})
+		return []module.TelemetryEvent{readEv, copyEv}
+	}
+}
+
+func (f *fileKeychainCopy) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	info := f.Info()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home directory: %w", err)
+	}
+
+	stageDir := params.Get("stage_dir", defaultKeychainStageDir)
+	if err := os.MkdirAll(stageDir, 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", stageDir, err)
+	}
+	f.stageDir = stageDir
+
+	targets := defaultKeychainTargets(home, systemKeychainDir)
+	names := stagedNames(targets)
+
+	for i, target := range targets {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		for _, ev := range keychainEvents(info, target, filepath.Join(stageDir, names[i])) {
+			emit(ev)
+		}
+	}
+	return nil
+}
+
+func (f *fileKeychainCopy) DryRun(params module.Params) []string {
+	stageDir := params.Get("stage_dir", defaultKeychainStageDir)
+	return []string{
+		fmt.Sprintf("mkdir -p %s (mode 0700)", stageDir),
+		fmt.Sprintf("cp ~/Library/Keychains/login.keychain-db ~/Library/Keychains/<uuid>/keychain-2.db %s/System.keychain %s/system-keychain-2.db %s/ (mode 0600)",
+			systemKeychainDir, systemKeychainDir, stageDir),
+	}
+}
+
+// Cleanup removes the staged copies. Leaving real credential stores duplicated
+// on disk is not an acceptable default, so this runs unless --no-cleanup is
+// passed, which announces itself.
+func (f *fileKeychainCopy) Cleanup() error {
+	if f.stageDir == "" {
+		return nil
+	}
+	return os.RemoveAll(f.stageDir)
+}
+
+func init() {
+	module.Register(&fileKeychainCopy{})
+}

--- a/modules/file/keychain_copy_integration_test.go
+++ b/modules/file/keychain_copy_integration_test.go
@@ -1,0 +1,152 @@
+//go:build integration && darwin
+
+package file
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// A chmod-000 keychain exists but cannot be opened. That refusal is the
+// detection signal and must read as denied, not as an absent store and not as a
+// macnoise failure. The same distinction cred_files draws, and the reason this
+// module opens rather than stats.
+func TestKeychainCopy_UnreadableKeychainIsDenied(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, mode bits do not deny access")
+	}
+
+	src := filepath.Join(t.TempDir(), "login.keychain-db")
+	if err := os.WriteFile(src, []byte("keychain"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(src, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(src, 0o600) })
+
+	dst := filepath.Join(t.TempDir(), "staged")
+	evs := keychainEvents(keychainInfo(), keychainTarget{kind: "login_keychain", path: src}, dst)
+
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want only a denied read: %+v", len(evs), evs)
+	}
+	if evs[0].Outcome != module.OutcomeDenied {
+		t.Errorf("outcome = %q, want denied", evs[0].Outcome)
+	}
+	if !evs[0].Success {
+		t.Error("Success = false: a permission denial is expected telemetry, not a macnoise fault")
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Error("a staged copy was created from a keychain that could not be read")
+	}
+}
+
+// End to end against a temp HOME with a planted login keychain, plus the real
+// /Library/Keychains this host has. The staged copy must be byte-for-byte and
+// not world-readable, and no target may report a macnoise fault.
+func TestKeychainCopy_GenerateStagesRealCopy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	keychainDir := filepath.Join(home, "Library", "Keychains")
+	if err := os.MkdirAll(keychainDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("kych\x00binary keychain bytes\x00")
+	loginKeychain := filepath.Join(keychainDir, "login.keychain-db")
+	if err := os.WriteFile(loginKeychain, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stageDir := filepath.Join(t.TempDir(), "stage")
+	mod := &fileKeychainCopy{}
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	if err := mod.Generate(context.Background(), module.Params{"stage_dir": stageDir}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var staged string
+	for _, ev := range events {
+		if ev.Outcome == module.OutcomeError {
+			t.Errorf("%s reported a macnoise failure: %s", ev.EventType, ev.Error)
+		}
+		if kind, _ := ev.Details["kind"].(string); kind == "login_keychain" && ev.EventType == "keychain_copy" {
+			staged, _ = ev.Details["staged_path"].(string)
+		}
+	}
+	if staged == "" {
+		t.Fatalf("no copy event for the planted login keychain: %+v", events)
+	}
+
+	got, err := os.ReadFile(staged)
+	if err != nil {
+		t.Fatalf("staged copy is not readable: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("staged copy differs from the source keychain")
+	}
+	fi, err := os.Stat(staged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := fi.Mode().Perm(); mode&0o077 != 0 {
+		t.Errorf("staged keychain copy mode = %#o, want no group or world access", mode)
+	}
+
+	// The system keychain is world-readable on a stock macOS install, so a real
+	// host must produce a copy of it too. This is the half a temp HOME cannot
+	// fake, and it is what proves the enumeration points at real paths.
+	var sawSystem bool
+	for _, ev := range events {
+		if kind, _ := ev.Details["kind"].(string); kind == "system_keychain" && ev.EventType == "keychain_copy" {
+			sawSystem = true
+		}
+	}
+	if !sawSystem {
+		t.Error("no copy event for /Library/Keychains/System.keychain")
+	}
+}
+
+// Cleanup must remove the staged copies. A run that leaves duplicates of real
+// credential stores behind is the failure mode that actually matters here, and
+// it is silent without this assertion.
+func TestKeychainCopy_CleanupRemovesStagedCopies(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	keychainDir := filepath.Join(home, "Library", "Keychains")
+	if err := os.MkdirAll(keychainDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(keychainDir, "login.keychain-db"), []byte("kc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stageDir := filepath.Join(t.TempDir(), "stage")
+	mod := &fileKeychainCopy{}
+	if err := mod.Generate(context.Background(), module.Params{"stage_dir": stageDir}, func(module.TelemetryEvent) {}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	entries, err := os.ReadDir(stageDir)
+	if err != nil {
+		t.Fatalf("stage dir not created: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("nothing was staged, so cleanup would pass vacuously")
+	}
+
+	if err := mod.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(stageDir); !os.IsNotExist(err) {
+		t.Errorf("staged keychain copies survived cleanup at %s", stageDir)
+	}
+}

--- a/modules/file/keychain_copy_test.go
+++ b/modules/file/keychain_copy_test.go
@@ -1,0 +1,237 @@
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func keychainInfo() module.ModuleInfo {
+	return (&fileKeychainCopy{}).Info()
+}
+
+// The legacy login.keychain-db is created by a GUI login and is absent on an
+// account that has only ever been reached over ssh, where the data-protection
+// keychain under a per-user UUID directory is the store that actually holds
+// credentials. Enumerating only the documented legacy name would emit nothing
+// but indeterminate on such a host.
+func TestDefaultKeychainTargetsFindsDataProtectionKeychain(t *testing.T) {
+	home := t.TempDir()
+	uuidDir := filepath.Join(home, "Library", "Keychains", "C5B97F12-031E-5B0C-82FF-A694DFA73A57")
+	if err := os.MkdirAll(uuidDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(uuidDir, "keychain-2.db"), []byte("kc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	targets := defaultKeychainTargets(home, t.TempDir())
+
+	var found bool
+	for _, tg := range targets {
+		if tg.kind == "data_protection_keychain" && tg.path == filepath.Join(uuidDir, "keychain-2.db") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("data-protection keychain under the UUID directory was not enumerated: %+v", targets)
+	}
+}
+
+// The well-known stores are targeted even when absent, so a host missing any of
+// them still emits telemetry rather than silently skipping. This mirrors
+// cred_files probing well-known key names that do not exist.
+func TestDefaultKeychainTargetsCoversEachKindWhenAbsent(t *testing.T) {
+	targets := defaultKeychainTargets(t.TempDir(), t.TempDir())
+
+	kinds := map[string]bool{}
+	for _, tg := range targets {
+		kinds[tg.kind] = true
+	}
+	for _, want := range []string{"login_keychain", "system_keychain", "system_data_protection_keychain"} {
+		if !kinds[want] {
+			t.Errorf("kind %q missing from default targets: %+v", want, targets)
+		}
+	}
+}
+
+// Two keychain directories both contain a keychain-2.db. Without a unique
+// destination name the second copy overwrites the first, so the module would
+// report two staged keychains while only one file existed.
+func TestStagedNamesDisambiguatesCollidingBasenames(t *testing.T) {
+	targets := []keychainTarget{
+		{kind: "data_protection_keychain", path: "/Users/a/Library/Keychains/UUID-1/keychain-2.db"},
+		{kind: "data_protection_keychain", path: "/Users/a/Library/Keychains/UUID-2/keychain-2.db"},
+		{kind: "system_keychain", path: "/Library/Keychains/System.keychain"},
+	}
+
+	names := stagedNames(targets)
+	if len(names) != len(targets) {
+		t.Fatalf("got %d names for %d targets", len(names), len(targets))
+	}
+	seen := map[string]bool{}
+	for i, n := range names {
+		if seen[n] {
+			t.Errorf("destination name %q reused for target %d (%s)", n, i, targets[i].path)
+		}
+		seen[n] = true
+	}
+}
+
+// A staged copy of a credential store must not be world-readable. The other
+// file modules write 0644, which in a world-writable /tmp would leave the copy
+// more exposed than the keychain it came from.
+func TestCopyKeychainWritesRestrictiveMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows has no unix mode bits; this runs in the linux and macOS jobs")
+	}
+	src := filepath.Join(t.TempDir(), "login.keychain-db")
+	if err := os.WriteFile(src, []byte("keychain bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "staged.keychain-db")
+
+	if _, err := copyKeychain(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	fi, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := fi.Mode().Perm(); mode&0o077 != 0 {
+		t.Errorf("staged copy mode = %#o, want no group or world access", mode)
+	}
+}
+
+// The copy must be byte-for-byte. A truncated copy would still produce a
+// plausible create event while not being the wholesale copy the module claims.
+func TestCopyKeychainCopiesEveryByte(t *testing.T) {
+	content := strings.Repeat("keychain payload ", 4096)
+	src := filepath.Join(t.TempDir(), "keychain-2.db")
+	if err := os.WriteFile(src, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "staged")
+
+	n, err := copyKeychain(src, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != int64(len(content)) {
+		t.Errorf("copied %d bytes, want %d", n, len(content))
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Errorf("staged copy differs from source (%d vs %d bytes)", len(got), len(content))
+	}
+}
+
+// The copied path: a readable keychain produces both halves of the copy, since
+// OCSF has no single activity for one. The read is the credential access and
+// the create is the staging, and a consumer needs both.
+func TestKeychainEventsEmitsReadAndCopy(t *testing.T) {
+	content := "keychain bytes"
+	src := filepath.Join(t.TempDir(), "login.keychain-db")
+	if err := os.WriteFile(src, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "login_keychain_login.keychain-db")
+
+	evs := keychainEvents(keychainInfo(), keychainTarget{kind: "login_keychain", path: src}, dst)
+	if len(evs) != 2 {
+		t.Fatalf("got %d events, want a read and a copy: %+v", len(evs), evs)
+	}
+	if evs[0].EventType != "keychain_read" {
+		t.Errorf("first event = %q, want keychain_read", evs[0].EventType)
+	}
+	if evs[1].EventType != "keychain_copy" {
+		t.Errorf("second event = %q, want keychain_copy", evs[1].EventType)
+	}
+	for _, ev := range evs {
+		if got := ev.ResolvedOutcome(); got != module.OutcomeExecuted {
+			t.Errorf("%s resolved outcome = %q, want executed", ev.EventType, got)
+		}
+	}
+	if evs[0].Details["bytes_read"] != int64(len(content)) {
+		t.Errorf("bytes_read = %v, want %d", evs[0].Details["bytes_read"], len(content))
+	}
+	if evs[1].Details["staged_path"] != dst {
+		t.Errorf("staged_path = %v, want %s", evs[1].Details["staged_path"], dst)
+	}
+}
+
+// The absent path: a store that does not exist made no access decision, so it
+// is indeterminate rather than denied. Reporting it as denied would fabricate a
+// refusal the host never issued, the defect PR #28 fixed in the TCC probes.
+func TestKeychainEventsAbsentStoreIsIndeterminate(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "login.keychain-db") // never created
+	dst := filepath.Join(t.TempDir(), "staged")
+
+	evs := keychainEvents(keychainInfo(), keychainTarget{kind: "login_keychain", path: src}, dst)
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want only a read: %+v", len(evs), evs)
+	}
+	if evs[0].Outcome != module.OutcomeIndeterminate {
+		t.Errorf("outcome = %q, want indeterminate", evs[0].Outcome)
+	}
+	if !evs[0].Success {
+		t.Error("Success = false; an absent store is a valid observation, not a fault")
+	}
+	if evs[0].Details["exists"] != false {
+		t.Errorf("exists = %v, want false", evs[0].Details["exists"])
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Error("a destination file was created for an absent source")
+	}
+}
+
+// A failure to write the staged copy is a macnoise fault, not a host refusal.
+// Classifying it as a denied read would put a privacy decision in the audit log
+// that the host never made.
+func TestKeychainEventsStageWriteFailureIsError(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "login.keychain-db")
+	if err := os.WriteFile(src, []byte("kc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A destination inside a path component that is a regular file cannot be
+	// created on any platform, so this exercises the write failure without
+	// needing chmod semantics.
+	blocker := filepath.Join(t.TempDir(), "not_a_dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(blocker, "staged")
+
+	evs := keychainEvents(keychainInfo(), keychainTarget{kind: "login_keychain", path: src}, dst)
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want a single copy failure: %+v", len(evs), evs)
+	}
+	if evs[0].EventType != "keychain_copy" {
+		t.Errorf("event type = %q, want keychain_copy", evs[0].EventType)
+	}
+	if got := evs[0].ResolvedOutcome(); got != module.OutcomeError {
+		t.Errorf("resolved outcome = %q, want error", got)
+	}
+}
+
+// The dry run must name the directory that will actually be written, and say
+// the copies are staged there, so an operator can see what will be left behind
+// before running with --no-cleanup.
+func TestKeychainDryRunNamesStageDir(t *testing.T) {
+	lines := (&fileKeychainCopy{}).DryRun(module.Params{"stage_dir": "/var/tmp/kc"})
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "/var/tmp/kc") {
+		t.Errorf("dry run does not mention the stage dir\ngot:\n%s", joined)
+	}
+	if strings.Contains(joined, defaultKeychainStageDir) {
+		t.Errorf("dry run advertises the default stage dir despite an override\ngot:\n%s", joined)
+	}
+}


### PR DESCRIPTION
Adds the literal keychain-copy module the AMOS scenario already claimed under `tcc_keychain`, which only ran `security list/unlock/dump` and never copied anything. Targets the legacy `login.keychain-db`, the per-user data-protection keychain (globbed, since the UUID directory varies), and both system keychains, so absent, readable, and root-only stores each produce a distinct outcome.

Copies go to a 0700 dir at 0600 rather than the 0644/0755 the other file modules use, since a credential store copied into `/tmp` would otherwise end up more exposed than the original.

Verified on a real Mac: `login.keychain-db` absent (indeterminate, an ssh-only account never gets one), data-protection and System keychains copied byte-for-byte (executed), `system-keychain-2.db` denied without root. Cleanup removes the staging dir; `--no-cleanup` keeps it at the right modes.