### PR TITLE
feat: add security software discovery to proc_discovery

### DIFF
--- a/modules/process/README.md
+++ b/modules/process/README.md
@@ -23,7 +23,16 @@ macnoise run proc_inject --param target=/tmp/my_unsigned_binary --param dylib_pa
 ```
 
 ### `proc_discovery`
-Runs a configurable set of macOS reconnaissance commands (`sw_vers`, `system_profiler`, `sysctl`, `ifconfig`, `whoami`, `dscl`, `csrutil status`, `fdesetup status`). Each command emits a separate `system_discovery` event with structured output. Maps to T1082, T1016, T1033, T1518.
+Runs a configurable set of macOS reconnaissance commands (`sw_vers`, `system_profiler`, `sysctl`, `ifconfig`, `whoami`, `dscl`, `csrutil status`, `fdesetup status`), plus security software enumeration via `systemextensionsctl list`, the application firewall state, and a process scan for known endpoint agents. Each command emits a separate `system_discovery` event with structured output. Maps to T1082, T1016, T1033, T1518, T1518.001.
+
+`systemextensionsctl list` carries most of the security-software signal on modern macOS, since every current EDR registers an Endpoint Security system extension and it needs no vendor list to stay current. The agent process scan names specific vendors and is illustrative rather than exhaustive - a miss costs one match, while the exec that a detection actually sees still happens.
+
+The security commands are part of the defaults on purpose. A technique claimed in `Info()` but only reachable by overriding `commands` would be unbacked on a default run, which is the defect the original T1518 claim had, and `discovery_test.go` fails if a claim loses its backing command.
+
+```bash
+macnoise run proc_discovery
+macnoise run proc_discovery --param commands="sw_vers,whoami,csrutil status"
+```
 
 ```bash
 macnoise run proc_discovery

--- a/modules/process/discovery.go
+++ b/modules/process/discovery.go
@@ -20,6 +20,26 @@ var defaultDiscoveryCommands = []string{
 	"dscl . -list /Users",
 	"csrutil status",
 	"fdesetup status",
+	// The three below back the T1518.001 claim and must stay in the defaults:
+	// a technique claimed in Info() but only reachable by overriding params is
+	// the same defect as the original T1518 claim that nothing performed.
+	//
+	// systemextensionsctl is the highest-signal check on modern macOS, since
+	// every current EDR registers an Endpoint Security system extension, and it
+	// needs no vendor list to stay current. The firewall state and the process
+	// grep cover what MITRE names directly for this sub-technique.
+	"systemextensionsctl list",
+	"/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate",
+	// Vendor names are illustrative, not exhaustive - a miss costs one match
+	// while the exec itself, which is what a detection sees, still happens.
+	// Note that no pattern here may contain a comma: the commands param is
+	// comma-separated, so one would split the command in half.
+	//
+	// The trailing || is load-bearing. grep exits 1 when it matches nothing,
+	// which on a machine with no security software is the expected answer
+	// rather than a failure, and without this the module reports "discovery
+	// command returned error" for a probe that worked perfectly.
+	`ps -eo comm= | grep -iE "crowdstrike|sentinel|falcon|littlesnitch|knockknock|jamf|defender|sophos|malwarebytes" || echo "no matching security agents"`,
 }
 
 type procDiscovery struct{}
@@ -27,15 +47,21 @@ type procDiscovery struct{}
 func (p *procDiscovery) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "proc_discovery",
-		Description: "Runs macOS system reconnaissance commands to generate discovery telemetry",
+		Description: "Runs macOS system reconnaissance commands, including security software enumeration, to generate discovery telemetry",
 		Category:    module.CategoryProcess,
-		Tags:        []string{"discovery", "recon", "sysinfo"},
+		Tags:        []string{"discovery", "recon", "sysinfo", "security-software"},
 		Privileges:  module.PrivilegeNone,
 		MITRE: []module.MITRE{
 			{Technique: "T1082", Name: "System Information Discovery"},
 			{Technique: "T1016", Name: "System Network Configuration Discovery"},
 			{Technique: "T1033", Name: "System Owner/User Discovery"},
 			{Technique: "T1518", Name: "Software Discovery"},
+			// Backed by systemextensionsctl, socketfilterfw, and the agent
+			// process grep in defaultDiscoveryCommands. MITRE names process
+			// listing, application folder checks, and system extension listing
+			// for this sub-technique, and cites csrutil status - already in the
+			// defaults - as an XCSSET procedure for it.
+			{Technique: "T1518", SubTech: ".001", Name: "Software Discovery: Security Software Discovery"},
 		},
 		Author:   "0xv1n",
 		MinMacOS: "12.0",

--- a/modules/process/discovery_test.go
+++ b/modules/process/discovery_test.go
@@ -1,0 +1,86 @@
+package process
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// A MITRE technique in Info() has to be backed by something the module actually
+// does with default params. proc_discovery has already shipped this defect once:
+// it claimed T1518 Software Discovery while its command list contained nothing
+// that enumerated software, which day 4 fixed by adding a real command rather
+// than dropping the claim.
+//
+// This ties each discovery sub-claim to a command that performs it, so removing
+// the command without removing the claim fails here rather than silently
+// restoring the original defect.
+func TestDiscoveryClaimsAreBackedByDefaultCommands(t *testing.T) {
+	defaults := strings.Join(defaultDiscoveryCommands, "\n")
+
+	backing := map[string][]string{
+		"T1082": {"sw_vers", "system_profiler SPHardwareDataType"},
+		"T1016": {"ifconfig"},
+		"T1033": {"whoami"},
+		"T1518": {"system_profiler SPApplicationsDataType"},
+		"T1518.001": {
+			"systemextensionsctl list",
+			"socketfilterfw --getglobalstate",
+		},
+	}
+
+	for _, m := range (&procDiscovery{}).Info().MITRE {
+		id := m.Technique + m.SubTech
+		cmds, ok := backing[id]
+		if !ok {
+			t.Errorf("%s is claimed but no backing command is recorded for it", id)
+			continue
+		}
+		for _, cmd := range cmds {
+			if !strings.Contains(defaults, cmd) {
+				t.Errorf("%s is claimed but %q is not in the default commands", id, cmd)
+			}
+		}
+	}
+}
+
+// The commands param is comma-separated, so a command containing a comma is
+// silently split into two broken halves. The security-software grep pattern is
+// the realistic place for one to creep in.
+func TestDefaultDiscoveryCommandsContainNoCommas(t *testing.T) {
+	for _, cmd := range defaultDiscoveryCommands {
+		if strings.Contains(cmd, ",") {
+			t.Errorf("default command would be split by the comma-separated param: %q", cmd)
+		}
+	}
+}
+
+// Every default command has to survive the split-and-trim round trip that
+// Generate performs, or a command present in the list never runs.
+func TestDefaultDiscoveryCommandsSurviveParamRoundTrip(t *testing.T) {
+	joined := strings.Join(defaultDiscoveryCommands, ",")
+
+	var got []string
+	for _, raw := range strings.Split(joined, ",") {
+		if cmd := strings.TrimSpace(raw); cmd != "" {
+			got = append(got, cmd)
+		}
+	}
+
+	if len(got) != len(defaultDiscoveryCommands) {
+		t.Fatalf("round trip produced %d commands, want %d", len(got), len(defaultDiscoveryCommands))
+	}
+	for i, cmd := range defaultDiscoveryCommands {
+		if got[i] != cmd {
+			t.Errorf("command %d round-tripped to %q, want %q", i, got[i], cmd)
+		}
+	}
+}
+
+func TestDiscoveryDryRunListsEveryCommand(t *testing.T) {
+	lines := (&procDiscovery{}).DryRun(module.Params{})
+	if len(lines) != len(defaultDiscoveryCommands) {
+		t.Errorf("dry run listed %d commands, want %d", len(lines), len(defaultDiscoveryCommands))
+	}
+}


### PR DESCRIPTION
Adds `systemextensionsctl list`, the application firewall state, and a process scan for known endpoint agents to the default command list, backing a T1518.001 claim. Extends the existing module rather than adding a new one, since this is the same primitive it already provides - running a discovery command and emitting its output - and the commands are defaults rather than opt-in because a technique only reachable by overriding params would be unbacked on a default run, which is the defect the original T1518 claim had.

`discovery_test.go` ties each claimed technique to a command that performs it, so dropping the command without dropping the claim fails the build.