### PR TITLE
feat: add net_tls for TLS handshake telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make build
 
 | Category | Description | Modules |
 |----------|-------------|---------|
-| `network` | Outbound connections, DNS, beaconing, listeners, reverse shells, exfiltration | net_connect, net_listen, net_beacon, net_revshell, net_dns, net_dns_exfil, net_exfil |
+| `network` | Outbound connections, DNS, beaconing, listeners, reverse shells, TLS, exfiltration | net_connect, net_listen, net_beacon, net_revshell, net_dns, net_dns_exfil, net_tls, net_exfil |
 | `process` | Process spawning, signal delivery, dylib injection, discovery, Gatekeeper bypass, osascript | proc_spawn, proc_signal, proc_inject, proc_discovery, proc_gatekeeper, proc_osascript |
 | `file` | File creation, modification, credential file and keychain reads, archiving, hiding | file_create, file_modify, file_browser_creds, file_cred_files, file_keychain_copy, file_archive, file_hide |
 | `tcc` | TCC permission probes (FDA, Contacts, Keychain, Accessibility, Screen Recording) | tcc_fda, tcc_contacts, tcc_keychain, tcc_accessibility, tcc_screen_recording |

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -93,7 +93,7 @@ func networkActivity(eventType string) (int, string) {
 	switch eventType {
 	case "tcp_listen":
 		return 7, "Listen"
-	case "tcp_connect", "tcp_accept", "reverse_shell_attempt":
+	case "tcp_connect", "tcp_accept", "reverse_shell_attempt", "tls_connect":
 		return 1, "Open"
 	}
 	return 99, "Other"

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -23,6 +23,7 @@ func TestClassify(t *testing.T) {
 		{"network", "tcp_accept", 4001, 1},
 		{"network", "tcp_listen", 4001, 7},
 		{"network", "reverse_shell_attempt", 4001, 1},
+		{"network", "tls_connect", 4001, 1},
 
 		// file
 		{"file", "archive_create", 1001, 1},

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -27,6 +27,14 @@ DNS resolution of configurable domains. Maps to T1071.004.
 ### `net_revshell`
 Connects a shell to a remote listener (connection refused is expected without one). Maps to T1059.004.
 
+### `net_tls`
+Performs TLS handshakes to configurable endpoints and reports the negotiated version, cipher suite, and server certificate subject. Fills the encrypted-traffic gap that all other network modules leave open - no SNI/JA3/certificate-based detection fires without a TLS handshake. Pass `insecure=true` to skip certificate verification, matching what real C2 does with self-signed certs. Maps to T1573.002.
+
+```bash
+macnoise run net_tls
+macnoise run net_tls --param targets="10.0.0.1:8443" --param insecure=true
+```
+
 ### `net_dns_exfil`
 Encodes a payload into base32 DNS subdomain labels and resolves each query. The `.invalid` TLD (RFC 6761) means queries never leave the resolver unless the base domain is overridden. Maps to T1048.003.
 

--- a/modules/network/tls.go
+++ b/modules/network/tls.go
@@ -1,0 +1,145 @@
+package network
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+type netTLS struct{}
+
+func (n *netTLS) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "net_tls",
+		Description: "Performs TLS handshakes to configurable endpoints and reports negotiated version, cipher suite, and certificate subject",
+		Category:    module.CategoryNetwork,
+		Tags:        []string{"tls", "encrypted", "handshake", "sni", "ja3"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			{Technique: "T1573", SubTech: ".002", Name: "Encrypted Channel: Asymmetric Cryptography"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "12.0",
+	}
+}
+
+func (n *netTLS) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{
+			Name:         "targets",
+			Description:  "Comma-separated host:port pairs to connect to",
+			Required:     false,
+			DefaultValue: "example.com:443,github.com:443",
+			Example:      "10.0.0.1:8443,c2.attacker.invalid:443",
+		},
+		{
+			Name:         "insecure",
+			Description:  "Skip certificate verification (true/false)",
+			Required:     false,
+			DefaultValue: "false",
+			Example:      "true",
+		},
+	}
+}
+
+func (n *netTLS) CheckPrereqs() error { return nil }
+
+// tlsConnect dials one target and returns the event. Extracted so the
+// handshake metadata parsing is testable against a local TLS server.
+func tlsConnect(ctx context.Context, info module.ModuleInfo, target string, insecure bool) module.TelemetryEvent {
+	host, _, err := net.SplitHostPort(target)
+	if err != nil {
+		host = target
+	}
+
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	conf := &tls.Config{
+		ServerName:         host,
+		InsecureSkipVerify: insecure,
+	}
+
+	ev := output.NewEvent(info, "tls_connect", false,
+		fmt.Sprintf("TLS handshake %s (SNI: %s)", target, host))
+
+	conn, err := tls.DialWithDialer(dialer, "tcp", target, conf)
+	if err != nil {
+		ev.Success = true
+		ev.Message = fmt.Sprintf("TLS handshake %s failed (telemetry generated)", target)
+		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
+		return output.WithDetails(ev, map[string]any{
+			"target":   target,
+			"sni":      host,
+			"insecure": insecure,
+		})
+	}
+	defer func() { _ = conn.Close() }()
+
+	state := conn.ConnectionState()
+	details := map[string]any{
+		"target":       target,
+		"sni":          host,
+		"insecure":     insecure,
+		"tls_version":  tls.VersionName(state.Version),
+		"cipher_suite": tls.CipherSuiteName(state.CipherSuite),
+	}
+	if len(state.PeerCertificates) > 0 {
+		leaf := state.PeerCertificates[0]
+		details["cert_subject"] = leaf.Subject.String()
+		details["cert_issuer"] = leaf.Issuer.String()
+	}
+
+	ev.Success = true
+	ev.Message = fmt.Sprintf("TLS %s to %s, cipher %s",
+		tls.VersionName(state.Version), target, tls.CipherSuiteName(state.CipherSuite))
+	return output.WithDetails(ev, details)
+}
+
+func (n *netTLS) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	targetsStr := params.Get("targets", "example.com:443,github.com:443")
+	insecure := params.Get("insecure", "false") == "true"
+	info := n.Info()
+
+	for _, raw := range strings.Split(targetsStr, ",") {
+		target := strings.TrimSpace(raw)
+		if target == "" {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		emit(tlsConnect(ctx, info, target, insecure))
+	}
+	return nil
+}
+
+func (n *netTLS) DryRun(params module.Params) []string {
+	targetsStr := params.Get("targets", "example.com:443,github.com:443")
+	insecure := params.Get("insecure", "false") == "true"
+	var steps []string
+	for _, raw := range strings.Split(targetsStr, ",") {
+		target := strings.TrimSpace(raw)
+		if target == "" {
+			continue
+		}
+		mode := "verify"
+		if insecure {
+			mode = "insecure"
+		}
+		steps = append(steps, fmt.Sprintf("TLS dial %s (%s)", target, mode))
+	}
+	return steps
+}
+
+func (n *netTLS) Cleanup() error { return nil }
+
+func init() {
+	module.Register(&netTLS{})
+}

--- a/modules/network/tls_test.go
+++ b/modules/network/tls_test.go
@@ -1,0 +1,138 @@
+package network
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// selfSignedTLSListener starts a TLS listener on localhost with a fresh
+// self-signed certificate and returns its address. The listener accepts
+// one connection (enough for a single test dial) and then closes.
+func selfSignedTLSListener(t *testing.T) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		DNSNames:     []string{"localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+	}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			if tc, ok := conn.(*tls.Conn); ok {
+				_ = tc.Handshake()
+			}
+			_ = conn.Close()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func TestTLSConnect_Handshake(t *testing.T) {
+	addr := selfSignedTLSListener(t)
+	info := (&netTLS{}).Info()
+
+	ev := tlsConnect(context.Background(), info, addr, true)
+	if ev.EventType != "tls_connect" {
+		t.Fatalf("event type = %q, want tls_connect", ev.EventType)
+	}
+	if !ev.Success {
+		t.Fatalf("handshake failed: %s", ev.Message)
+	}
+	details := ev.Details
+	if details == nil {
+		t.Fatal("event has no details")
+	}
+	if v, ok := details["tls_version"].(string); !ok || v == "" {
+		t.Error("tls_version missing or empty")
+	}
+	if v, ok := details["cipher_suite"].(string); !ok || v == "" {
+		t.Error("cipher_suite missing or empty")
+	}
+	if v, ok := details["sni"].(string); !ok || v == "" {
+		t.Error("sni missing or empty")
+	}
+}
+
+func TestTLSConnect_RefusedIsTelemetry(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	info := (&netTLS{}).Info()
+	ev := tlsConnect(context.Background(), info, addr, true)
+	if !ev.Success {
+		t.Error("refused connection should still report success=true")
+	}
+	if ev.Details["tls_version"] != nil {
+		t.Error("refused connection should not have tls_version")
+	}
+}
+
+func TestTLSConnect_CertDetails(t *testing.T) {
+	addr := selfSignedTLSListener(t)
+	info := (&netTLS{}).Info()
+
+	ev := tlsConnect(context.Background(), info, addr, true)
+	if ev.Details["cert_subject"] == nil {
+		t.Error("expected cert_subject in details")
+	}
+}
+
+func TestTLSDryRunMatchesTargets(t *testing.T) {
+	mod := &netTLS{}
+	steps := mod.DryRun(module.Params{})
+	targets := strings.Split("example.com:443,github.com:443", ",")
+	if len(steps) != len(targets) {
+		t.Errorf("dry run listed %d steps, want %d", len(steps), len(targets))
+	}
+}
+
+func TestTLSDryRunInsecureLabel(t *testing.T) {
+	mod := &netTLS{}
+	steps := mod.DryRun(module.Params{"insecure": "true"})
+	for _, s := range steps {
+		if !strings.Contains(s, "insecure") {
+			t.Errorf("insecure mode not reflected in dry run: %s", s)
+		}
+	}
+}


### PR DESCRIPTION
Adds net_tls, which performs TLS handshakes and reports negotiated version, cipher suite, and certificate subject. Closes the encrypted-traffic gap - every other network module is plain HTTP, so SNI/JA3/cert-based detections had nothing to fire on. Maps to T1573.002.