### PR TITLE
fix: register evasion module and clean up plist parent directory

### DIFF
--- a/cmd/macnoise/main.go
+++ b/cmd/macnoise/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/0xv1n/macnoise/pkg/module"
 
 	_ "github.com/0xv1n/macnoise/modules/endpoint_security"
+	_ "github.com/0xv1n/macnoise/modules/evasion"
 	_ "github.com/0xv1n/macnoise/modules/file"
 	_ "github.com/0xv1n/macnoise/modules/network"
 	_ "github.com/0xv1n/macnoise/modules/plist"

--- a/modules/plist/create.go
+++ b/modules/plist/create.go
@@ -131,9 +131,14 @@ func (p *plistCreate) DryRun(params module.Params) []string {
 }
 
 func (p *plistCreate) Cleanup() error {
-	if p.createdPath != "" {
-		return os.Remove(p.createdPath)
+	if p.createdPath == "" {
+		return nil
 	}
+	if err := os.Remove(p.createdPath); err != nil {
+		return err
+	}
+	dir := filepath.Dir(p.createdPath)
+	_ = os.Remove(dir)
 	return nil
 }
 

--- a/modules/plist/create_cleanup_test.go
+++ b/modules/plist/create_cleanup_test.go
@@ -1,0 +1,56 @@
+package plistmod
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCleanup_RemovesEmptyParentDir(t *testing.T) {
+	base := t.TempDir()
+	subdir := filepath.Join(base, "macnoise_staging")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fpath := filepath.Join(subdir, "test.plist")
+	if err := os.WriteFile(fpath, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &plistCreate{createdPath: fpath}
+	if err := p.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, err := os.Stat(fpath); !os.IsNotExist(err) {
+		t.Error("plist file should be removed")
+	}
+	if _, err := os.Stat(subdir); !os.IsNotExist(err) {
+		t.Error("empty parent directory should be removed")
+	}
+}
+
+func TestCleanup_LeavesNonEmptyParentDir(t *testing.T) {
+	base := t.TempDir()
+	subdir := filepath.Join(base, "macnoise_staging")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fpath := filepath.Join(subdir, "test.plist")
+	other := filepath.Join(subdir, "other.txt")
+	if err := os.WriteFile(fpath, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(other, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &plistCreate{createdPath: fpath}
+	if err := p.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, err := os.Stat(subdir); os.IsNotExist(err) {
+		t.Error("non-empty parent directory should be preserved")
+	}
+}


### PR DESCRIPTION
## Summary

- Add missing blank import for `modules/evasion` so `evade_log_clear` actually registers at runtime
- Fix `plist_create` Cleanup to remove the empty parent directory that `MkdirAll` creates
- Add cross-platform unit tests proving the cleanup fix

## Test plan

- [x] `macnoise categories` shows evasion=1
- [x] `macnoise list --category evasion` lists evade_log_clear
- [x] Cleanup removes empty parent dir, preserves non-empty parent dir
- [x] Full test suite passes, linter clean