### PR TITLE
feat: lift run ID to runner and expose via module context

### DIFF
--- a/cmd/macnoise/main.go
+++ b/cmd/macnoise/main.go
@@ -38,6 +38,7 @@ var (
 	globalTimeout   int
 	globalAuditLog  string
 	globalConfig    string
+	globalRunID     string
 )
 
 var loadedConfig config.Config
@@ -82,6 +83,7 @@ EDR validation, and detection engineering.`,
 	root.PersistentFlags().IntVar(&globalTimeout, "timeout", 30, "Per-module timeout in seconds (0 = no timeout)")
 	root.PersistentFlags().StringVar(&globalAuditLog, "audit-log", "", "Write OCSF 1.7.0 JSONL audit records to file")
 	root.PersistentFlags().StringVar(&globalConfig, "config", "", "Config YAML file (default: none)")
+	root.PersistentFlags().StringVar(&globalRunID, "run-id", "", "Correlation ID for this run (auto-generated if omitted)")
 
 	root.AddCommand(
 		buildRun(),
@@ -137,11 +139,11 @@ func resolveAuditLogPath(scenarioAuditLog string) string {
 	return loadedConfig.AuditLog
 }
 
-func buildAuditLogger(path string) (*audit.Logger, func(), error) {
+func buildAuditLogger(path, runID string) (*audit.Logger, func(), error) {
 	if path == "" {
 		return nil, func() {}, nil
 	}
-	l, err := audit.NewLogger(path, version)
+	l, err := audit.NewLogger(path, version, runID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -179,7 +181,14 @@ func signalContext() (context.Context, context.CancelFunc) {
 	}
 }
 
-func buildRunOpts(auditLogger *audit.Logger) runner.Options {
+func resolveRunID() string {
+	if globalRunID != "" {
+		return globalRunID
+	}
+	return audit.GenerateRunID()
+}
+
+func buildRunOpts(auditLogger *audit.Logger, runID string) runner.Options {
 	timeout := time.Duration(globalTimeout) * time.Second
 	return runner.Options{
 		DryRun:    globalDryRun,
@@ -187,6 +196,7 @@ func buildRunOpts(auditLogger *audit.Logger) runner.Options {
 		Timeout:   timeout,
 		Verbose:   globalVerbose,
 		AuditLog:  auditLogger,
+		RunID:     runID,
 	}
 }
 
@@ -214,14 +224,17 @@ func buildRun() *cobra.Command {
 			}
 			defer closeEM()
 
-			auditLogger, closeAL, err := buildAuditLogger(resolveAuditLogPath(""))
+			runID := resolveRunID()
+			auditLogger, closeAL, err := buildAuditLogger(resolveAuditLogPath(""), runID)
 			if err != nil {
 				return err
 			}
 			defer closeAL()
 
+			fmt.Fprintf(os.Stderr, "run_id=%s\n", runID)
+
 			params := parseParams(paramFlags)
-			opts := buildRunOpts(auditLogger)
+			opts := buildRunOpts(auditLogger, runID)
 			ctx, stop := signalContext()
 			defer stop()
 
@@ -355,13 +368,16 @@ func buildScenario() *cobra.Command {
 				scenarioAuditLog = sc.AuditLog
 			}
 
-			auditLogger, closeAL, err := buildAuditLogger(resolveAuditLogPath(scenarioAuditLog))
+			runID := resolveRunID()
+			auditLogger, closeAL, err := buildAuditLogger(resolveAuditLogPath(scenarioAuditLog), runID)
 			if err != nil {
 				return err
 			}
 			defer closeAL()
 
-			opts := buildRunOpts(auditLogger)
+			fmt.Fprintf(os.Stderr, "run_id=%s\n", runID)
+
+			opts := buildRunOpts(auditLogger, runID)
 			ctx, stop := signalContext()
 			defer stop()
 

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -42,14 +42,19 @@ type Logger struct {
 }
 
 // NewLogger opens (or creates) path for append and returns a ready Logger.
-func NewLogger(path, version string) (*Logger, error) {
+// runID is the correlation identifier for this invocation; pass an empty
+// string to have one generated automatically.
+func NewLogger(path, version, runID string) (*Logger, error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("audit: open %s: %w", path, err)
 	}
+	if runID == "" {
+		runID = GenerateRunID()
+	}
 	return &Logger{
 		f:       f,
-		runID:   generateRunID(),
+		runID:   runID,
 		version: version,
 		actor:   currentActor(),
 		device:  currentDevice(),

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -15,7 +15,7 @@ func newTestLogger(t *testing.T) (*Logger, string) {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "audit.jsonl")
-	l, err := NewLogger(path, "test-version")
+	l, err := NewLogger(path, "test-version", "")
 	if err != nil {
 		t.Fatalf("NewLogger: %v", err)
 	}
@@ -317,6 +317,38 @@ func TestCorrelationUID_SameAcrossRecords(t *testing.T) {
 	}
 	if records[0].Metadata.CorrelationUID == "" {
 		t.Error("correlation_uid must not be empty")
+	}
+}
+
+func TestNewLogger_ExternalRunID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	l, err := NewLogger(path, "v1", "deadbeef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	info := module.ModuleInfo{Name: "test", Category: "network", Privileges: module.PrivilegeNone}
+	ev := module.TelemetryEvent{Category: "network", EventType: "tcp_connect", Success: true}
+	l.LogEvent(ev, info, module.Params{})
+	l.Close()
+
+	records := readRecords(t, path)
+	if records[0].Metadata.CorrelationUID != "deadbeef01234567" {
+		t.Errorf("correlation_uid = %q, want deadbeef01234567", records[0].Metadata.CorrelationUID)
+	}
+}
+
+func TestGenerateRunID_Format(t *testing.T) {
+	id := GenerateRunID()
+	if len(id) != 16 {
+		t.Errorf("RunID length = %d, want 16", len(id))
+	}
+	for _, c := range id {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			t.Fatalf("RunID contains non-hex char %q: %s", c, id)
+		}
 	}
 }
 

--- a/internal/audit/runid.go
+++ b/internal/audit/runid.go
@@ -5,7 +5,9 @@ import (
 	"encoding/hex"
 )
 
-func generateRunID() string {
+// GenerateRunID returns a 16-character hex string suitable for correlating
+// a macnoise run across audit records and host telemetry.
+func GenerateRunID() string {
 	b := make([]byte, 8)
 	if _, err := rand.Read(b); err != nil {
 		return "0000000000000000"

--- a/internal/runner/nocleanup_test.go
+++ b/internal/runner/nocleanup_test.go
@@ -54,7 +54,7 @@ func TestRunSingle_NoCleanupIsRecordedAsSkipped(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
-			logger, err := audit.NewLogger(auditPath, "test")
+			logger, err := audit.NewLogger(auditPath, "test", "")
 			if err != nil {
 				t.Fatalf("new audit logger: %v", err)
 			}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -24,6 +24,10 @@ type Options struct {
 	Timeout   time.Duration
 	Verbose   bool
 	AuditLog  *audit.Logger
+	// RunID is the correlation identifier for this invocation. Modules
+	// retrieve it via module.RunIDFromContext so they can fold it into
+	// artifact names, DNS labels, and command arguments.
+	RunID string
 }
 
 // RunSingle executes one module through its full lifecycle (prereqs → generate → cleanup).
@@ -64,10 +68,10 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 		auditEmit = opts.AuditLog.WrapEmitter(emit, info, params, &eventsEmitted)
 	}
 
-	runCtx := ctx
+	runCtx := module.ContextWithRunID(ctx, opts.RunID)
 	var cancel context.CancelFunc
 	if opts.Timeout > 0 {
-		runCtx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		runCtx, cancel = context.WithTimeout(runCtx, opts.Timeout)
 		defer cancel()
 	}
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -220,7 +220,7 @@ func TestRunScenarioAuditsInterrupt(t *testing.T) {
 	module.Register(gen)
 
 	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
-	logger, err := audit.NewLogger(auditPath, "test")
+	logger, err := audit.NewLogger(auditPath, "test", "")
 	if err != nil {
 		t.Fatalf("new audit logger: %v", err)
 	}
@@ -268,5 +268,33 @@ func TestRunScenarioAuditsInterrupt(t *testing.T) {
 	}
 	if got := scenarioRec["status_id"]; got != float64(2) {
 		t.Errorf("status_id = %v, want 2 (Failure) for an interrupted scenario", got)
+	}
+}
+
+type ctxCapturingGen struct {
+	mockGen
+	capturedRunID string
+}
+
+func (c *ctxCapturingGen) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	c.capturedRunID = module.RunIDFromContext(ctx)
+	return c.mockGen.Generate(ctx, params, emit)
+}
+
+func TestRunSingle_RunIDInContext(t *testing.T) {
+	gen := &ctxCapturingGen{
+		mockGen: mockGen{
+			name:   "ctx_test",
+			events: []module.TelemetryEvent{{Success: true, Category: "test", EventType: "test"}},
+		},
+	}
+
+	emit := func(module.TelemetryEvent) {}
+	opts := runner.Options{RunID: "test_run_id_1234"}
+	if err := runner.RunSingle(context.Background(), gen, module.Params{}, emit, opts); err != nil {
+		t.Fatal(err)
+	}
+	if gen.capturedRunID != "test_run_id_1234" {
+		t.Errorf("RunIDFromContext = %q, want test_run_id_1234", gen.capturedRunID)
 	}
 }

--- a/pkg/module/context.go
+++ b/pkg/module/context.go
@@ -1,0 +1,16 @@
+package module
+
+import "context"
+
+type runIDKey struct{}
+
+// ContextWithRunID returns a child context carrying the run ID.
+func ContextWithRunID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, runIDKey{}, id)
+}
+
+// RunIDFromContext returns the run ID from ctx, or "" if none is set.
+func RunIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(runIDKey{}).(string)
+	return v
+}

--- a/pkg/module/context_test.go
+++ b/pkg/module/context_test.go
@@ -1,0 +1,19 @@
+package module
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRunIDFromContext_RoundTrips(t *testing.T) {
+	ctx := ContextWithRunID(context.Background(), "abc123")
+	if got := RunIDFromContext(ctx); got != "abc123" {
+		t.Errorf("RunIDFromContext = %q, want abc123", got)
+	}
+}
+
+func TestRunIDFromContext_EmptyWhenUnset(t *testing.T) {
+	if got := RunIDFromContext(context.Background()); got != "" {
+		t.Errorf("RunIDFromContext on bare context = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Run ID now generated at the CLI layer so every invocation gets one, not just `--audit-log` runs
- Modules access it via `module.RunIDFromContext(ctx)` to fold into artifact names (day 3)
- `--run-id` flag lets an orchestrator supply a known correlation token
- Printed to stderr at run start (`run_id=<hex>`)

## Test plan

- [x] `macnoise run net_dns --dry-run` prints auto-generated run_id
- [x] `--run-id customtoken` overrides it
- [x] Audit log `correlation_uid` matches the supplied run ID
- [x] `RunIDFromContext` round-trips through runner context
- [x] Full test suite passes, linter clean