### PR TITLE
feat: fold run ID into module artifacts for host telemetry correlation

### DIFF
--- a/modules/file/create.go
+++ b/modules/file/create.go
@@ -42,10 +42,20 @@ func (f *fileCreate) ParamSpecs() []module.ParamSpec {
 
 func (f *fileCreate) CheckPrereqs() error { return nil }
 
+// stampedFileName builds the file name, folding the run ID in after the prefix
+// when one is set so a consumer can correlate the file back to the run.
+func stampedFileName(prefix, runID, ts string, i int) string {
+	if runID != "" {
+		return fmt.Sprintf("%s%s_%s%d.txt", prefix, runID, ts, i)
+	}
+	return fmt.Sprintf("%s%s%d.txt", prefix, ts, i)
+}
+
 func (f *fileCreate) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	baseDir := params.Get("base_dir", "/tmp/macnoise_test")
 	countStr := params.Get("count", "3")
 	prefix := params.Get("prefix", "mnfile_")
+	runID := module.RunIDFromContext(ctx)
 
 	count := 3
 	fmt.Sscanf(countStr, "%d", &count) //nolint:errcheck
@@ -66,7 +76,7 @@ func (f *fileCreate) Generate(ctx context.Context, params module.Params, emit mo
 		default:
 		}
 
-		fname := fmt.Sprintf("%s%s%d.txt", prefix, time.Now().Format("20060102_150405"), i)
+		fname := stampedFileName(prefix, runID, time.Now().Format("20060102_150405"), i)
 		fpath := filepath.Join(baseDir, fname)
 		content := fmt.Sprintf("MacNoise telemetry file %d created at %s\n", i, time.Now().UTC())
 

--- a/modules/file/stamp_test.go
+++ b/modules/file/stamp_test.go
@@ -1,0 +1,26 @@
+package file
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStampedFileName_WithRunID(t *testing.T) {
+	name := stampedFileName("mnfile_", "deadbeef01234567", "20060102_150405", 2)
+	if !strings.Contains(name, "deadbeef01234567") {
+		t.Errorf("run ID missing from file name: %s", name)
+	}
+	if !strings.HasPrefix(name, "mnfile_") {
+		t.Errorf("prefix not preserved: %s", name)
+	}
+	if !strings.HasSuffix(name, ".txt") {
+		t.Errorf("extension not preserved: %s", name)
+	}
+}
+
+func TestStampedFileName_WithoutRunID(t *testing.T) {
+	name := stampedFileName("mnfile_", "", "20060102_150405", 2)
+	if name != "mnfile_20060102_1504052.txt" {
+		t.Errorf("unstamped name = %q, want mnfile_20060102_1504052.txt", name)
+	}
+}

--- a/modules/network/dns_exfil.go
+++ b/modules/network/dns_exfil.go
@@ -77,15 +77,20 @@ func chunkExfilLabels(encoded string, max int) []string {
 }
 
 // exfilQueries builds the DNS names for exfiltration. Each name is
-// <chunk>.<seq>.<baseDomain>, with the chunk label capped at dnsLabelMax
-// and the total name at dnsNameMax. Chunks that would exceed the name
-// limit are dropped.
-func exfilQueries(payload, baseDomain string) []string {
+// <chunk>.<seq>.<baseDomain>, or <chunk>.<seq>.<runID>.<baseDomain> when a
+// run ID is set, so a consumer can correlate the queries back to the run
+// (the run ID is a cleartext label, not part of the base32 payload). The
+// chunk label is capped at dnsLabelMax and the total name at dnsNameMax;
+// chunks that would exceed the name limit are dropped.
+func exfilQueries(payload, baseDomain, runID string) []string {
 	encoded := encodeExfilPayload(payload)
 	chunks := chunkExfilLabels(encoded, dnsLabelMax)
 	queries := make([]string, 0, len(chunks))
 	for i, chunk := range chunks {
-		name := fmt.Sprintf("%s.%s.%s", chunk, fmt.Sprintf("%d", i), baseDomain)
+		name := fmt.Sprintf("%s.%d.%s", chunk, i, baseDomain)
+		if runID != "" {
+			name = fmt.Sprintf("%s.%d.%s.%s", chunk, i, runID, baseDomain)
+		}
 		if len(name) <= dnsNameMax {
 			queries = append(queries, name)
 		}
@@ -98,7 +103,7 @@ func (n *netDNSExfil) Generate(ctx context.Context, params module.Params, emit m
 	baseDomain := params.Get("base_domain", defaultExfilDomain)
 	info := n.Info()
 
-	queries := exfilQueries(payload, baseDomain)
+	queries := exfilQueries(payload, baseDomain, module.RunIDFromContext(ctx))
 	resolver := net.DefaultResolver
 	for i, qname := range queries {
 		select {
@@ -138,7 +143,7 @@ func (n *netDNSExfil) Generate(ctx context.Context, params module.Params, emit m
 func (n *netDNSExfil) DryRun(params module.Params) []string {
 	payload := params.Get("payload", "macnoise-exfil-test")
 	baseDomain := params.Get("base_domain", defaultExfilDomain)
-	queries := exfilQueries(payload, baseDomain)
+	queries := exfilQueries(payload, baseDomain, "")
 	steps := make([]string, len(queries))
 	for i, q := range queries {
 		steps[i] = fmt.Sprintf("DNS resolve: %s", q)

--- a/modules/network/dns_exfil_test.go
+++ b/modules/network/dns_exfil_test.go
@@ -46,7 +46,7 @@ func TestChunkExfilLabels_ShortInput(t *testing.T) {
 }
 
 func TestExfilQueries_DefaultPayload(t *testing.T) {
-	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain)
+	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain, "")
 	if len(queries) == 0 {
 		t.Fatal("expected at least one query")
 	}
@@ -65,7 +65,7 @@ func TestExfilQueries_DefaultPayload(t *testing.T) {
 }
 
 func TestExfilQueries_ContainsSequenceNumber(t *testing.T) {
-	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain)
+	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain, "")
 	for i, q := range queries {
 		seq := strings.SplitN(q, ".", 3)[1]
 		want := fmt.Sprintf("%d", i)
@@ -77,7 +77,7 @@ func TestExfilQueries_ContainsSequenceNumber(t *testing.T) {
 
 func TestExfilQueries_NameTooLong(t *testing.T) {
 	longDomain := strings.Repeat("x", 200) + ".invalid"
-	queries := exfilQueries("test", longDomain)
+	queries := exfilQueries("test", longDomain, "")
 	for _, q := range queries {
 		if len(q) > dnsNameMax {
 			t.Errorf("query exceeds DNS name max: %s", q)
@@ -85,10 +85,26 @@ func TestExfilQueries_NameTooLong(t *testing.T) {
 	}
 }
 
+func TestExfilQueries_RunIDLabel(t *testing.T) {
+	runID := "deadbeef01234567"
+	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain, runID)
+	if len(queries) == 0 {
+		t.Fatal("expected at least one query")
+	}
+	for i, q := range queries {
+		if !strings.Contains(q, "."+runID+".") {
+			t.Errorf("query %d missing cleartext run ID label: %s", i, q)
+		}
+		if !strings.HasSuffix(q, "."+runID+"."+defaultExfilDomain) {
+			t.Errorf("query %d: run ID label not positioned before base domain: %s", i, q)
+		}
+	}
+}
+
 func TestDNSExfilDryRunMatchesQueries(t *testing.T) {
 	mod := &netDNSExfil{}
 	steps := mod.DryRun(module.Params{})
-	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain)
+	queries := exfilQueries("macnoise-exfil-test", defaultExfilDomain, "")
 	if len(steps) != len(queries) {
 		t.Errorf("dry run listed %d steps, want %d", len(steps), len(queries))
 	}

--- a/modules/process/spawn.go
+++ b/modules/process/spawn.go
@@ -37,8 +37,18 @@ func (p *procSpawn) ParamSpecs() []module.ParamSpec {
 
 func (p *procSpawn) CheckPrereqs() error { return nil }
 
+// stampCommand appends the run ID as a shell comment. It is inert to execution
+// but lands in the process argv, where a consumer's EDR captures it and can
+// correlate the exec back to the run.
+func stampCommand(command, runID string) string {
+	if runID == "" {
+		return command
+	}
+	return command + " # mn:" + runID
+}
+
 func (p *procSpawn) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	command := params.Get("command", "echo 'Telemetry Payload Executed'")
+	command := stampCommand(params.Get("command", "echo 'Telemetry Payload Executed'"), module.RunIDFromContext(ctx))
 	info := p.Info()
 
 	ev := output.NewEvent(info, "process_spawn", false, fmt.Sprintf("spawning: sh -c %q", command))

--- a/modules/process/spawn_test.go
+++ b/modules/process/spawn_test.go
@@ -1,0 +1,26 @@
+package process
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStampCommand_WithRunID(t *testing.T) {
+	cmd := stampCommand("echo hi", "deadbeef01234567")
+	if !strings.Contains(cmd, "deadbeef01234567") {
+		t.Errorf("run ID missing from command: %s", cmd)
+	}
+	if !strings.HasPrefix(cmd, "echo hi") {
+		t.Errorf("original command not preserved: %s", cmd)
+	}
+	if !strings.Contains(cmd, "#") {
+		t.Errorf("run ID should be a shell comment: %s", cmd)
+	}
+}
+
+func TestStampCommand_WithoutRunID(t *testing.T) {
+	cmd := stampCommand("echo hi", "")
+	if cmd != "echo hi" {
+		t.Errorf("unstamped command = %q, want %q", cmd, "echo hi")
+	}
+}

--- a/modules/service/cron.go
+++ b/modules/service/cron.go
@@ -65,12 +65,22 @@ func classifyCrontabList(out []byte, err error) (existing string, safe bool) {
 	return "", false
 }
 
+// cronMarker returns the trailing comment tagging the entry as macnoise's,
+// folding the run ID in when set so a consumer can correlate the crontab
+// change back to the run.
+func cronMarker(runID string) string {
+	if runID == "" {
+		return "# macnoise"
+	}
+	return "# macnoise " + runID
+}
+
 func (s *svcCron) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	schedule := params.Get("schedule", "*/5 * * * *")
 	command := params.Get("command", "/usr/bin/true")
 	info := s.Info()
 
-	marker := "# macnoise"
+	marker := cronMarker(module.RunIDFromContext(ctx))
 	entry := fmt.Sprintf("%s %s %s", schedule, command, marker)
 
 	listEv := output.NewEvent(info, "cron_job_list", false, "listing current crontab entries")

--- a/modules/service/launch_agent.go
+++ b/modules/service/launch_agent.go
@@ -47,8 +47,18 @@ func (s *svcLaunchAgent) CheckPrereqs() error {
 	return nil
 }
 
+// stampLabel appends the run ID as a trailing reverse-DNS component so the
+// plist filename, Label key, and launchctl service target all carry it,
+// letting a consumer correlate the persistence back to the run.
+func stampLabel(label, runID string) string {
+	if runID == "" {
+		return label
+	}
+	return label + "." + runID
+}
+
 func (s *svcLaunchAgent) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	label := params.Get("label", "com.macnoise.testagent")
+	label := stampLabel(params.Get("label", "com.macnoise.testagent"), module.RunIDFromContext(ctx))
 	program := params.Get("program", "/usr/bin/true")
 	info := s.Info()
 

--- a/modules/service/stamp_test.go
+++ b/modules/service/stamp_test.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStampLabel_WithRunID(t *testing.T) {
+	label := stampLabel("com.macnoise.testagent", "deadbeef01234567")
+	if label != "com.macnoise.testagent.deadbeef01234567" {
+		t.Errorf("stamped label = %q, want com.macnoise.testagent.deadbeef01234567", label)
+	}
+}
+
+func TestStampLabel_WithoutRunID(t *testing.T) {
+	label := stampLabel("com.macnoise.testagent", "")
+	if label != "com.macnoise.testagent" {
+		t.Errorf("unstamped label = %q, want com.macnoise.testagent", label)
+	}
+}
+
+func TestCronMarker_WithRunID(t *testing.T) {
+	marker := cronMarker("deadbeef01234567")
+	if !strings.HasPrefix(marker, "# macnoise") {
+		t.Errorf("marker lost its macnoise tag: %s", marker)
+	}
+	if !strings.Contains(marker, "deadbeef01234567") {
+		t.Errorf("run ID missing from marker: %s", marker)
+	}
+}
+
+func TestCronMarker_WithoutRunID(t *testing.T) {
+	if marker := cronMarker(""); marker != "# macnoise" {
+		t.Errorf("unstamped marker = %q, want # macnoise", marker)
+	}
+}


### PR DESCRIPTION
Builds on the run-token plumbing (#51): modules that create observable artifacts now stamp the run ID into them - file_create filename, net_dns_exfil cleartext DNS label, proc_spawn argv comment, svc_launch_agent plist label, svc_cron marker - so a consumer can attribute host telemetry back to a specific run. Behavior is unchanged when no run ID is set.