### PR TITLE
feat: extend run ID stamping to all artifact-producing modules

### DIFF
--- a/modules/endpoint_security/es_file.go
+++ b/modules/endpoint_security/es_file.go
@@ -43,7 +43,7 @@ func (e *esFile) ParamSpecs() []module.ParamSpec {
 func (e *esFile) CheckPrereqs() error { return nil }
 
 func (e *esFile) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	workDir := params.Get("work_dir", "/tmp/macnoise_es")
+	workDir := module.TagPath(params.Get("work_dir", "/tmp/macnoise_es"), module.RunIDFromContext(ctx))
 	info := e.Info()
 
 	if err := os.MkdirAll(workDir, 0o755); err != nil {

--- a/modules/endpoint_security/es_mount.go
+++ b/modules/endpoint_security/es_mount.go
@@ -107,7 +107,8 @@ func detachArgs(target string) []string {
 }
 
 func (e *esMount) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	workDir := params.Get("work_dir", "/tmp/macnoise_es")
+	runID := module.RunIDFromContext(ctx)
+	workDir := module.TagPath(params.Get("work_dir", "/tmp/macnoise_es"), runID)
 	info := e.Info()
 
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
@@ -155,7 +156,7 @@ func (e *esMount) Generate(ctx context.Context, params module.Params, emit modul
 	mountEv.Message = fmt.Sprintf("mounted %s at %s (ES_EVENT_TYPE_NOTIFY_MOUNT)", dmgPath, res.MountPoint)
 	emit(output.WithDetails(mountEv, mountDetails))
 
-	e.emitVolumeExec(ctx, info, emit)
+	e.emitVolumeExec(ctx, info, emit, runID)
 
 	unmountEv := output.NewEvent(info, "es_notify_unmount", false, fmt.Sprintf("unmounting %s (triggers ES_EVENT_TYPE_NOTIFY_UNMOUNT)", res.MountPoint))
 	if out, err := exec.CommandContext(ctx, "hdiutil", detachArgs(res.MountPoint)...).CombinedOutput(); err != nil {
@@ -178,12 +179,16 @@ func (e *esMount) Generate(ctx context.Context, params module.Params, emit modul
 // the half that makes T1204.002 accurate: a bare mount is weak signal, while a
 // process launched from a /Volumes path is what AMOS-style delivery actually
 // looks like on an endpoint.
-func (e *esMount) emitVolumeExec(ctx context.Context, info module.ModuleInfo, emit module.EventEmitter) {
+func (e *esMount) emitVolumeExec(ctx context.Context, info module.ModuleInfo, emit module.EventEmitter, runID string) {
 	payload := path.Join(e.mountPoint, payloadName)
 	ev := output.NewEvent(info, "es_volume_exec", false, fmt.Sprintf("executing %s (triggers ES_EVENT_TYPE_NOTIFY_EXEC)", payload))
 	details := map[string]any{"payload": payload, "mount_point": e.mountPoint, "es_event": "ES_EVENT_TYPE_NOTIFY_EXEC"}
 
-	script := "#!/bin/sh\necho macnoise_dmg_payload\n"
+	echoArg := "macnoise_dmg_payload"
+	if runID != "" {
+		echoArg += "_" + runID
+	}
+	script := "#!/bin/sh\necho " + echoArg + "\n"
 	if err := os.WriteFile(payload, []byte(script), 0o755); err != nil {
 		ev = output.WithError(ev, err)
 		emit(output.WithDetails(ev, details))

--- a/modules/endpoint_security/es_process.go
+++ b/modules/endpoint_security/es_process.go
@@ -37,9 +37,14 @@ func (e *esProcess) CheckPrereqs() error { return nil }
 // buildExecChainArgs nests depth-1 levels of `sh -c '"$@"' sh <rest>` around
 // a final `echo es_exit`. The '"$@"' script just re-execs its own
 // positional params, so nesting threads through argv with no shell-quote
-// escaping needed.
-func buildExecChainArgs(depth int) []string {
-	args := []string{"echo", "es_exit"}
+// escaping needed. The run ID rides on the leaf echo argument so it lands in
+// the ES_EVENT_TYPE_NOTIFY_EXEC argv a consumer captures.
+func buildExecChainArgs(depth int, runID string) []string {
+	leaf := "es_exit"
+	if runID != "" {
+		leaf = "es_exit_" + runID
+	}
+	args := []string{"echo", leaf}
 	for i := 0; i < depth-1; i++ {
 		wrapped := make([]string, 0, len(args)+4)
 		wrapped = append(wrapped, "sh", "-c", `"$@"`, "sh")
@@ -62,7 +67,7 @@ func (e *esProcess) Generate(ctx context.Context, params module.Params, emit mod
 	ev := output.NewEvent(info, "es_exec_chain", false,
 		fmt.Sprintf("executing %d-deep process fork/exec chain", depth))
 
-	chainArgs := buildExecChainArgs(depth)
+	chainArgs := buildExecChainArgs(depth, module.RunIDFromContext(ctx))
 	cmd := exec.CommandContext(ctx, chainArgs[0], chainArgs[1:]...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/modules/endpoint_security/es_process_exec_test.go
+++ b/modules/endpoint_security/es_process_exec_test.go
@@ -17,14 +17,14 @@ func TestBuildExecChainArgs_ActuallyExecutes(t *testing.T) {
 	}
 
 	for _, depth := range []int{3, 5, 10} {
-		args := buildExecChainArgs(depth)
+		args := buildExecChainArgs(depth, "abc123")
 		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
 		if err != nil {
 			t.Errorf("depth=%d: exec failed: %v (output: %q)", depth, err, out)
 			continue
 		}
-		if got := strings.TrimSpace(string(out)); got != "es_exit" {
-			t.Errorf("depth=%d: output = %q, want %q", depth, got, "es_exit")
+		if got := strings.TrimSpace(string(out)); got != "es_exit_abc123" {
+			t.Errorf("depth=%d: output = %q, want %q", depth, got, "es_exit_abc123")
 		}
 	}
 }

--- a/modules/endpoint_security/es_process_test.go
+++ b/modules/endpoint_security/es_process_test.go
@@ -18,7 +18,7 @@ func TestBuildExecChainArgs_Shape(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		args := buildExecChainArgs(tt.depth)
+		args := buildExecChainArgs(tt.depth, "")
 		if len(args) != tt.wantLen {
 			t.Errorf("depth=%d: len(args) = %d, want %d (%v)", tt.depth, len(args), tt.wantLen, args)
 		}
@@ -42,7 +42,7 @@ func TestBuildExecChainArgs_Shape(t *testing.T) {
 func TestBuildExecChainArgs_LinearGrowth(t *testing.T) {
 	prevLen := -1
 	for depth := 1; depth <= 10; depth++ {
-		args := buildExecChainArgs(depth)
+		args := buildExecChainArgs(depth, "")
 		if prevLen >= 0 {
 			grew := len(args) - prevLen
 			if grew != 4 {
@@ -54,9 +54,20 @@ func TestBuildExecChainArgs_LinearGrowth(t *testing.T) {
 }
 
 func TestBuildExecChainArgs_NoUserInputInScript(t *testing.T) {
-	for _, a := range buildExecChainArgs(5) {
+	for _, a := range buildExecChainArgs(5, "") {
 		if strings.Contains(a, "'") {
 			t.Errorf("argv element %q contains a raw single quote", a)
 		}
+	}
+}
+
+func TestBuildExecChainArgs_RunIDInLeaf(t *testing.T) {
+	args := buildExecChainArgs(3, "deadbeef01234567")
+	leaf := args[len(args)-1]
+	if !strings.Contains(leaf, "deadbeef01234567") {
+		t.Errorf("leaf echo arg %q missing run ID", leaf)
+	}
+	if args[len(args)-2] != "echo" {
+		t.Errorf("chain must still end in echo, got %v", args[len(args)-2:])
 	}
 }

--- a/modules/evasion/log_clear.go
+++ b/modules/evasion/log_clear.go
@@ -137,7 +137,7 @@ func clearHistory(info module.ModuleInfo, stageDir string) module.TelemetryEvent
 
 func (e *evadeLogClear) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	info := e.Info()
-	stageDir := params.Get("stage_dir", defaultEvasionStageDir)
+	stageDir := module.TagPath(params.Get("stage_dir", defaultEvasionStageDir), module.RunIDFromContext(ctx))
 	if err := os.MkdirAll(stageDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", stageDir, err)
 	}

--- a/modules/file/archive.go
+++ b/modules/file/archive.go
@@ -43,8 +43,9 @@ func (f *fileArchive) ParamSpecs() []module.ParamSpec {
 func (f *fileArchive) CheckPrereqs() error { return nil }
 
 func (f *fileArchive) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	sourceDir := params.Get("source_dir", "/tmp/macnoise_archive_src")
-	outputPath := params.Get("output_path", "/tmp/macnoise_archive.zip")
+	runID := module.RunIDFromContext(ctx)
+	sourceDir := module.TagPath(params.Get("source_dir", "/tmp/macnoise_archive_src"), runID)
+	outputPath := module.TagPath(params.Get("output_path", "/tmp/macnoise_archive.zip"), runID)
 	tool := params.Get("tool", "zip")
 	f.sourceDir = sourceDir
 	f.outputPath = outputPath

--- a/modules/file/hide.go
+++ b/modules/file/hide.go
@@ -45,7 +45,7 @@ func (f *fileHide) ParamSpecs() []module.ParamSpec {
 func (f *fileHide) CheckPrereqs() error { return nil }
 
 func (f *fileHide) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	workDir := params.Get("work_dir", "/tmp/macnoise_hide")
+	workDir := module.TagPath(params.Get("work_dir", "/tmp/macnoise_hide"), module.RunIDFromContext(ctx))
 	f.workDir = workDir
 	info := f.Info()
 

--- a/modules/file/keychain_copy.go
+++ b/modules/file/keychain_copy.go
@@ -231,7 +231,7 @@ func (f *fileKeychainCopy) Generate(ctx context.Context, params module.Params, e
 		return fmt.Errorf("cannot determine home directory: %w", err)
 	}
 
-	stageDir := params.Get("stage_dir", defaultKeychainStageDir)
+	stageDir := module.TagPath(params.Get("stage_dir", defaultKeychainStageDir), module.RunIDFromContext(ctx))
 	if err := os.MkdirAll(stageDir, 0o700); err != nil {
 		return fmt.Errorf("mkdir %s: %w", stageDir, err)
 	}

--- a/modules/file/modify.go
+++ b/modules/file/modify.go
@@ -42,8 +42,12 @@ func (f *fileModify) ParamSpecs() []module.ParamSpec {
 func (f *fileModify) CheckPrereqs() error { return nil }
 
 func (f *fileModify) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	targetPath := params.Get("target_path", "/tmp/macnoise_modify_target.txt")
+	runID := module.RunIDFromContext(ctx)
+	targetPath := module.TagPath(params.Get("target_path", "/tmp/macnoise_modify_target.txt"), runID)
 	content := params.Get("content", "macnoise modification")
+	if runID != "" {
+		content += " mn:" + runID
+	}
 	info := f.Info()
 
 	f.targetPath = targetPath

--- a/modules/network/beacon.go
+++ b/modules/network/beacon.go
@@ -62,7 +62,7 @@ func jitterInterval(base time.Duration, jitterPct int, rnd *rand.Rand) time.Dura
 func (c *c2Beacon) CheckPrereqs() error { return nil }
 
 func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	target := params.Get("target", "http://example.com")
+	target := tagURL(params.Get("target", "http://example.com"), module.RunIDFromContext(ctx))
 	countStr := params.Get("count", "3")
 	intervalStr := params.Get("interval", "2")
 	jitterStr := params.Get("jitter", "0")

--- a/modules/network/connect.go
+++ b/modules/network/connect.go
@@ -63,7 +63,7 @@ func (n *netConnect) Generate(ctx context.Context, params module.Params, emit mo
 		emit(ev)
 	}
 
-	url := fmt.Sprintf("http://%s", address)
+	url := tagURL(fmt.Sprintf("http://%s", address), module.RunIDFromContext(ctx))
 	httpEv := output.NewEvent(info, "http_get", false, fmt.Sprintf("HTTP GET %s", url))
 	client := http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Get(url)

--- a/modules/network/exfil.go
+++ b/modules/network/exfil.go
@@ -40,7 +40,7 @@ func (n *netExfil) ParamSpecs() []module.ParamSpec {
 func (n *netExfil) CheckPrereqs() error { return nil }
 
 func (n *netExfil) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	target := params.Get("target", "http://127.0.0.1:8080/upload")
+	target := tagURL(params.Get("target", "http://127.0.0.1:8080/upload"), module.RunIDFromContext(ctx))
 	payloadSizeStr := params.Get("payload_size", "4096")
 	contentType := params.Get("content_type", "application/octet-stream")
 	info := n.Info()

--- a/modules/network/listen.go
+++ b/modules/network/listen.go
@@ -57,6 +57,11 @@ func (n *netListen) Generate(ctx context.Context, params module.Params, emit mod
 	ev = output.WithDetails(ev, map[string]any{"address": address})
 	emit(ev)
 
+	payload := "TELEMETRY_PING"
+	if runID := module.RunIDFromContext(ctx); runID != "" {
+		payload += " mn:" + runID
+	}
+
 	go func() {
 		time.Sleep(200 * time.Millisecond)
 		target := net.JoinHostPort("127.0.0.1", port)
@@ -64,7 +69,7 @@ func (n *netListen) Generate(ctx context.Context, params module.Params, emit mod
 		if err != nil {
 			return
 		}
-		conn.Write([]byte("TELEMETRY_PING")) //nolint:errcheck
+		conn.Write([]byte(payload)) //nolint:errcheck
 		_ = conn.Close()
 	}()
 

--- a/modules/network/runtag.go
+++ b/modules/network/runtag.go
@@ -1,0 +1,20 @@
+package network
+
+import "net/url"
+
+// tagURL sets a mn=<runID> query parameter on rawURL so a consumer can
+// correlate the request back to the run. Returns rawURL unchanged when runID
+// is empty or the URL cannot be parsed.
+func tagURL(rawURL, runID string) string {
+	if runID == "" {
+		return rawURL
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	q.Set("mn", runID)
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/modules/network/runtag_test.go
+++ b/modules/network/runtag_test.go
@@ -1,0 +1,38 @@
+package network
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestTagURL_AddsRunID(t *testing.T) {
+	got := tagURL("http://example.com/path", "deadbeef01234567")
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("result is not a valid URL: %v", err)
+	}
+	if u.Query().Get("mn") != "deadbeef01234567" {
+		t.Errorf("mn query param = %q, want deadbeef01234567 (%s)", u.Query().Get("mn"), got)
+	}
+	if !strings.HasPrefix(got, "http://example.com/path") {
+		t.Errorf("base URL not preserved: %s", got)
+	}
+}
+
+func TestTagURL_PreservesExistingQuery(t *testing.T) {
+	got := tagURL("http://example.com/?a=1", "abc")
+	u, _ := url.Parse(got)
+	if u.Query().Get("a") != "1" {
+		t.Errorf("existing query dropped: %s", got)
+	}
+	if u.Query().Get("mn") != "abc" {
+		t.Errorf("run ID not added: %s", got)
+	}
+}
+
+func TestTagURL_EmptyRunIDUnchanged(t *testing.T) {
+	if got := tagURL("http://example.com", ""); got != "http://example.com" {
+		t.Errorf("empty run ID should leave URL unchanged, got %s", got)
+	}
+}

--- a/modules/plist/create.go
+++ b/modules/plist/create.go
@@ -46,8 +46,12 @@ func (p *plistCreate) ParamSpecs() []module.ParamSpec {
 func (p *plistCreate) CheckPrereqs() error { return nil }
 
 func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	outPath := params.Get("output_path", "/tmp/macnoise_test.plist")
+	runID := module.RunIDFromContext(ctx)
+	outPath := module.TagPath(params.Get("output_path", "/tmp/macnoise_test.plist"), runID)
 	bundleID := params.Get("bundle_id", "com.macnoise.test")
+	if runID != "" {
+		bundleID += "." + runID
+	}
 	mode := params.Get("mode", "bundle")
 	info := p.Info()
 

--- a/modules/plist/modify.go
+++ b/modules/plist/modify.go
@@ -95,6 +95,9 @@ func (p *plistModify) CheckPrereqs() error {
 
 func (p *plistModify) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	domain := params.Get("domain", "com.macnoise.test")
+	if runID := module.RunIDFromContext(ctx); runID != "" {
+		domain += "." + runID
+	}
 	key := params.Get("key", "MacnoiseTest")
 	value := params.Get("value", "true")
 	info := p.Info()

--- a/modules/process/gatekeeper.go
+++ b/modules/process/gatekeeper.go
@@ -45,7 +45,8 @@ func (p *procGatekeeper) ParamSpecs() []module.ParamSpec {
 func (p *procGatekeeper) CheckPrereqs() error { return nil }
 
 func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	targetPath := params.Get("target_path", "/tmp/macnoise_gatekeeper_test")
+	runID := module.RunIDFromContext(ctx)
+	targetPath := module.TagPath(params.Get("target_path", "/tmp/macnoise_gatekeeper_test"), runID)
 	p.targetPath = targetPath
 	info := p.Info()
 
@@ -56,8 +57,14 @@ func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emi
 		return err
 	}
 
+	// The quarantine value's agent field carries the run ID so a consumer can
+	// correlate the xattr back to the run.
+	quarantineVal := "0081;00000000;macnoise;"
+	if runID != "" {
+		quarantineVal = "0081;00000000;macnoise-" + runID + ";"
+	}
 	setEv := output.NewEvent(info, "xattr_quarantine_set", false, fmt.Sprintf("setting quarantine xattr on %s", targetPath))
-	setOut, setErr := exec.CommandContext(ctx, "xattr", "-w", "com.apple.quarantine", "0081;00000000;macnoise;", targetPath).CombinedOutput()
+	setOut, setErr := exec.CommandContext(ctx, "xattr", "-w", "com.apple.quarantine", quarantineVal, targetPath).CombinedOutput()
 	if setErr != nil {
 		setEv = output.WithError(setEv, fmt.Errorf("%v: %s", setErr, setOut))
 		emit(setEv)

--- a/modules/process/inject.go
+++ b/modules/process/inject.go
@@ -82,7 +82,7 @@ func classifyInjection(dylibExists bool, stderr string) injectOutcome {
 }
 
 func (p *procInject) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	dylibPath := params.Get("dylib_path", "/tmp/macnoise_inject.dylib")
+	dylibPath := module.TagPath(params.Get("dylib_path", "/tmp/macnoise_inject.dylib"), module.RunIDFromContext(ctx))
 	targetBin := params.Get("target", "")
 	if targetBin == "" {
 		var err error

--- a/modules/process/osascript.go
+++ b/modules/process/osascript.go
@@ -74,9 +74,22 @@ func (p *procOsascript) ParamSpecs() []module.ParamSpec {
 
 func (p *procOsascript) CheckPrereqs() error { return nil }
 
+// stampScript appends the run ID as a language-appropriate comment so it lands
+// in the osascript argv (what detection keys on) without altering execution.
+func stampScript(script, language, runID string) string {
+	if runID == "" {
+		return script
+	}
+	comment := "-- mn:" + runID
+	if strings.EqualFold(language, "JavaScript") {
+		comment = "// mn:" + runID
+	}
+	return script + "\n" + comment
+}
+
 func (p *procOsascript) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	script := params.Get("script", `display notification "macnoise telemetry" with title "MacNoise"`)
 	language := params.Get("language", "AppleScript")
+	script := stampScript(params.Get("script", `display notification "macnoise telemetry" with title "MacNoise"`), language, module.RunIDFromContext(ctx))
 	info := p.Info()
 
 	ev := output.NewEvent(info, "osascript_exec", false, fmt.Sprintf("executing %s via osascript", language))

--- a/modules/process/signal.go
+++ b/modules/process/signal.go
@@ -40,7 +40,7 @@ func (p *procSignal) ParamSpecs() []module.ParamSpec {
 func (p *procSignal) CheckPrereqs() error { return nil }
 
 func (p *procSignal) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	targetCmd := params.Get("target_command", "sleep 30")
+	targetCmd := stampCommand(params.Get("target_command", "sleep 30"), module.RunIDFromContext(ctx))
 	info := p.Info()
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", targetCmd)

--- a/modules/service/launch_daemon.go
+++ b/modules/service/launch_daemon.go
@@ -46,7 +46,7 @@ func (s *svcLaunchDaemon) CheckPrereqs() error {
 }
 
 func (s *svcLaunchDaemon) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	label := params.Get("label", "com.macnoise.testdaemon")
+	label := stampLabel(params.Get("label", "com.macnoise.testdaemon"), module.RunIDFromContext(ctx))
 	program := params.Get("program", "/usr/bin/true")
 	info := s.Info()
 

--- a/modules/service/login_item.go
+++ b/modules/service/login_item.go
@@ -117,6 +117,9 @@ func parseLoginItemNames(out string) []string {
 
 func (s *svcLoginItem) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	name := params.Get("name", "MacNoiseLoginItem")
+	if runID := module.RunIDFromContext(ctx); runID != "" {
+		name += "_" + runID
+	}
 	targetPath := params.Get("path", "/usr/bin/true")
 	info := s.Info()
 	s.name = name

--- a/modules/service/shell_profile.go
+++ b/modules/service/shell_profile.go
@@ -45,7 +45,6 @@ func (s *svcShellProfile) ParamSpecs() []module.ParamSpec {
 func (s *svcShellProfile) CheckPrereqs() error { return nil }
 
 func (s *svcShellProfile) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	_ = ctx
 	target := params.Get("target", "~/.zshrc")
 	payload := params.Get("payload", "export MACNOISE_PERSIST=1")
 	info := s.Info()
@@ -59,7 +58,13 @@ func (s *svcShellProfile) Generate(ctx context.Context, params module.Params, em
 	}
 	s.targetFile = target
 
-	block := fmt.Sprintf("\n%s\n%s\n%s\n", shellProfileMarkerStart, payload, shellProfileMarkerEnd)
+	// The run ID rides on the start marker line (Cleanup still matches on the
+	// constant prefix) so a consumer can correlate the profile change.
+	startMarker := shellProfileMarkerStart
+	if runID := module.RunIDFromContext(ctx); runID != "" {
+		startMarker += " mn:" + runID
+	}
+	block := fmt.Sprintf("\n%s\n%s\n%s\n", startMarker, payload, shellProfileMarkerEnd)
 
 	ev := output.NewEvent(info, "shell_profile_modify", false, fmt.Sprintf("appending persistence marker to %s", target))
 	f, err := os.OpenFile(target, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)

--- a/modules/tcc/screen_recording.go
+++ b/modules/tcc/screen_recording.go
@@ -61,7 +61,11 @@ func (t *tccScreenRecording) Generate(ctx context.Context, params module.Params,
 	// deleted immediately. Contents are never read or emitted: the goal is to
 	// generate the screen-capture telemetry a real stealer would, not to
 	// collect the screen, the same discard posture as the credential modules.
-	f, err := os.CreateTemp("", "mn_screencap_*.png")
+	prefix := "mn_screencap_"
+	if runID := module.RunIDFromContext(ctx); runID != "" {
+		prefix += runID + "_"
+	}
+	f, err := os.CreateTemp("", prefix+"*.png")
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
 	}

--- a/pkg/module/runtag.go
+++ b/pkg/module/runtag.go
@@ -1,0 +1,25 @@
+package module
+
+import (
+	"path"
+	"strings"
+)
+
+// TagPath folds the run ID into the base name of a filesystem path, before the
+// extension, so a consumer can correlate the created artifact back to the run.
+// Returns p unchanged when id is empty. Paths are treated as slash-separated
+// (macnoise's artifact paths always are), so results are stable across OSes.
+//
+// Examples:
+//
+//	TagPath("/tmp/macnoise_test.plist", "abc") -> "/tmp/macnoise_test_abc.plist"
+//	TagPath("/tmp/macnoise_es", "abc")         -> "/tmp/macnoise_es_abc"
+func TagPath(p, id string) string {
+	if id == "" {
+		return p
+	}
+	dir, base := path.Split(p)
+	ext := path.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	return dir + stem + "_" + id + ext
+}

--- a/pkg/module/runtag_test.go
+++ b/pkg/module/runtag_test.go
@@ -1,0 +1,24 @@
+package module
+
+import "testing"
+
+func TestTagPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		id   string
+		want string
+	}{
+		{"file with extension", "/tmp/macnoise_test.plist", "abc", "/tmp/macnoise_test_abc.plist"},
+		{"directory no extension", "/tmp/macnoise_es", "abc", "/tmp/macnoise_es_abc"},
+		{"empty id unchanged", "/tmp/macnoise_test.plist", "", "/tmp/macnoise_test.plist"},
+		{"bare filename", "report.zip", "xyz", "report_xyz.zip"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TagPath(tt.path, tt.id); got != tt.want {
+				t.Errorf("TagPath(%q, %q) = %q, want %q", tt.path, tt.id, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Completes the correlation coverage started in #52: every module that creates an observable artifact now folds the run ID into it, via a new shared module.TagPath helper for filesystem paths plus per-category stamping for URLs, argv, service labels, plist domains, and markers. Read-only probe modules are exempt and behavior is unchanged when no run ID is set.