### PR TITLE
feat: emit machine-readable module catalog via list --format jsonl

### DIFF
--- a/cmd/macnoise/catalog_test.go
+++ b/cmd/macnoise/catalog_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// list --format jsonl must emit one valid CatalogEntry per registered module,
+// so a consumer can enumerate the module set programmatically.
+func TestListJSONLCatalog(t *testing.T) {
+	globalFormat = "jsonl"
+	t.Cleanup(func() { globalFormat = "human" })
+
+	cmd := buildList()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("list --format jsonl: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != len(module.All()) {
+		t.Fatalf("emitted %d catalog lines, want %d registered modules", len(lines), len(module.All()))
+	}
+
+	for i, line := range lines {
+		var e module.CatalogEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("line %d is not valid JSON: %v\n%s", i, err, line)
+			continue
+		}
+		if e.Name == "" || e.Category == "" {
+			t.Errorf("line %d missing name/category: %s", i, line)
+		}
+	}
+}
+
+// A bad --format must be rejected rather than silently falling back to the
+// human table.
+func TestListRejectsBadFormat(t *testing.T) {
+	globalFormat = "garbage"
+	t.Cleanup(func() { globalFormat = "human" })
+
+	cmd := buildList()
+	if err := cmd.RunE(cmd, nil); err == nil {
+		t.Error("expected an error for an invalid --format, got nil")
+	}
+}

--- a/cmd/macnoise/main.go
+++ b/cmd/macnoise/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
@@ -275,12 +276,28 @@ func buildList() *cobra.Command {
 		Use:   "list",
 		Short: "List available telemetry modules",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			format, err := parseFormat(globalFormat)
+			if err != nil {
+				return err
+			}
+
 			var gens []module.Generator
 			if catFilter != "" {
 				gens = module.ByCategory(module.Category(catFilter))
 			} else {
 				gens = module.All()
 			}
+
+			if format == output.FormatJSONL {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				for _, g := range gens {
+					if err := enc.Encode(module.NewCatalogEntry(g)); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+
 			if len(gens) == 0 {
 				fmt.Println("No modules found.")
 				return nil

--- a/pkg/module/catalog.go
+++ b/pkg/module/catalog.go
@@ -1,0 +1,75 @@
+package module
+
+// CatalogEntry is the machine-readable description of a module emitted by
+// `macnoise list --format jsonl`. It lets a consumer discover modules, their
+// ATT&CK mappings, and parameters without parsing the human-readable table.
+//
+// It intentionally mirrors ModuleInfo and ParamSpec into its own JSON shape
+// rather than tagging those shared structs, so the telemetry event schema
+// (which already serialises ModuleInfo.MITRE) is left untouched.
+type CatalogEntry struct {
+	Name        string         `json:"name"`
+	Category    Category       `json:"category"`
+	Description string         `json:"description"`
+	Privileges  Privilege      `json:"privileges"`
+	MinMacOS    string         `json:"min_macos,omitempty"`
+	Tags        []string       `json:"tags,omitempty"`
+	MITRE       []CatalogMITRE `json:"mitre,omitempty"`
+	Params      []CatalogParam `json:"params,omitempty"`
+}
+
+// CatalogMITRE is one ATT&CK reference in a CatalogEntry. SubTechnique is the
+// fully-qualified sub-technique ID (e.g. "T1071.001"), empty when the mapping
+// is at technique granularity.
+type CatalogMITRE struct {
+	Technique    string `json:"technique"`
+	SubTechnique string `json:"sub_technique,omitempty"`
+	Name         string `json:"name"`
+}
+
+// CatalogParam is one parameter in a CatalogEntry.
+type CatalogParam struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Required    bool   `json:"required"`
+	Default     string `json:"default,omitempty"`
+	Example     string `json:"example,omitempty"`
+}
+
+// NewCatalogEntry builds the catalog view of a module from its Info and
+// parameter specs.
+func NewCatalogEntry(g Generator) CatalogEntry {
+	info := g.Info()
+
+	mitre := make([]CatalogMITRE, 0, len(info.MITRE))
+	for _, m := range info.MITRE {
+		cm := CatalogMITRE{Technique: m.Technique, Name: m.Name}
+		if m.SubTech != "" {
+			cm.SubTechnique = m.Technique + m.SubTech
+		}
+		mitre = append(mitre, cm)
+	}
+
+	specs := g.ParamSpecs()
+	params := make([]CatalogParam, 0, len(specs))
+	for _, s := range specs {
+		params = append(params, CatalogParam{
+			Name:        s.Name,
+			Description: s.Description,
+			Required:    s.Required,
+			Default:     s.DefaultValue,
+			Example:     s.Example,
+		})
+	}
+
+	return CatalogEntry{
+		Name:        info.Name,
+		Category:    info.Category,
+		Description: info.Description,
+		Privileges:  info.Privileges,
+		MinMacOS:    info.MinMacOS,
+		Tags:        info.Tags,
+		MITRE:       mitre,
+		Params:      params,
+	}
+}

--- a/pkg/module/catalog_test.go
+++ b/pkg/module/catalog_test.go
@@ -1,0 +1,54 @@
+package module
+
+import (
+	"context"
+	"testing"
+)
+
+type catalogTestGen struct{}
+
+func (catalogTestGen) Info() ModuleInfo {
+	return ModuleInfo{
+		Name:        "cat_test",
+		Category:    CategoryNetwork,
+		Description: "desc",
+		Privileges:  PrivilegeRoot,
+		MinMacOS:    "12.0",
+		Tags:        []string{"a", "b"},
+		MITRE: []MITRE{
+			{Technique: "T1071", SubTech: ".001", Name: "Application Layer Protocol: Web Protocols"},
+			{Technique: "T1105", Name: "Ingress Tool Transfer"},
+		},
+	}
+}
+func (catalogTestGen) ParamSpecs() []ParamSpec {
+	return []ParamSpec{
+		{Name: "target", Description: "the target", Required: true, DefaultValue: "1.2.3.4", Example: "10.0.0.1"},
+	}
+}
+func (catalogTestGen) CheckPrereqs() error                                  { return nil }
+func (catalogTestGen) Generate(context.Context, Params, EventEmitter) error { return nil }
+func (catalogTestGen) DryRun(Params) []string                               { return nil }
+func (catalogTestGen) Cleanup() error                                       { return nil }
+
+func TestNewCatalogEntry(t *testing.T) {
+	e := NewCatalogEntry(catalogTestGen{})
+
+	if e.Name != "cat_test" || e.Category != CategoryNetwork || e.Privileges != PrivilegeRoot {
+		t.Errorf("core fields wrong: %+v", e)
+	}
+	if len(e.MITRE) != 2 {
+		t.Fatalf("expected 2 MITRE entries, got %d", len(e.MITRE))
+	}
+	// Sub-technique is fully qualified.
+	if e.MITRE[0].SubTechnique != "T1071.001" {
+		t.Errorf("sub_technique = %q, want T1071.001", e.MITRE[0].SubTechnique)
+	}
+	// Technique-only entry leaves sub_technique empty.
+	if e.MITRE[1].SubTechnique != "" {
+		t.Errorf("sub_technique should be empty for technique-only mapping, got %q", e.MITRE[1].SubTechnique)
+	}
+	if len(e.Params) != 1 || e.Params[0].Name != "target" || !e.Params[0].Required || e.Params[0].Default != "1.2.3.4" {
+		t.Errorf("params mapped wrong: %+v", e.Params)
+	}
+}


### PR DESCRIPTION
The list command ignored the global --format flag and always printed the human table; it now emits one JSON CatalogEntry per module (name, category, description, privileges, MITRE with fully-qualified sub-techniques, params) so a consumer can enumerate modules programmatically, and rejects an invalid --format. Event types are out of scope: they live as literals inside each Generate, not in ModuleInfo, so the catalog schema is additive and they can be added later without breaking consumers.