### PR TITLE
feat: add emitted event types to module catalog

### DIFF
--- a/cmd/macnoise/event_types_test.go
+++ b/cmd/macnoise/event_types_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+var (
+	eventTypesLiteralRe = regexp.MustCompile(`EventTypes:\s*\[\]string\{([^}]*)\}`)
+	newEventLiteralRe   = regexp.MustCompile(`NewEvent\(\w+,\s*"([a-z_0-9]+)"`)
+	quotedStringRe      = regexp.MustCompile(`"([a-z_0-9]+)"`)
+)
+
+// Every event_type a module emits via NewEvent must appear in its declared
+// EventTypes, so the catalog never advertises a stale or incomplete set. This
+// is the drift guard the ModuleInfo.EventTypes doc references: it scans source
+// rather than running modules, so it holds on any OS and needs no privileges.
+//
+// Direction is emitted-is-subset-of-declared. plist_create builds its event
+// type from a variable rather than a literal, so nothing is scanned there and
+// its declaration is taken on trust (the same blind spot classify_test notes).
+func TestModuleEventTypesMatchEmitted(t *testing.T) {
+	root := filepath.Join("..", "..", "modules")
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		text := string(src)
+
+		emitted := map[string]bool{}
+		for _, m := range newEventLiteralRe.FindAllStringSubmatch(text, -1) {
+			emitted[m[1]] = true
+		}
+		if len(emitted) == 0 {
+			return nil // helper file, or event type built from a variable
+		}
+
+		declared := map[string]bool{}
+		if m := eventTypesLiteralRe.FindStringSubmatch(text); m != nil {
+			for _, q := range quotedStringRe.FindAllStringSubmatch(m[1], -1) {
+				declared[q[1]] = true
+			}
+		}
+
+		for et := range emitted {
+			if !declared[et] {
+				t.Errorf("%s emits %q via NewEvent but does not declare it in EventTypes", path, et)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk modules: %v", err)
+	}
+}
+
+// Every registered module must declare at least one event type, since every
+// module emits telemetry. Off darwin the registry is a subset (some modules are
+// build-tagged), which is fine: this checks whatever is registered.
+func TestAllModulesDeclareEventTypes(t *testing.T) {
+	for _, g := range module.All() {
+		if len(g.Info().EventTypes) == 0 {
+			t.Errorf("%s declares no EventTypes", g.Info().Name)
+		}
+	}
+}

--- a/modules/endpoint_security/es_file.go
+++ b/modules/endpoint_security/es_file.go
@@ -22,6 +22,7 @@ type esFile struct {
 func (e *esFile) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "es_file",
+		EventTypes:  []string{"es_notify_create", "es_notify_open", "es_notify_write", "es_notify_setmode", "es_notify_rename", "es_notify_unlink"},
 		Description: "Performs file operations that trigger ES_EVENT_TYPE_NOTIFY_CREATE/OPEN/WRITE/SETMODE/RENAME/UNLINK",
 		Category:    module.CategoryEndpointSecurity,
 		Tags:        []string{"endpoint-security", "file", "create", "open", "write", "setmode", "rename", "delete"},

--- a/modules/endpoint_security/es_mount.go
+++ b/modules/endpoint_security/es_mount.go
@@ -34,6 +34,7 @@ type esMount struct {
 func (e *esMount) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "es_mount",
+		EventTypes:  []string{"es_dmg_create", "es_notify_mount", "es_volume_exec", "es_notify_unmount"},
 		Description: "Mounts a disk image and executes a payload from it, triggering ES_EVENT_TYPE_NOTIFY_MOUNT/EXEC/UNMOUNT",
 		Category:    module.CategoryEndpointSecurity,
 		Tags:        []string{"endpoint-security", "mount", "dmg", "disk-image", "delivery"},

--- a/modules/endpoint_security/es_process.go
+++ b/modules/endpoint_security/es_process.go
@@ -14,6 +14,7 @@ type esProcess struct{}
 func (e *esProcess) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "es_process",
+		EventTypes:  []string{"es_exec_chain"},
 		Description: "Executes process chains that trigger ES_EVENT_TYPE_NOTIFY_EXEC/FORK/EXIT",
 		Category:    module.CategoryEndpointSecurity,
 		Tags:        []string{"endpoint-security", "process", "exec", "fork"},

--- a/modules/evasion/log_clear.go
+++ b/modules/evasion/log_clear.go
@@ -21,6 +21,7 @@ type evadeLogClear struct {
 func (e *evadeLogClear) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "evade_log_clear",
+		EventTypes:  []string{"file_timestomp", "log_erase_attempt", "history_clear"},
 		Description: "Timestomps a file, attempts unified log erasure, and clears a mock history file to generate defense evasion telemetry",
 		Category:    module.CategoryEvasion,
 		Tags:        []string{"evasion", "anti-forensics", "timestomp", "log-clear", "history"},

--- a/modules/file/archive.go
+++ b/modules/file/archive.go
@@ -20,6 +20,7 @@ type fileArchive struct {
 func (f *fileArchive) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "file_archive",
+		EventTypes:  []string{"archive_create"},
 		Description: "Creates an archive of staged files to generate archive creation telemetry",
 		Category:    module.CategoryFile,
 		Tags:        []string{"archive", "zip", "staging", "collection"},

--- a/modules/file/browser_creds.go
+++ b/modules/file/browser_creds.go
@@ -119,6 +119,7 @@ func readCredFile(path string) (int64, error) {
 func (f *fileBrowserCreds) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "file_browser_creds",
+		EventTypes:  []string{"browser_cred_probe", "browser_cred_read"},
 		Description: "Reads known browser credential files to generate browser credential access telemetry",
 		Category:    module.CategoryFile,
 		Tags:        []string{"browser", "credentials", "chromium", "firefox", "safari"},

--- a/modules/file/create.go
+++ b/modules/file/create.go
@@ -20,6 +20,7 @@ type fileCreate struct {
 func (f *fileCreate) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "file_create",
+		EventTypes:  []string{"dir_create", "file_create"},
 		Description: "Creates files in a target directory to generate file creation telemetry",
 		Category:    module.CategoryFile,
 		Tags:        []string{"file", "create", "write"},

--- a/modules/file/cred_files.go
+++ b/modules/file/cred_files.go
@@ -24,6 +24,7 @@ type credTarget struct {
 func (f *fileCredFiles) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "file_cred_files",
+		EventTypes:  []string{"cred_file_probe", "cred_file_read"},
 		Description: "Reads well-known credential files (SSH keys, cloud and container configs, .env) to generate credential-in-files access telemetry",
 		Category:    module.CategoryFile,
 		Tags:        []string{"credentials", "ssh", "aws", "kubernetes", "docker", "dotenv"},

--- a/modules/file/hide.go
+++ b/modules/file/hide.go
@@ -18,6 +18,7 @@ type fileHide struct {
 func (f *fileHide) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "file_hide",
+		EventTypes:  []string{"file_hide_chflags", "file_hide_dotfile"},
 		Description: "Creates hidden files using chflags and dotfile naming to generate file hiding telemetry",
 		Category:    module.CategoryFile,
 		Tags:        []string{"hide", "chflags", "dotfile", "stealth"},

--- a/modules/file/keychain_copy.go
+++ b/modules/file/keychain_copy.go
@@ -41,6 +41,7 @@ type keychainTarget struct {
 func (f *fileKeychainCopy) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "file_keychain_copy",
+		EventTypes:  []string{"keychain_read", "keychain_copy"},
 		Description: "Copies macOS keychain databases wholesale into a staging directory to generate keychain collection telemetry",
 		Category:    module.CategoryFile,
 		Tags:        []string{"credentials", "keychain", "collection", "staging"},

--- a/modules/file/modify.go
+++ b/modules/file/modify.go
@@ -20,6 +20,7 @@ type fileModify struct {
 func (f *fileModify) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "file_modify",
+		EventTypes:  []string{"file_modify"},
 		Description: "Modifies an existing file's content to generate file write/modify telemetry",
 		Category:    module.CategoryFile,
 		Tags:        []string{"file", "modify", "write"},

--- a/modules/network/beacon.go
+++ b/modules/network/beacon.go
@@ -16,6 +16,7 @@ type c2Beacon struct{}
 func (c *c2Beacon) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "net_beacon",
+		EventTypes:  []string{"http_beacon"},
 		Description: "Simulates periodic HTTP C2 beaconing traffic",
 		Category:    module.CategoryNetwork,
 		Tags:        []string{"http", "c2", "beaconing", "periodic"},

--- a/modules/network/connect.go
+++ b/modules/network/connect.go
@@ -19,6 +19,7 @@ type netConnect struct{}
 func (n *netConnect) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "net_connect",
+		EventTypes:  []string{"tcp_connect", "http_get"},
 		Description: "Initiates a TCP connection and HTTP GET to a target host",
 		Category:    module.CategoryNetwork,
 		Tags:        []string{"tcp", "http", "outbound"},

--- a/modules/network/dns.go
+++ b/modules/network/dns.go
@@ -15,6 +15,7 @@ type netDNS struct{}
 func (n *netDNS) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "net_dns",
+		EventTypes:  []string{"dns_lookup"},
 		Description: "Performs DNS resolution of configurable domains to generate DNS telemetry",
 		Category:    module.CategoryNetwork,
 		Tags:        []string{"dns", "lookup", "outbound"},

--- a/modules/network/dns_exfil.go
+++ b/modules/network/dns_exfil.go
@@ -22,6 +22,7 @@ type netDNSExfil struct{}
 func (n *netDNSExfil) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "net_dns_exfil",
+		EventTypes:  []string{"dns_exfil_query"},
 		Description: "Encodes a payload into DNS subdomain labels and resolves each query to generate DNS exfiltration telemetry",
 		Category:    module.CategoryNetwork,
 		Tags:        []string{"dns", "exfiltration", "subdomain", "encoding"},

--- a/modules/network/exfil.go
+++ b/modules/network/exfil.go
@@ -17,6 +17,7 @@ type netExfil struct{}
 func (n *netExfil) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "net_exfil",
+		EventTypes:  []string{"http_post_exfil"},
 		Description: "Sends an HTTP POST with a dummy payload to simulate data exfiltration traffic",
 		Category:    module.CategoryNetwork,
 		Tags:        []string{"exfil", "http", "post", "data-exfiltration"},

--- a/modules/network/listen.go
+++ b/modules/network/listen.go
@@ -17,6 +17,7 @@ type netListen struct {
 func (n *netListen) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "net_listen",
+		EventTypes:  []string{"tcp_listen", "tcp_accept"},
 		Description: "Opens a local TCP listener and simulates an inbound connection",
 		Category:    module.CategoryNetwork,
 		Tags:        []string{"tcp", "listen", "inbound"},

--- a/modules/network/revshell.go
+++ b/modules/network/revshell.go
@@ -15,6 +15,7 @@ type netRevShell struct{}
 func (n *netRevShell) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "net_revshell",
+		EventTypes:  []string{"reverse_shell_attempt"},
 		Description: "Spawns /bin/sh and pipes stdio to a remote TCP connection (telemetry simulation)",
 		Category:    module.CategoryNetwork,
 		Tags:        []string{"tcp", "reverse-shell", "execution"},

--- a/modules/network/tls.go
+++ b/modules/network/tls.go
@@ -17,6 +17,7 @@ type netTLS struct{}
 func (n *netTLS) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "net_tls",
+		EventTypes:  []string{"tls_connect"},
 		Description: "Performs TLS handshakes to configurable endpoints and reports negotiated version, cipher suite, and certificate subject",
 		Category:    module.CategoryNetwork,
 		Tags:        []string{"tls", "encrypted", "handshake", "sni", "ja3"},

--- a/modules/plist/create.go
+++ b/modules/plist/create.go
@@ -20,6 +20,7 @@ type plistCreate struct {
 func (p *plistCreate) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "plist_create",
+		EventTypes:  []string{"plist_create", "plist_create_launchagent"},
 		Description: "Creates a plist file using howett.net/plist to generate plist write telemetry",
 		Category:    module.CategoryPlist,
 		Tags:        []string{"plist", "create", "file"},

--- a/modules/plist/modify.go
+++ b/modules/plist/modify.go
@@ -69,6 +69,7 @@ func isRestorableScalar(text string) bool {
 func (p *plistModify) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "plist_modify",
+		EventTypes:  []string{"plist_read_prior", "plist_modify"},
 		Description: "Modifies a user defaults plist key via 'defaults write' to generate plist write telemetry",
 		Category:    module.CategoryPlist,
 		Tags:        []string{"plist", "modify", "defaults"},

--- a/modules/process/discovery.go
+++ b/modules/process/discovery.go
@@ -47,6 +47,7 @@ type procDiscovery struct{}
 func (p *procDiscovery) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "proc_discovery",
+		EventTypes:  []string{"system_discovery"},
 		Description: "Runs macOS system reconnaissance commands, including security software enumeration, to generate discovery telemetry",
 		Category:    module.CategoryProcess,
 		Tags:        []string{"discovery", "recon", "sysinfo", "security-software"},

--- a/modules/process/gatekeeper.go
+++ b/modules/process/gatekeeper.go
@@ -18,6 +18,7 @@ type procGatekeeper struct {
 func (p *procGatekeeper) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "proc_gatekeeper",
+		EventTypes:  []string{"test_file_create_fail", "xattr_quarantine_set", "xattr_quarantine_remove", "spctl_status_check"},
 		Description: "Sets and removes com.apple.quarantine xattr to simulate Gatekeeper bypass telemetry",
 		Category:    module.CategoryProcess,
 		Tags:        []string{"gatekeeper", "quarantine", "xattr", "bypass"},

--- a/modules/process/inject.go
+++ b/modules/process/inject.go
@@ -25,6 +25,7 @@ const (
 func (p *procInject) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "proc_inject",
+		EventTypes:  []string{"dylib_inject_attempt"},
 		Description: "Spawns a process with DYLD_INSERT_LIBRARIES to generate dylib injection telemetry",
 		Category:    module.CategoryProcess,
 		Tags:        []string{"dylib", "injection", "execution", "dyld"},

--- a/modules/process/osascript.go
+++ b/modules/process/osascript.go
@@ -40,6 +40,7 @@ func sanitizeOsascriptOutput(script, out string) string {
 func (p *procOsascript) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "proc_osascript",
+		EventTypes:  []string{"osascript_exec"},
 		Description: "Executes AppleScript or JXA via osascript to generate scripting interpreter telemetry",
 		Category:    module.CategoryProcess,
 		Tags:        []string{"osascript", "applescript", "jxa", "execution"},

--- a/modules/process/signal.go
+++ b/modules/process/signal.go
@@ -19,6 +19,7 @@ type procSignal struct{}
 func (p *procSignal) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "proc_signal",
+		EventTypes:  []string{"process_fork", "signal_send"},
 		Description: "Forks a process then sends signals (SIGTERM, SIGSTOP, SIGCONT) to generate signal telemetry",
 		Category:    module.CategoryProcess,
 		Tags:        []string{"signal", "process", "fork"},

--- a/modules/process/spawn.go
+++ b/modules/process/spawn.go
@@ -17,6 +17,7 @@ type procSpawn struct{}
 func (p *procSpawn) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "proc_spawn",
+		EventTypes:  []string{"process_spawn"},
 		Description: "Spawns a suspicious shell command chain to generate process execution telemetry",
 		Category:    module.CategoryProcess,
 		Tags:        []string{"execution", "shell", "spawn"},

--- a/modules/service/cron.go
+++ b/modules/service/cron.go
@@ -17,6 +17,7 @@ type svcCron struct {
 func (s *svcCron) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "svc_cron",
+		EventTypes:  []string{"cron_job_list", "cron_job_create"},
 		Description: "Lists and appends a cron job entry to simulate cron-based persistence",
 		Category:    module.CategoryService,
 		Tags:        []string{"cron", "persistence", "scheduled-task"},

--- a/modules/service/launch_agent.go
+++ b/modules/service/launch_agent.go
@@ -24,6 +24,7 @@ type svcLaunchAgent struct {
 func (s *svcLaunchAgent) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "svc_launch_agent",
+		EventTypes:  []string{"launchagent_create", "launchagent_load"},
 		Description: "Creates and loads a LaunchAgent plist in ~/Library/LaunchAgents/ for persistence telemetry",
 		Category:    module.CategoryService,
 		Tags:        []string{"launchagent", "persistence", "plist", "launchctl"},

--- a/modules/service/launch_daemon.go
+++ b/modules/service/launch_daemon.go
@@ -22,6 +22,7 @@ type svcLaunchDaemon struct {
 func (s *svcLaunchDaemon) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "svc_launch_daemon",
+		EventTypes:  []string{"launchdaemon_create", "launchdaemon_load"},
 		Description: "Creates and loads a LaunchDaemon plist in /Library/LaunchDaemons/ (requires root)",
 		Category:    module.CategoryService,
 		Tags:        []string{"launchdaemon", "persistence", "plist", "launchctl", "root"},

--- a/modules/service/login_item.go
+++ b/modules/service/login_item.go
@@ -19,6 +19,7 @@ type svcLoginItem struct {
 func (s *svcLoginItem) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "svc_login_item",
+		EventTypes:  []string{"login_item_add"},
 		Description: "Adds a Login Item via System Events, triggering ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD",
 		Category:    module.CategoryService,
 		Tags:        []string{"login-item", "persistence", "btm", "osascript", "backgroundtaskmanagement"},

--- a/modules/service/shell_profile.go
+++ b/modules/service/shell_profile.go
@@ -23,6 +23,7 @@ type svcShellProfile struct {
 func (s *svcShellProfile) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "svc_shell_profile",
+		EventTypes:  []string{"shell_profile_modify"},
 		Description: "Appends a marked payload block to a shell profile file to simulate shell persistence",
 		Category:    module.CategoryService,
 		Tags:        []string{"shell-profile", "persistence", "zshrc", "bashrc"},

--- a/modules/tcc/accessibility.go
+++ b/modules/tcc/accessibility.go
@@ -15,6 +15,7 @@ type tccAccessibility struct{}
 func (t *tccAccessibility) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "tcc_accessibility",
+		EventTypes:  []string{"tcc_accessibility_probe"},
 		Description: "Probes Accessibility permission by reading UI elements via System Events",
 		Category:    module.CategoryTCC,
 		Tags:        []string{"tcc", "accessibility", "keylogging", "privacy"},

--- a/modules/tcc/contacts.go
+++ b/modules/tcc/contacts.go
@@ -15,6 +15,7 @@ type tccContacts struct{}
 func (t *tccContacts) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "tcc_contacts",
+		EventTypes:  []string{"tcc_contacts_probe"},
 		Description: "Attempts to enumerate the AddressBook directory to probe Contacts TCC permission",
 		Category:    module.CategoryTCC,
 		Tags:        []string{"tcc", "contacts", "addressbook", "privacy"},

--- a/modules/tcc/fda.go
+++ b/modules/tcc/fda.go
@@ -18,6 +18,7 @@ type tccFDA struct{}
 func (t *tccFDA) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "tcc_fda",
+		EventTypes:  []string{"tcc_fda_probe"},
 		Description: "Attempts to read TCC.db to probe Full Disk Access permission",
 		Category:    module.CategoryTCC,
 		Tags:        []string{"tcc", "fda", "full-disk-access", "privacy"},

--- a/modules/tcc/keychain.go
+++ b/modules/tcc/keychain.go
@@ -16,6 +16,7 @@ type tccKeychain struct{}
 func (t *tccKeychain) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "tcc_keychain",
+		EventTypes:  []string{"keychain_list", "keychain_unlock_attempt", "keychain_dump_attempt"},
 		Description: "Probes keychain access by listing, unlocking, and dumping keychain entries to generate Keychain TCC telemetry",
 		Category:    module.CategoryTCC,
 		Tags:        []string{"tcc", "keychain", "credentials", "security"},

--- a/modules/tcc/screen_recording.go
+++ b/modules/tcc/screen_recording.go
@@ -16,6 +16,7 @@ type tccScreenRecording struct{}
 func (t *tccScreenRecording) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "tcc_screen_recording",
+		EventTypes:  []string{"screen_capture_attempt"},
 		Description: "Attempts a screen capture via screencapture to generate screen-capture telemetry",
 		Category:    module.CategoryTCC,
 		Tags:        []string{"tcc", "screen-recording", "screencapture", "privacy"},

--- a/modules/xpc/enumerate.go
+++ b/modules/xpc/enumerate.go
@@ -19,6 +19,7 @@ type xpcEnumerate struct{}
 func (x *xpcEnumerate) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "xpc_enumerate",
+		EventTypes:  []string{"xpc_enumerate"},
 		Description: "Enumerates launchd service registrations via launchctl print, where XPC services are registered",
 		Category:    module.CategoryXPC,
 		Tags:        []string{"xpc", "launchctl", "ipc", "enumeration"},

--- a/pkg/module/catalog.go
+++ b/pkg/module/catalog.go
@@ -14,6 +14,7 @@ type CatalogEntry struct {
 	Privileges  Privilege      `json:"privileges"`
 	MinMacOS    string         `json:"min_macos,omitempty"`
 	Tags        []string       `json:"tags,omitempty"`
+	EventTypes  []string       `json:"event_types,omitempty"`
 	MITRE       []CatalogMITRE `json:"mitre,omitempty"`
 	Params      []CatalogParam `json:"params,omitempty"`
 }
@@ -69,6 +70,7 @@ func NewCatalogEntry(g Generator) CatalogEntry {
 		Privileges:  info.Privileges,
 		MinMacOS:    info.MinMacOS,
 		Tags:        info.Tags,
+		EventTypes:  info.EventTypes,
 		MITRE:       mitre,
 		Params:      params,
 	}

--- a/pkg/module/interface.go
+++ b/pkg/module/interface.go
@@ -33,8 +33,14 @@ type ModuleInfo struct { //nolint:revive // stutter is intentional: ModuleInfo i
 	Tags        []string
 	Privileges  Privilege
 	MITRE       []MITRE
-	Author      string
-	MinMacOS    string
+	// EventTypes lists every event_type the module can emit. It is declared
+	// here (rather than derived) so the catalog can advertise what a consumer
+	// should expect to observe; TestModuleEventTypesMatchEmitted guards it
+	// against drift by requiring every NewEvent literal in a module's source
+	// to appear in this list.
+	EventTypes []string
+	Author     string
+	MinMacOS   string
 }
 
 // ParamSpec describes a single named parameter accepted by a module.


### PR DESCRIPTION
Declares EventTypes on every module's Info and surfaces it as event_types in the JSONL catalog, so a consumer knows which event_types to expect from each module without running it. A source-scanning test asserts every NewEvent literal is declared in its module's EventTypes, guarding the list against drift.