### PR TITLE
test: add coverage for net_dns, net_connect, net_exfil

### DIFF
--- a/modules/network/connect_test.go
+++ b/modules/network/connect_test.go
@@ -1,0 +1,95 @@
+package network
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// hostPort splits an httptest server URL (http://127.0.0.1:PORT) into its host
+// and port for use as net_connect params.
+func hostPort(t *testing.T, rawURL string) (string, string) {
+	t.Helper()
+	host, port, err := net.SplitHostPort(strings.TrimPrefix(rawURL, "http://"))
+	if err != nil {
+		t.Fatalf("split %s: %v", rawURL, err)
+	}
+	return host, port
+}
+
+func TestConnectGenerate_EmitsConnectThenGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+	host, port := hostPort(t, ts.URL)
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	if err := (&netConnect{}).Generate(context.Background(), module.Params{"target": host, "port": port}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("emitted %d events, want 2 (tcp_connect, http_get)", len(events))
+	}
+	if events[0].EventType != "tcp_connect" || events[1].EventType != "http_get" {
+		t.Errorf("event types = %q,%q; want tcp_connect,http_get", events[0].EventType, events[1].EventType)
+	}
+	if !events[0].Success || !events[1].Success {
+		t.Errorf("both events should succeed against a live server: %+v", events)
+	}
+}
+
+func TestConnectGenerate_RefusedIsDenied(t *testing.T) {
+	// Bind then immediately close to obtain a port nothing is listening on.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := hostPort(t, "http://"+ln.Addr().String())
+	_ = ln.Close()
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	if err := (&netConnect{}).Generate(context.Background(), module.Params{"target": host, "port": port}, emit); err != nil {
+		t.Fatalf("Generate should not error on a refused connection: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("emitted %d events, want 2 even when refused", len(events))
+	}
+	if events[0].ResolvedOutcome() != module.OutcomeDenied {
+		t.Errorf("refused tcp_connect outcome = %q, want denied", events[0].ResolvedOutcome())
+	}
+}
+
+func TestConnectGenerate_RunIDInHTTPURL(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+	host, port := hostPort(t, ts.URL)
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	ctx := module.ContextWithRunID(context.Background(), "runid1234")
+	if err := (&netConnect{}).Generate(ctx, module.Params{"target": host, "port": port}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	url, _ := events[1].Details["url"].(string)
+	if !strings.Contains(url, "mn=runid1234") {
+		t.Errorf("http_get url = %q, want it to carry mn=runid1234", url)
+	}
+}
+
+func TestConnectDryRun(t *testing.T) {
+	steps := (&netConnect{}).DryRun(module.Params{"target": "10.0.0.1", "port": "443"})
+	if len(steps) != 2 {
+		t.Fatalf("dry run = %v, want 2 lines", steps)
+	}
+	if !strings.Contains(steps[0], "10.0.0.1:443") {
+		t.Errorf("first dry-run line %q should name the address", steps[0])
+	}
+}

--- a/modules/network/dns_test.go
+++ b/modules/network/dns_test.go
@@ -1,0 +1,83 @@
+package network
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestDNSGenerate_EmitsOnePerDomain(t *testing.T) {
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	err := (&netDNS{}).Generate(context.Background(), module.Params{"domains": "localhost,macnoise.invalid"}, emit)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("emitted %d events, want 2", len(events))
+	}
+	for _, ev := range events {
+		if ev.EventType != "dns_lookup" {
+			t.Errorf("event type = %q, want dns_lookup", ev.EventType)
+		}
+	}
+}
+
+func TestDNSGenerate_SkipsEmptyDomains(t *testing.T) {
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	// Leading/trailing commas and whitespace-only entries must not produce a lookup.
+	err := (&netDNS{}).Generate(context.Background(), module.Params{"domains": "localhost, ,,macnoise.invalid,"}, emit)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("emitted %d events, want 2 (empties skipped)", len(events))
+	}
+}
+
+func TestDNSGenerate_FailedLookupIsDeniedNotError(t *testing.T) {
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	// A .invalid name (RFC 6761) never resolves, but a failed resolution is
+	// valid telemetry — the query still went out — not a macnoise error.
+	err := (&netDNS{}).Generate(context.Background(), module.Params{"domains": "does-not-exist.macnoise.invalid"}, emit)
+	if err != nil {
+		t.Fatalf("Generate should not return an error for a failed lookup: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("emitted %d events, want 1", len(events))
+	}
+	if events[0].ResolvedOutcome() != module.OutcomeDenied {
+		t.Errorf("outcome = %q, want denied", events[0].ResolvedOutcome())
+	}
+}
+
+func TestDNSGenerate_SuccessCarriesAddresses(t *testing.T) {
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+
+	// localhost resolves on every platform without a network round-trip.
+	if err := (&netDNS{}).Generate(context.Background(), module.Params{"domains": "localhost"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(events) != 1 || !events[0].Success {
+		t.Fatalf("expected 1 successful event, got %+v", events)
+	}
+	addrs, ok := events[0].Details["addresses"].([]string)
+	if !ok || len(addrs) == 0 {
+		t.Errorf("expected resolved addresses in details, got %v", events[0].Details["addresses"])
+	}
+}
+
+func TestDNSDryRunListsDomains(t *testing.T) {
+	steps := (&netDNS{}).DryRun(module.Params{"domains": "a.invalid,b.invalid"})
+	if len(steps) != 1 || !strings.Contains(steps[0], "a.invalid,b.invalid") {
+		t.Errorf("dry run = %v, want one line naming the domains", steps)
+	}
+}

--- a/modules/network/exfil_test.go
+++ b/modules/network/exfil_test.go
@@ -1,0 +1,85 @@
+package network
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestExfilGenerate_PostsToLiveServer(t *testing.T) {
+	var gotBytes int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBytes = r.ContentLength
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	if err := (&netExfil{}).Generate(context.Background(), module.Params{"target": ts.URL, "payload_size": "2048"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(events) != 1 || events[0].EventType != "http_post_exfil" {
+		t.Fatalf("expected 1 http_post_exfil event, got %+v", events)
+	}
+	if !events[0].Success {
+		t.Errorf("POST to a live server should succeed: %s", events[0].Message)
+	}
+	if events[0].Details["status"] != http.StatusOK {
+		t.Errorf("status detail = %v, want 200", events[0].Details["status"])
+	}
+	if gotBytes != 2048 {
+		t.Errorf("server received %d bytes, want the requested 2048", gotBytes)
+	}
+}
+
+func TestExfilGenerate_NoListenerStillSucceeds(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := "http://" + ln.Addr().String() + "/upload"
+	_ = ln.Close()
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	if err := (&netExfil{}).Generate(context.Background(), module.Params{"target": target}, emit); err != nil {
+		t.Fatalf("Generate should not error with no listener: %v", err)
+	}
+	// The outbound POST is the telemetry; a refused connection does not make it a failure.
+	if len(events) != 1 || !events[0].Success {
+		t.Fatalf("expected 1 successful event even with no listener, got %+v", events)
+	}
+	if events[0].Details["error"] == nil {
+		t.Error("expected the connection error to be recorded in details")
+	}
+}
+
+func TestExfilGenerate_RunIDInRequestURL(t *testing.T) {
+	var gotMN string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMN = r.URL.Query().Get("mn")
+	}))
+	defer ts.Close()
+
+	emit := func(module.TelemetryEvent) {}
+	ctx := module.ContextWithRunID(context.Background(), "exfilrun99")
+	if err := (&netExfil{}).Generate(ctx, module.Params{"target": ts.URL}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if gotMN != "exfilrun99" {
+		t.Errorf("server saw mn=%q, want exfilrun99", gotMN)
+	}
+}
+
+func TestExfilDryRun(t *testing.T) {
+	steps := (&netExfil{}).DryRun(module.Params{"target": "http://10.0.0.1/x", "payload_size": "512"})
+	if len(steps) != 1 {
+		t.Fatalf("dry run = %v, want 1 line", steps)
+	}
+}


### PR DESCRIPTION
Adds unit tests for the three network modules that lacked them: net_dns (one event per domain, empty-domain skipping, denied-vs-error outcomes), net_connect (connect-then-get ordering, refused handling), and net_exfil (live-server vs no-listener paths). The connect and exfil tests also assert the run ID reaches the outbound HTTP URL end to end via an httptest server.