### PR TITLE
test: add coverage for proc_spawn, proc_gatekeeper, proc_signal

### DIFF
--- a/modules/process/gatekeeper_integration_test.go
+++ b/modules/process/gatekeeper_integration_test.go
@@ -1,0 +1,50 @@
+//go:build integration && darwin
+
+package process
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// Exercises the real xattr/spctl path on macOS: the module must create its
+// test file, set and remove the quarantine xattr, and check Gatekeeper status,
+// folding the run ID into the tagged file path.
+func TestGatekeeperGenerate_FullCycle(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "gk_target")
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	p := &procGatekeeper{}
+	ctx := module.ContextWithRunID(context.Background(), "gkrun7")
+	if err := p.Generate(ctx, module.Params{"target_path": target}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Cleanup() })
+
+	byType := map[string]module.TelemetryEvent{}
+	for _, ev := range events {
+		byType[ev.EventType] = ev
+	}
+
+	for _, et := range []string{"xattr_quarantine_set", "xattr_quarantine_remove", "spctl_status_check"} {
+		if _, ok := byType[et]; !ok {
+			t.Errorf("missing expected event %q; got %v", et, events)
+		}
+	}
+
+	set := byType["xattr_quarantine_set"]
+	if !set.Success {
+		t.Fatalf("quarantine set failed: %s", set.Message)
+	}
+	if !byType["xattr_quarantine_remove"].Success {
+		t.Errorf("quarantine remove failed: %s", byType["xattr_quarantine_remove"].Message)
+	}
+	// The run ID must ride on the tagged file path.
+	if path, _ := set.Details["path"].(string); filepath.Base(path) != "gk_target_gkrun7" {
+		t.Errorf("set event path = %q, want base gk_target_gkrun7", path)
+	}
+}

--- a/modules/process/gatekeeper_test.go
+++ b/modules/process/gatekeeper_test.go
@@ -1,0 +1,50 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestGatekeeperDryRun(t *testing.T) {
+	steps := (&procGatekeeper{}).DryRun(module.Params{"target_path": "/tmp/gk_test"})
+	if len(steps) != 4 {
+		t.Fatalf("dry run = %v, want 4 steps", steps)
+	}
+	joined := strings.Join(steps, "\n")
+	for _, want := range []string{"com.apple.quarantine", "spctl --status", "/tmp/gk_test"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("dry run missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestGatekeeperCleanup_RemovesTargetFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gk_target")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &procGatekeeper{targetPath: path}
+	if err := p.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("target file should be removed, stat err = %v", err)
+	}
+}
+
+func TestGatekeeperCleanup_ToleratesMissingAndEmpty(t *testing.T) {
+	// No target path recorded (Generate never ran).
+	if err := (&procGatekeeper{}).Cleanup(); err != nil {
+		t.Errorf("Cleanup with no target should be a no-op, got %v", err)
+	}
+	// Target recorded but already gone.
+	p := &procGatekeeper{targetPath: filepath.Join(t.TempDir(), "never_created")}
+	if err := p.Cleanup(); err != nil {
+		t.Errorf("Cleanup of an absent file should tolerate IsNotExist, got %v", err)
+	}
+}

--- a/modules/process/signal_integration_test.go
+++ b/modules/process/signal_integration_test.go
@@ -1,0 +1,45 @@
+//go:build integration && darwin
+
+package process
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// Forks a real short-lived process and signals it: the module must emit a
+// process_fork followed by a signal_send per signal, and fold the run ID into
+// the forked command's argv.
+func TestSignalGenerate_ForkThenSignals(t *testing.T) {
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	ctx := module.ContextWithRunID(context.Background(), "sigrun3")
+	if err := (&procSignal{}).Generate(ctx, module.Params{"target_command": "sleep 2"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(events) == 0 || events[0].EventType != "process_fork" {
+		t.Fatalf("first event should be process_fork, got %+v", events)
+	}
+	if !events[0].Success {
+		t.Fatalf("fork failed: %s", events[0].Message)
+	}
+
+	cmd, _ := events[0].Details["command"].(string)
+	if !strings.Contains(cmd, "# mn:sigrun3") {
+		t.Errorf("forked command %q should carry the run ID comment # mn:sigrun3", cmd)
+	}
+
+	var signalSends int
+	for _, ev := range events[1:] {
+		if ev.EventType == "signal_send" {
+			signalSends++
+		}
+	}
+	if signalSends != 3 {
+		t.Errorf("emitted %d signal_send events, want 3 (SIGSTOP, SIGCONT, SIGTERM)", signalSends)
+	}
+}

--- a/modules/process/signal_test.go
+++ b/modules/process/signal_test.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package process
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestSignalDryRun(t *testing.T) {
+	steps := (&procSignal{}).DryRun(module.Params{"target_command": "sleep 5"})
+	if len(steps) != 2 {
+		t.Fatalf("dry run = %v, want 2 lines", steps)
+	}
+	if !strings.Contains(steps[0], "sleep 5") {
+		t.Errorf("first dry-run line %q should name the target command", steps[0])
+	}
+	if !strings.Contains(steps[1], "SIGSTOP") || !strings.Contains(steps[1], "SIGTERM") {
+		t.Errorf("second dry-run line %q should list the signals", steps[1])
+	}
+}

--- a/modules/process/spawn_exec_test.go
+++ b/modules/process/spawn_exec_test.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+package process
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// Excluded on Windows for the same reason as es_process's exec test: Go's
+// os/exec there routes through an MSYS2/Cygwin sh that re-parses the command
+// line unlike real POSIX sh, which is not this module's target. CI runs this on
+// Linux, and it runs on the mini.
+func TestSpawnGenerate_EmitsSuccess(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	err := (&procSpawn{}).Generate(context.Background(), module.Params{"command": "echo macnoise-spawn-test"}, emit)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(events) != 1 || events[0].EventType != "process_spawn" {
+		t.Fatalf("expected 1 process_spawn event, got %+v", events)
+	}
+	if !events[0].Success {
+		t.Errorf("spawn of a plain echo should succeed: %s", events[0].Message)
+	}
+	if out, _ := events[0].Details["output"].(string); !strings.Contains(out, "macnoise-spawn-test") {
+		t.Errorf("captured output %q should contain the echoed text", out)
+	}
+}
+
+func TestSpawnGenerate_RunIDInCommand(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	ctx := module.ContextWithRunID(context.Background(), "spawnrun42")
+	if err := (&procSpawn{}).Generate(ctx, module.Params{"command": "echo hi"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	cmd, _ := events[0].Details["command"].(string)
+	if !strings.Contains(cmd, "# mn:spawnrun42") {
+		t.Errorf("spawned command %q should carry the run ID comment", cmd)
+	}
+}

--- a/modules/process/spawn_test.go
+++ b/modules/process/spawn_test.go
@@ -3,6 +3,8 @@ package process
 import (
 	"strings"
 	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
 )
 
 func TestStampCommand_WithRunID(t *testing.T) {
@@ -22,5 +24,15 @@ func TestStampCommand_WithoutRunID(t *testing.T) {
 	cmd := stampCommand("echo hi", "")
 	if cmd != "echo hi" {
 		t.Errorf("unstamped command = %q, want %q", cmd, "echo hi")
+	}
+}
+
+func TestSpawnDryRun(t *testing.T) {
+	steps := (&procSpawn{}).DryRun(module.Params{"command": "id && whoami"})
+	if len(steps) != 1 {
+		t.Fatalf("dry run = %v, want 1 line", steps)
+	}
+	if !strings.Contains(steps[0], "id && whoami") {
+		t.Errorf("dry-run line %q should name the command", steps[0])
 	}
 }


### PR DESCRIPTION
Adds tests for the three process modules that lacked Generate/DryRun coverage. Cross-platform tests run in CI (spawn DryRun, gatekeeper DryRun and Cleanup); the sh exec path is gated behind !windows, and the real xattr/spctl and fork/signal paths behind integration && darwin. The spawn, gatekeeper, and signal tests also assert the run ID reaches the argv, the quarantine agent field, and the forked command respectively.