### PR TITLE
test: add coverage for tcc_keychain and tcc_contacts dry run

### DIFF
--- a/modules/tcc/contacts_test.go
+++ b/modules/tcc/contacts_test.go
@@ -1,0 +1,18 @@
+package tcc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestContactsDryRun(t *testing.T) {
+	steps := (&tccContacts{}).DryRun(module.Params{})
+	if len(steps) != 1 {
+		t.Fatalf("dry run = %v, want 1 line", steps)
+	}
+	if !strings.Contains(steps[0], "AddressBook") {
+		t.Errorf("dry-run line %q should name the AddressBook probe", steps[0])
+	}
+}

--- a/modules/tcc/keychain_integration_test.go
+++ b/modules/tcc/keychain_integration_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 // Drives the real `security` tool. Pointed at a keychain path that does not
-// exist, the unlock and dump attempts are refused - which is the expected,
-// valid telemetry this module exists to generate - while list-keychains still
-// enumerates the session keychains.
+// exist, unlocking with no password is refused - the expected, valid telemetry
+// this module exists to generate. (dump-keychain ignores a bad path and dumps a
+// default store, so its verdict is environment-dependent and only checked to be
+// a non-error observation.)
 func TestKeychainGenerate_EmitsThreeProbes(t *testing.T) {
 	bogus := filepath.Join(t.TempDir(), "nope.keychain-db")
 
@@ -33,14 +34,19 @@ func TestKeychainGenerate_EmitsThreeProbes(t *testing.T) {
 		}
 	}
 
-	// Unlock and dump against a nonexistent keychain with no password must be
-	// refused, not error out macnoise.
-	for _, ev := range events[1:] {
-		if ev.ResolvedOutcome() != module.OutcomeDenied {
-			t.Errorf("%s outcome = %q, want denied", ev.EventType, ev.ResolvedOutcome())
-		}
-		if ev.Details["result"] != "denied" {
-			t.Errorf("%s result detail = %v, want denied", ev.EventType, ev.Details["result"])
-		}
+	// Unlock of a nonexistent keychain with no password is reliably refused.
+	unlock := events[1]
+	if unlock.ResolvedOutcome() != module.OutcomeDenied {
+		t.Errorf("unlock outcome = %q, want denied", unlock.ResolvedOutcome())
+	}
+	if unlock.Details["result"] != "denied" {
+		t.Errorf("unlock result detail = %v, want denied", unlock.Details["result"])
+	}
+
+	// The dump attempt must at least run and be recorded as a real observation,
+	// never a macnoise error.
+	dump := events[2]
+	if o := dump.ResolvedOutcome(); o != module.OutcomeExecuted && o != module.OutcomeDenied {
+		t.Errorf("dump outcome = %q, want executed or denied", o)
 	}
 }

--- a/modules/tcc/keychain_integration_test.go
+++ b/modules/tcc/keychain_integration_test.go
@@ -1,0 +1,46 @@
+//go:build integration && darwin
+
+package tcc
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// Drives the real `security` tool. Pointed at a keychain path that does not
+// exist, the unlock and dump attempts are refused - which is the expected,
+// valid telemetry this module exists to generate - while list-keychains still
+// enumerates the session keychains.
+func TestKeychainGenerate_EmitsThreeProbes(t *testing.T) {
+	bogus := filepath.Join(t.TempDir(), "nope.keychain-db")
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	if err := (&tccKeychain{}).Generate(context.Background(), module.Params{"keychain_path": bogus}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	wantOrder := []string{"keychain_list", "keychain_unlock_attempt", "keychain_dump_attempt"}
+	if len(events) != len(wantOrder) {
+		t.Fatalf("emitted %d events, want %d: %+v", len(events), len(wantOrder), events)
+	}
+	for i, want := range wantOrder {
+		if events[i].EventType != want {
+			t.Errorf("event %d type = %q, want %q", i, events[i].EventType, want)
+		}
+	}
+
+	// Unlock and dump against a nonexistent keychain with no password must be
+	// refused, not error out macnoise.
+	for _, ev := range events[1:] {
+		if ev.ResolvedOutcome() != module.OutcomeDenied {
+			t.Errorf("%s outcome = %q, want denied", ev.EventType, ev.ResolvedOutcome())
+		}
+		if ev.Details["result"] != "denied" {
+			t.Errorf("%s result detail = %v, want denied", ev.EventType, ev.Details["result"])
+		}
+	}
+}

--- a/modules/tcc/keychain_test.go
+++ b/modules/tcc/keychain_test.go
@@ -1,0 +1,21 @@
+package tcc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestKeychainDryRun(t *testing.T) {
+	steps := (&tccKeychain{}).DryRun(module.Params{"keychain_path": "/tmp/victim.keychain-db"})
+	if len(steps) != 3 {
+		t.Fatalf("dry run = %v, want 3 steps", steps)
+	}
+	joined := strings.Join(steps, "\n")
+	for _, want := range []string{"list-keychains", "unlock-keychain", "dump-keychain", "/tmp/victim.keychain-db"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("dry run missing %q:\n%s", want, joined)
+		}
+	}
+}


### PR DESCRIPTION
tcc_keychain had no tests: adds a cross-platform DryRun check and an integration && darwin test that drives the real security tool, asserting the three keychain probes emit in order and that an unlock against a nonexistent keychain with no password is refused. Also adds the missing DryRun test for tcc_contacts. The other three tcc modules (fda, accessibility, screen_recording) were already covered by the existing probe/perms tests.