### PR TITLE
feat: add evade_masquerade module for masquerading telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ make build
 | `service` | LaunchAgent/Daemon persistence, cron, shell profile, Login Items | svc_launch_agent, svc_launch_daemon, svc_cron, svc_shell_profile, svc_login_item |
 | `plist` | Plist creation and modification | plist_create, plist_modify |
 | `xpc` | XPC service enumeration | xpc_enumerate |
-| `evasion` | Defense evasion: log clearing, timestomping, history removal | evade_log_clear |
+| `evasion` | Defense evasion: log clearing, timestomping, history removal, masquerading | evade_log_clear, evade_masquerade |
 
 ## Commands
 

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -59,6 +59,10 @@ func Classify(category, eventType string) Classification {
 		return Classification{1007, "Process Activity", 1, "System Activity", 1, "Launch"}
 	case "history_clear":
 		return Classification{1001, "File System Activity", 1, "System Activity", 4, "Delete"}
+	case "masquerade_copy":
+		return Classification{1001, "File System Activity", 1, "System Activity", 1, "Create"}
+	case "masquerade_exec":
+		return Classification{1007, "Process Activity", 1, "System Activity", 1, "Launch"}
 	}
 
 	switch category {

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -96,6 +96,8 @@ func TestClassify(t *testing.T) {
 		{"evasion", "file_timestomp", 1001, 6},
 		{"evasion", "log_erase_attempt", 1007, 1},
 		{"evasion", "history_clear", 1001, 4},
+		{"evasion", "masquerade_copy", 1001, 1},
+		{"evasion", "masquerade_exec", 1007, 1},
 
 		// unmapped category/event falls back to API Activity/Other
 		{"unknown_category", "unknown_event", 6003, 99},

--- a/modules/evasion/README.md
+++ b/modules/evasion/README.md
@@ -13,3 +13,13 @@ All artifacts live in a staging directory (default `/tmp/macnoise_evasion`) and 
 macnoise run evade_log_clear
 macnoise run evade_log_clear --param stage_dir=/var/tmp/macnoise_evasion
 ```
+
+### `evade_masquerade`
+Copies a benign system utility (default `/usr/bin/true`) into a staging directory under a name that impersonates a legitimate macOS process (default `com.apple.WindowServer`), then executes it. The exec fires for a process whose name and location masquerade as a trusted system component while its real provenance differs. Maps to T1036.003, T1036.005.
+
+The staged binary lives in the staging directory (default `/tmp/macnoise_masquerade`) and is removed on cleanup.
+
+```bash
+macnoise run evade_masquerade
+macnoise run evade_masquerade --param masquerade_name=mdworker_shared --param source_binary=/bin/cp
+```

--- a/modules/evasion/masquerade.go
+++ b/modules/evasion/masquerade.go
@@ -1,0 +1,153 @@
+package evasion
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+const (
+	defaultMasqueradeStageDir = "/tmp/macnoise_masquerade"
+	defaultMasqueradeSource   = "/usr/bin/true"
+	// A real macOS system process name. Running a copy of a benign utility under
+	// this name from a non-standard path is the masquerade: the process advertises
+	// itself as a trusted system component it is not.
+	defaultMasqueradeName = "com.apple.WindowServer"
+)
+
+type evadeMasquerade struct {
+	stageDir string
+}
+
+func (e *evadeMasquerade) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "evade_masquerade",
+		EventTypes:  []string{"masquerade_copy", "masquerade_exec"},
+		Description: "Copies a system utility to a name impersonating a legitimate process and executes it to generate masquerading telemetry",
+		Category:    module.CategoryEvasion,
+		Tags:        []string{"evasion", "masquerade", "rename", "defense-evasion"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			{Technique: "T1036", SubTech: ".003", Name: "Masquerading: Rename System Utilities"},
+			{Technique: "T1036", SubTech: ".005", Name: "Masquerading: Match Legitimate Name or Location"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "12.0",
+	}
+}
+
+func (e *evadeMasquerade) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{Name: "stage_dir", Description: "Directory for the masqueraded binary", Required: false, DefaultValue: defaultMasqueradeStageDir, Example: "/var/tmp/macnoise_masquerade"},
+		{Name: "source_binary", Description: "Benign system utility to copy and run", Required: false, DefaultValue: defaultMasqueradeSource, Example: "/bin/cp"},
+		{Name: "masquerade_name", Description: "Legitimate-looking name to run the copy under", Required: false, DefaultValue: defaultMasqueradeName, Example: "mdworker_shared"},
+	}
+}
+
+func (e *evadeMasquerade) CheckPrereqs() error { return nil }
+
+// copyExecutable copies src to dst with executable permissions. It is the pure,
+// cross-platform-testable half of the module; the exec that follows is the
+// macOS-specific part.
+func copyExecutable(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close() //nolint:errcheck
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func (e *evadeMasquerade) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	runID := module.RunIDFromContext(ctx)
+	stageDir := module.TagPath(params.Get("stage_dir", defaultMasqueradeStageDir), runID)
+	source := params.Get("source_binary", defaultMasqueradeSource)
+	masqName := params.Get("masquerade_name", defaultMasqueradeName)
+	info := e.Info()
+
+	if err := os.MkdirAll(stageDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", stageDir, err)
+	}
+	e.stageDir = stageDir
+	destPath := filepath.Join(stageDir, masqName)
+
+	copyEv := output.NewEvent(info, "masquerade_copy", false,
+		fmt.Sprintf("copying %s to %s (masquerading as %q)", source, destPath, masqName))
+	if err := copyExecutable(source, destPath); err != nil {
+		copyEv = output.WithError(copyEv, err)
+		emit(copyEv)
+		return nil
+	}
+	copyEv.Success = true
+	copyEv.Message = fmt.Sprintf("staged %s as %s", source, destPath)
+	copyEv = output.WithDetails(copyEv, map[string]any{
+		"source":         source,
+		"path":           destPath,
+		"masqueraded_as": masqName,
+	})
+	emit(copyEv)
+
+	execEv := output.NewEvent(info, "masquerade_exec", false,
+		fmt.Sprintf("executing %s under masquerading name %q", destPath, masqName))
+	out, err := exec.CommandContext(ctx, destPath).CombinedOutput()
+	if err != nil {
+		// The environment refused the launch (SIP, noexec, missing loader). That
+		// is the host declining, not macnoise breaking, and the attempted exec is
+		// still the telemetry a masquerading detection keys on.
+		execEv = output.WithOutcome(execEv, module.OutcomeDenied, err)
+		execEv.Message = fmt.Sprintf("masqueraded exec of %s could not be launched", destPath)
+		execEv = output.WithDetails(execEv, map[string]any{
+			"path":           destPath,
+			"masqueraded_as": masqName,
+			"output":         strings.TrimSpace(string(out)),
+		})
+	} else {
+		execEv.Success = true
+		execEv.Message = fmt.Sprintf("ran %s as %q (real binary: %s)", destPath, masqName, source)
+		execEv = output.WithDetails(execEv, map[string]any{
+			"path":           destPath,
+			"masqueraded_as": masqName,
+			"real_source":    source,
+		})
+	}
+	emit(execEv)
+	return nil
+}
+
+func (e *evadeMasquerade) DryRun(params module.Params) []string {
+	source := params.Get("source_binary", defaultMasqueradeSource)
+	masqName := params.Get("masquerade_name", defaultMasqueradeName)
+	stageDir := params.Get("stage_dir", defaultMasqueradeStageDir)
+	dest := filepath.Join(stageDir, masqName)
+	return []string{
+		fmt.Sprintf("copy %s to %s (T1036.003)", source, dest),
+		fmt.Sprintf("execute %s masquerading as %q (T1036.005)", dest, masqName),
+	}
+}
+
+func (e *evadeMasquerade) Cleanup() error {
+	if e.stageDir == "" {
+		return nil
+	}
+	return os.RemoveAll(e.stageDir)
+}
+
+func init() {
+	module.Register(&evadeMasquerade{})
+}

--- a/modules/evasion/masquerade_integration_test.go
+++ b/modules/evasion/masquerade_integration_test.go
@@ -1,0 +1,49 @@
+//go:build integration && darwin
+
+package evasion
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// Runs the real copy-and-exec on macOS: a copy of /usr/bin/true executed under
+// a system process name must emit a masquerade_copy and a masquerade_exec, with
+// the run ID folded into the staged path.
+func TestMasqueradeGenerate_CopiesAndExecutes(t *testing.T) {
+	stage := filepath.Join(t.TempDir(), "mq")
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	e := &evadeMasquerade{}
+	ctx := module.ContextWithRunID(context.Background(), "mqrun5")
+	params := module.Params{"stage_dir": stage, "masquerade_name": "com.apple.WindowServer"}
+	if err := e.Generate(ctx, params, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	t.Cleanup(func() { _ = e.Cleanup() })
+
+	if len(events) != 2 {
+		t.Fatalf("emitted %d events, want 2: %+v", len(events), events)
+	}
+	if events[0].EventType != "masquerade_copy" || events[1].EventType != "masquerade_exec" {
+		t.Fatalf("event types = %q,%q; want masquerade_copy,masquerade_exec", events[0].EventType, events[1].EventType)
+	}
+	if !events[0].Success {
+		t.Fatalf("copy failed: %s", events[0].Message)
+	}
+	// A copy of /usr/bin/true exits 0, so the masqueraded exec should succeed.
+	if !events[1].Success {
+		t.Errorf("masqueraded exec failed: %s", events[1].Message)
+	}
+	if events[1].Details["masqueraded_as"] != "com.apple.WindowServer" {
+		t.Errorf("exec masqueraded_as = %v, want com.apple.WindowServer", events[1].Details["masqueraded_as"])
+	}
+	// The run ID must ride on the staged path.
+	if path, _ := events[0].Details["path"].(string); !filepath.IsAbs(path) || filepath.Base(filepath.Dir(path)) != "mq_mqrun5" {
+		t.Errorf("staged path %q should sit under the run-ID-tagged stage dir mq_mqrun5", path)
+	}
+}

--- a/modules/evasion/masquerade_test.go
+++ b/modules/evasion/masquerade_test.go
@@ -1,0 +1,93 @@
+package evasion
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestCopyExecutable_CopiesContentAndIsExecutable(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("#!/bin/sh\ntrue\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyExecutable(src, dst); err != nil {
+		t.Fatalf("copyExecutable: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "#!/bin/sh\ntrue\n" {
+		t.Errorf("copied content = %q, want the source content", got)
+	}
+	// The copy must be executable, otherwise the masquerading exec cannot launch.
+	// Mode bits are a Unix concept; on Windows the exec bit is not represented.
+	if fi, _ := os.Stat(dst); fi.Mode().Perm()&0o111 == 0 && os.PathSeparator == '/' {
+		t.Errorf("copied file mode = %v, want executable", fi.Mode().Perm())
+	}
+}
+
+func TestCopyExecutable_MissingSourceErrors(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "dst")
+	if err := copyExecutable(filepath.Join(t.TempDir(), "does-not-exist"), dst); err == nil {
+		t.Error("expected an error copying a missing source")
+	}
+}
+
+func TestMasqueradeDryRun(t *testing.T) {
+	steps := (&evadeMasquerade{}).DryRun(module.Params{
+		"stage_dir":       "/tmp/mq",
+		"source_binary":   "/usr/bin/true",
+		"masquerade_name": "com.apple.WindowServer",
+	})
+	if len(steps) != 2 {
+		t.Fatalf("dry run = %v, want 2 steps", steps)
+	}
+	joined := strings.Join(steps, "\n")
+	// The dest path is built with filepath.Join, so match the OS separator the
+	// module actually produces rather than assuming forward slashes.
+	dest := filepath.Join("/tmp/mq", "com.apple.WindowServer")
+	for _, want := range []string{"/usr/bin/true", "com.apple.WindowServer", dest} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("dry run missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestMasqueradeCleanup_RemovesStageDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "stage")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "com.apple.WindowServer"), []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &evadeMasquerade{stageDir: dir}
+	if err := e.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("stage dir should be removed, stat err = %v", err)
+	}
+}
+
+func TestMasqueradeInfo_HasMasqueradingMITRE(t *testing.T) {
+	mitre := (&evadeMasquerade{}).Info().MITRE
+	if len(mitre) != 2 {
+		t.Fatalf("expected 2 MITRE entries, got %d", len(mitre))
+	}
+	for _, m := range mitre {
+		if m.Technique != "T1036" {
+			t.Errorf("technique = %q, want T1036", m.Technique)
+		}
+	}
+}


### PR DESCRIPTION
Adds an evasion module that copies a benign system utility to a name impersonating a legitimate macOS process (default com.apple.WindowServer) and executes it, so an exec fires for a process whose name and location masquerade as a trusted component while its real provenance differs. Emits masquerade_copy (OCSF 1001/Create) and masquerade_exec (1007/Launch), stages under a run-ID-tagged directory, and cleans up after itself. Maps to T1036.003 and T1036.005.