### PR TITLE
feat: add file_encrypt module (T1486)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make build
 |----------|-------------|---------|
 | `network` | Outbound connections, DNS, beaconing, listeners, reverse shells, TLS, exfiltration | net_connect, net_listen, net_beacon, net_revshell, net_dns, net_dns_exfil, net_tls, net_exfil |
 | `process` | Process spawning, signal delivery, dylib injection, discovery, Gatekeeper bypass, osascript | proc_spawn, proc_signal, proc_inject, proc_discovery, proc_gatekeeper, proc_osascript |
-| `file` | File creation, modification, credential file and keychain reads, archiving, hiding | file_create, file_modify, file_browser_creds, file_cred_files, file_keychain_copy, file_archive, file_hide |
+| `file` | File creation, modification, credential file and keychain reads, archiving, hiding, encryption | file_create, file_modify, file_browser_creds, file_cred_files, file_keychain_copy, file_archive, file_hide, file_encrypt |
 | `tcc` | TCC permission probes (FDA, Contacts, Keychain, Accessibility, Screen Recording) | tcc_fda, tcc_contacts, tcc_keychain, tcc_accessibility, tcc_screen_recording |
 | `endpoint_security` | ES framework event triggers, including .dmg mount and payload execution | es_file, es_process, es_mount |
 | `service` | LaunchAgent/Daemon persistence, cron, shell profile, Login Items | svc_launch_agent, svc_launch_daemon, svc_cron, svc_shell_profile, svc_login_item |

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Scenarios chain modules into ordered sequences - a single YAML file that replays
 | `lazarus_group.yaml` | Lazarus Group: dylib injection, service discovery, reverse shell, plist persistence |
 | `amos_atomic_stealer.yaml` | AMOS / Atomic Stealer: MaaS infostealer, Gatekeeper bypass, keychain dump, ZIP exfil, backdoor persistence |
 | `clickfix.yaml` | ClickFix: obfuscated one-liner pasted into Terminal, base64 decode, second-stage fetch, LaunchAgent persistence |
+| `ransomware.yaml` | Ransomware impact: stage plaintext decoys, encrypt them, then drop a ransom note |
 
 The two APT scenarios follow real documented intrusion sequences, technique by technique - each YAML file cites the actual threat intel it's built from and annotates every step with the MITRE technique it exercises, so start there for the full breakdown rather than a retelling here.
 

--- a/configs/scenarios/ransomware.yaml
+++ b/configs/scenarios/ransomware.yaml
@@ -1,0 +1,25 @@
+name: Ransomware Impact Simulation
+description: |
+  Stages plaintext decoy files with randomized common extensions, encrypts them
+  for T1486 telemetry, then drops a named ransom note. The encryption module
+  touches only the decoys it stages; the note is a separate scenario step so
+  the two actions remain independently composable.
+
+steps:
+  # T1486 — stage decoy documents first, then encrypt those exact files.
+  - module: file_encrypt
+    params:
+      stage_dir: "/tmp/macnoise_ransomware_files"
+      file_count: "25"
+      extension: ".locked"
+
+  # File creation after encryption — intentionally composed here instead of
+  # being emitted by file_encrypt.
+  - module: file_create
+    params:
+      base_dir: "/tmp/macnoise_ransomware_note"
+      filename: "RECOVER_YOUR_FILES.txt"
+      content: |
+        Your files have been encrypted.
+
+        This is an authorized MacNoise simulation. No user files were touched.

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -117,11 +117,11 @@ func processActivity(eventType string) (int, string) {
 func fileActivity(eventType string) (int, string) {
 	switch eventType {
 	case "file_create", "dir_create", "file_hide_dotfile", "archive_create",
-		"plist_create", "plist_create_launchagent", "keychain_copy":
+		"plist_create", "plist_create_launchagent", "keychain_copy", "ransom_note_drop":
 		return 1, "Create"
 	case "plist_read_prior", "browser_cred_read", "cred_file_read", "keychain_read":
 		return 2, "Read"
-	case "file_modify", "plist_modify":
+	case "file_modify", "plist_modify", "file_encrypt":
 		return 3, "Update"
 	case "file_hide_chflags":
 		return 6, "Set Attributes"

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -117,7 +117,7 @@ func processActivity(eventType string) (int, string) {
 func fileActivity(eventType string) (int, string) {
 	switch eventType {
 	case "file_create", "dir_create", "file_hide_dotfile", "archive_create",
-		"plist_create", "plist_create_launchagent", "keychain_copy", "ransom_note_drop":
+		"plist_create", "plist_create_launchagent", "keychain_copy":
 		return 1, "Create"
 	case "plist_read_prior", "browser_cred_read", "cred_file_read", "keychain_read":
 		return 2, "Read"

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -33,6 +33,8 @@ func TestClassify(t *testing.T) {
 		{"file", "cred_file_read", 1001, 2},
 		{"file", "dir_create", 1001, 1},
 		{"file", "file_create", 1001, 1},
+		{"file", "file_encrypt", 1001, 3},
+		{"file", "ransom_note_drop", 1001, 1},
 		{"file", "file_hide_chflags", 1001, 6},
 		{"file", "file_hide_dotfile", 1001, 1},
 		{"file", "file_modify", 1001, 3},

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -34,7 +34,6 @@ func TestClassify(t *testing.T) {
 		{"file", "dir_create", 1001, 1},
 		{"file", "file_create", 1001, 1},
 		{"file", "file_encrypt", 1001, 3},
-		{"file", "ransom_note_drop", 1001, 1},
 		{"file", "file_hide_chflags", 1001, 6},
 		{"file", "file_hide_dotfile", 1001, 1},
 		{"file", "file_modify", 1001, 3},

--- a/modules/file/README.md
+++ b/modules/file/README.md
@@ -44,6 +44,14 @@ macnoise run file_archive
 macnoise run file_archive --param tool=ditto --param output_path=/tmp/staged.zip
 ```
 
+### `file_encrypt`
+Stages decoy `.dat` files, encrypts each in place with AES-256-GCM (nonce prepended, so the operation is reversible with the recovery key), and drops a ransom note recording the recovery key hex. No real files are touched. Maps to T1486. Cleanup removes the staging directory.
+
+```bash
+macnoise run file_encrypt
+macnoise run file_encrypt --param file_count=20 --param extension=.crypted
+```
+
 ### `file_hide`
 Creates a test file and hides it via `chflags hidden` (Finder-invisible), then creates a dotfile. Emits `file_hide_chflags` and `file_hide_dotfile` events. Maps to T1564.001. Cleanup removes the working directory.
 

--- a/modules/file/README.md
+++ b/modules/file/README.md
@@ -5,7 +5,7 @@ File creation, modification, credential and keychain reads, archiving, and hidin
 ## Modules
 
 ### `file_create`
-Creates files in a directory. Maps to T1074.001. Cleanup removes created files.
+Creates files in a directory. `filename` and `content` create one exact, named file; scenarios use this for artifacts such as ransom notes without adding purpose-specific modules. Maps to T1074.001. Cleanup removes created files.
 
 ### `file_modify`
 Appends to a file. Maps to T1565.001. Cleanup restores original content.
@@ -45,7 +45,7 @@ macnoise run file_archive --param tool=ditto --param output_path=/tmp/staged.zip
 ```
 
 ### `file_encrypt`
-Stages decoy `.dat` files, encrypts each in place with AES-256-GCM (nonce prepended, so the operation is reversible with the recovery key), and drops a ransom note recording the recovery key hex. No real files are touched. Maps to T1486. Cleanup removes the staging directory.
+Stages the requested number of plaintext decoys with randomized common file extensions, then encrypts each in place with AES-256-GCM (nonce prepended). No real files are touched. Maps to T1486. Cleanup removes the staging directory. The ransomware scenario composes this with a named `file_create` step to drop its ransom note.
 
 ```bash
 macnoise run file_encrypt

--- a/modules/file/create.go
+++ b/modules/file/create.go
@@ -38,6 +38,8 @@ func (f *fileCreate) ParamSpecs() []module.ParamSpec {
 		{Name: "base_dir", Description: "Directory to create files in", Required: false, DefaultValue: "/tmp/macnoise_test", Example: "/var/tmp/macnoise"},
 		{Name: "count", Description: "Number of files to create", Required: false, DefaultValue: "3", Example: "10"},
 		{Name: "prefix", Description: "File name prefix", Required: false, DefaultValue: "mnfile_", Example: "test_"},
+		{Name: "filename", Description: "Exact name for a single file (overrides count and prefix)", Required: false, Example: "RECOVER_YOUR_FILES.txt"},
+		{Name: "content", Description: "Contents for a named file", Required: false, Example: "Your files have been encrypted."},
 	}
 }
 
@@ -56,6 +58,8 @@ func (f *fileCreate) Generate(ctx context.Context, params module.Params, emit mo
 	baseDir := params.Get("base_dir", "/tmp/macnoise_test")
 	countStr := params.Get("count", "3")
 	prefix := params.Get("prefix", "mnfile_")
+	filename := params.Get("filename", "")
+	content := params.Get("content", "")
 	runID := module.RunIDFromContext(ctx)
 
 	count := 3
@@ -70,6 +74,13 @@ func (f *fileCreate) Generate(ctx context.Context, params module.Params, emit mo
 		return err
 	}
 
+	if filename != "" {
+		if filepath.Base(filename) != filename {
+			return fmt.Errorf("filename must not include a directory: %q", filename)
+		}
+		count = 1
+	}
+
 	for i := 0; i < count; i++ {
 		select {
 		case <-ctx.Done():
@@ -77,20 +88,26 @@ func (f *fileCreate) Generate(ctx context.Context, params module.Params, emit mo
 		default:
 		}
 
-		fname := stampedFileName(prefix, runID, time.Now().Format("20060102_150405"), i)
+		fname := filename
+		if fname == "" {
+			fname = stampedFileName(prefix, runID, time.Now().Format("20060102_150405"), i)
+		}
 		fpath := filepath.Join(baseDir, fname)
-		content := fmt.Sprintf("MacNoise telemetry file %d created at %s\n", i, time.Now().UTC())
+		fileContent := content
+		if fileContent == "" {
+			fileContent = fmt.Sprintf("MacNoise telemetry file %d created at %s\n", i, time.Now().UTC())
+		}
 
 		ev := output.NewEvent(info, "file_create", false, fmt.Sprintf("creating %s", fpath))
-		if err := os.WriteFile(fpath, []byte(content), 0o644); err != nil {
+		if err := os.WriteFile(fpath, []byte(fileContent), 0o644); err != nil {
 			ev = output.WithError(ev, err)
 			emit(ev)
 			continue
 		}
 		f.createdPaths = append(f.createdPaths, fpath)
 		ev.Success = true
-		ev.Message = fmt.Sprintf("created %s (%d bytes)", fpath, len(content))
-		ev = output.WithDetails(ev, map[string]any{"path": fpath, "size": len(content)})
+		ev.Message = fmt.Sprintf("created %s (%d bytes)", fpath, len(fileContent))
+		ev = output.WithDetails(ev, map[string]any{"path": fpath, "size": len(fileContent)})
 		emit(ev)
 	}
 	return nil
@@ -100,6 +117,13 @@ func (f *fileCreate) DryRun(params module.Params) []string {
 	baseDir := params.Get("base_dir", "/tmp/macnoise_test")
 	countStr := params.Get("count", "3")
 	prefix := params.Get("prefix", "mnfile_")
+	filename := params.Get("filename", "")
+	if filename != "" {
+		return []string{
+			fmt.Sprintf("mkdir -p %s", baseDir),
+			fmt.Sprintf("create %s in %s", filename, baseDir),
+		}
+	}
 	return []string{
 		fmt.Sprintf("mkdir -p %s", baseDir),
 		fmt.Sprintf("create %s files with prefix %q in %s", countStr, prefix, baseDir),

--- a/modules/file/create_named_test.go
+++ b/modules/file/create_named_test.go
@@ -1,0 +1,59 @@
+package file
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestFileCreate_GenerateNamedFile(t *testing.T) {
+	dir := t.TempDir()
+	f := &fileCreate{}
+	params := module.Params{
+		"base_dir": dir,
+		"filename": "RECOVER_YOUR_FILES.txt",
+		"content":  "MacNoise simulation",
+		"count":    "99",
+		"prefix":   "ignored_",
+	}
+	if err := f.Generate(context.Background(), params, func(module.TelemetryEvent) {}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	path := filepath.Join(dir, "RECOVER_YOUR_FILES.txt")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read named file: %v", err)
+	}
+	if got, want := string(content), "MacNoise simulation"; got != want {
+		t.Errorf("content = %q, want %q", got, want)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("created %d files, want 1", len(entries))
+	}
+
+	if err := f.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("named file should be removed, stat err = %v", err)
+	}
+}
+
+func TestFileCreate_RejectsNestedFilename(t *testing.T) {
+	f := &fileCreate{}
+	err := f.Generate(context.Background(), module.Params{
+		"base_dir": t.TempDir(),
+		"filename": "nested/RECOVER_YOUR_FILES.txt",
+	}, func(module.TelemetryEvent) {})
+	if err == nil {
+		t.Fatal("Generate succeeded with a nested filename")
+	}
+}

--- a/modules/file/encrypt.go
+++ b/modules/file/encrypt.go
@@ -1,0 +1,196 @@
+package file
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+const (
+	defaultEncryptStageDir  = "/tmp/macnoise_encrypt"
+	defaultEncryptExtension = ".locked"
+	defaultEncryptCount     = 5
+	ransomNoteName          = "RECOVER_YOUR_FILES.txt"
+)
+
+type fileEncrypt struct {
+	stageDir string
+}
+
+func (f *fileEncrypt) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "file_encrypt",
+		EventTypes:  []string{"file_encrypt", "ransom_note_drop"},
+		Description: "Encrypts staged decoy files in place with AES-GCM and drops a ransom note to generate ransomware impact telemetry",
+		Category:    module.CategoryFile,
+		Tags:        []string{"ransomware", "encryption", "impact", "aes"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			{Technique: "T1486", Name: "Data Encrypted for Impact"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "12.0",
+	}
+}
+
+func (f *fileEncrypt) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{Name: "stage_dir", Description: "Directory of decoy files to encrypt (only files here are touched)", Required: false, DefaultValue: defaultEncryptStageDir, Example: "/var/tmp/macnoise_encrypt"},
+		{Name: "file_count", Description: "Number of decoy files to create and encrypt", Required: false, DefaultValue: "5", Example: "20"},
+		{Name: "extension", Description: "Extension appended to encrypted files", Required: false, DefaultValue: defaultEncryptExtension, Example: ".crypted"},
+	}
+}
+
+func (f *fileEncrypt) CheckPrereqs() error { return nil }
+
+// stageDecoyFiles writes count throwaway files into dir and returns their paths.
+// Only these macnoise-created decoys are ever encrypted; the module never reads
+// or touches anything the user owns.
+func stageDecoyFiles(dir string, count int) ([]string, error) {
+	paths := make([]string, 0, count)
+	for i := range count {
+		p := filepath.Join(dir, fmt.Sprintf("decoy_%d.dat", i))
+		content := fmt.Sprintf("macnoise decoy document %d - simulated victim data\n", i)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			return nil, err
+		}
+		paths = append(paths, p)
+	}
+	return paths, nil
+}
+
+// encryptFile AES-GCM encrypts the file at path, writes the ciphertext to
+// path+extension, and removes the plaintext original. It returns the encrypted
+// path. The nonce is prepended to the ciphertext so the operation is
+// reversible with the key, which keeps this a faithful simulation rather than
+// irreversible destruction.
+func encryptFile(path, extension string, key []byte) (string, error) {
+	plaintext, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+
+	encPath := path + extension
+	if err := os.WriteFile(encPath, ciphertext, 0o644); err != nil {
+		return "", err
+	}
+	if err := os.Remove(path); err != nil {
+		return "", err
+	}
+	return encPath, nil
+}
+
+func (f *fileEncrypt) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	runID := module.RunIDFromContext(ctx)
+	stageDir := module.TagPath(params.Get("stage_dir", defaultEncryptStageDir), runID)
+	extension := params.Get("extension", defaultEncryptExtension)
+	count := defaultEncryptCount
+	fmt.Sscanf(params.Get("file_count", "5"), "%d", &count) //nolint:errcheck
+	if count < 1 {
+		count = 1
+	}
+	info := f.Info()
+
+	if err := os.MkdirAll(stageDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", stageDir, err)
+	}
+	f.stageDir = stageDir
+
+	paths, err := stageDecoyFiles(stageDir, count)
+	if err != nil {
+		return fmt.Errorf("stage decoy files: %w", err)
+	}
+
+	// One key per run, generated fresh. It is recorded in the ransom-note event
+	// details so the encryption is transparently reversible, not destructive.
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return fmt.Errorf("generate key: %w", err)
+	}
+
+	encrypted := 0
+	for _, p := range paths {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		ev := output.NewEvent(info, "file_encrypt", false, fmt.Sprintf("encrypting %s", p))
+		encPath, encErr := encryptFile(p, extension, key)
+		if encErr != nil {
+			ev = output.WithError(ev, encErr)
+			emit(ev)
+			continue
+		}
+		encrypted++
+		ev.Success = true
+		ev.Message = fmt.Sprintf("encrypted %s -> %s", p, encPath)
+		ev = output.WithDetails(ev, map[string]any{
+			"original":  p,
+			"encrypted": encPath,
+			"cipher":    "AES-256-GCM",
+		})
+		emit(ev)
+	}
+
+	notePath := filepath.Join(stageDir, ransomNoteName)
+	note := fmt.Sprintf("Your files have been encrypted.\nThis is a MacNoise simulation. Recovery key (hex): %s\n", hex.EncodeToString(key))
+	noteEv := output.NewEvent(info, "ransom_note_drop", false, fmt.Sprintf("dropping ransom note at %s", notePath))
+	if err := os.WriteFile(notePath, []byte(note), 0o644); err != nil {
+		noteEv = output.WithError(noteEv, err)
+		emit(noteEv)
+		return nil
+	}
+	noteEv.Success = true
+	noteEv.Message = fmt.Sprintf("ransom note written to %s", notePath)
+	noteEv = output.WithDetails(noteEv, map[string]any{
+		"path":             notePath,
+		"files_encrypted":  encrypted,
+		"recovery_key_hex": hex.EncodeToString(key),
+	})
+	emit(noteEv)
+	return nil
+}
+
+func (f *fileEncrypt) DryRun(params module.Params) []string {
+	stageDir := params.Get("stage_dir", defaultEncryptStageDir)
+	extension := params.Get("extension", defaultEncryptExtension)
+	count := params.Get("file_count", "5")
+	return []string{
+		fmt.Sprintf("create %s decoy files in %s", count, stageDir),
+		fmt.Sprintf("AES-256-GCM encrypt each in place, appending %q and removing the original (T1486)", extension),
+		fmt.Sprintf("drop ransom note %s in %s", ransomNoteName, stageDir),
+	}
+}
+
+func (f *fileEncrypt) Cleanup() error {
+	if f.stageDir == "" {
+		return nil
+	}
+	return os.RemoveAll(f.stageDir)
+}
+
+func init() {
+	module.Register(&fileEncrypt{})
+}

--- a/modules/file/encrypt.go
+++ b/modules/file/encrypt.go
@@ -5,8 +5,8 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"encoding/hex"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 
@@ -18,8 +18,11 @@ const (
 	defaultEncryptStageDir  = "/tmp/macnoise_encrypt"
 	defaultEncryptExtension = ".locked"
 	defaultEncryptCount     = 5
-	ransomNoteName          = "RECOVER_YOUR_FILES.txt"
 )
+
+var decoyExtensions = []string{
+	".docx", ".xlsx", ".pdf", ".jpg", ".png", ".txt", ".zip",
+}
 
 type fileEncrypt struct {
 	stageDir string
@@ -28,8 +31,8 @@ type fileEncrypt struct {
 func (f *fileEncrypt) Info() module.ModuleInfo {
 	return module.ModuleInfo{
 		Name:        "file_encrypt",
-		EventTypes:  []string{"file_encrypt", "ransom_note_drop"},
-		Description: "Encrypts staged decoy files in place with AES-GCM and drops a ransom note to generate ransomware impact telemetry",
+		EventTypes:  []string{"file_encrypt"},
+		Description: "Stages plaintext decoy files and encrypts them in place with AES-GCM to generate ransomware impact telemetry",
 		Category:    module.CategoryFile,
 		Tags:        []string{"ransomware", "encryption", "impact", "aes"},
 		Privileges:  module.PrivilegeNone,
@@ -43,21 +46,25 @@ func (f *fileEncrypt) Info() module.ModuleInfo {
 
 func (f *fileEncrypt) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "stage_dir", Description: "Directory of decoy files to encrypt (only files here are touched)", Required: false, DefaultValue: defaultEncryptStageDir, Example: "/var/tmp/macnoise_encrypt"},
-		{Name: "file_count", Description: "Number of decoy files to create and encrypt", Required: false, DefaultValue: "5", Example: "20"},
+		{Name: "stage_dir", Description: "Directory used to stage and encrypt decoy files (only files here are touched)", Required: false, DefaultValue: defaultEncryptStageDir, Example: "/var/tmp/macnoise_encrypt"},
+		{Name: "file_count", Description: "Number of plaintext decoy files to stage before encrypting", Required: false, DefaultValue: "5", Example: "20"},
 		{Name: "extension", Description: "Extension appended to encrypted files", Required: false, DefaultValue: defaultEncryptExtension, Example: ".crypted"},
 	}
 }
 
 func (f *fileEncrypt) CheckPrereqs() error { return nil }
 
-// stageDecoyFiles writes count throwaway files into dir and returns their paths.
+// stageDecoyFiles writes all plaintext decoys into dir before encryption begins.
 // Only these macnoise-created decoys are ever encrypted; the module never reads
 // or touches anything the user owns.
 func stageDecoyFiles(dir string, count int) ([]string, error) {
 	paths := make([]string, 0, count)
 	for i := range count {
-		p := filepath.Join(dir, fmt.Sprintf("decoy_%d.dat", i))
+		extension, err := randomDecoyExtension()
+		if err != nil {
+			return nil, err
+		}
+		p := filepath.Join(dir, fmt.Sprintf("document_%d%s", i, extension))
 		content := fmt.Sprintf("macnoise decoy document %d - simulated victim data\n", i)
 		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
 			return nil, err
@@ -65,6 +72,14 @@ func stageDecoyFiles(dir string, count int) ([]string, error) {
 		paths = append(paths, p)
 	}
 	return paths, nil
+}
+
+func randomDecoyExtension() (string, error) {
+	index, err := rand.Int(rand.Reader, big.NewInt(int64(len(decoyExtensions))))
+	if err != nil {
+		return "", err
+	}
+	return decoyExtensions[index.Int64()], nil
 }
 
 // encryptFile AES-GCM encrypts the file at path, writes the ciphertext to
@@ -122,14 +137,13 @@ func (f *fileEncrypt) Generate(ctx context.Context, params module.Params, emit m
 		return fmt.Errorf("stage decoy files: %w", err)
 	}
 
-	// One key per run, generated fresh. It is recorded in the ransom-note event
-	// details so the encryption is transparently reversible, not destructive.
+	// One key per run is generated fresh. The nonce is stored with each
+	// ciphertext, matching the AES-GCM file layout used by the round-trip test.
 	key := make([]byte, 32)
 	if _, err := rand.Read(key); err != nil {
 		return fmt.Errorf("generate key: %w", err)
 	}
 
-	encrypted := 0
 	for _, p := range paths {
 		select {
 		case <-ctx.Done():
@@ -143,7 +157,6 @@ func (f *fileEncrypt) Generate(ctx context.Context, params module.Params, emit m
 			emit(ev)
 			continue
 		}
-		encrypted++
 		ev.Success = true
 		ev.Message = fmt.Sprintf("encrypted %s -> %s", p, encPath)
 		ev = output.WithDetails(ev, map[string]any{
@@ -153,23 +166,6 @@ func (f *fileEncrypt) Generate(ctx context.Context, params module.Params, emit m
 		})
 		emit(ev)
 	}
-
-	notePath := filepath.Join(stageDir, ransomNoteName)
-	note := fmt.Sprintf("Your files have been encrypted.\nThis is a MacNoise simulation. Recovery key (hex): %s\n", hex.EncodeToString(key))
-	noteEv := output.NewEvent(info, "ransom_note_drop", false, fmt.Sprintf("dropping ransom note at %s", notePath))
-	if err := os.WriteFile(notePath, []byte(note), 0o644); err != nil {
-		noteEv = output.WithError(noteEv, err)
-		emit(noteEv)
-		return nil
-	}
-	noteEv.Success = true
-	noteEv.Message = fmt.Sprintf("ransom note written to %s", notePath)
-	noteEv = output.WithDetails(noteEv, map[string]any{
-		"path":             notePath,
-		"files_encrypted":  encrypted,
-		"recovery_key_hex": hex.EncodeToString(key),
-	})
-	emit(noteEv)
 	return nil
 }
 
@@ -178,9 +174,8 @@ func (f *fileEncrypt) DryRun(params module.Params) []string {
 	extension := params.Get("extension", defaultEncryptExtension)
 	count := params.Get("file_count", "5")
 	return []string{
-		fmt.Sprintf("create %s decoy files in %s", count, stageDir),
+		fmt.Sprintf("stage %s plaintext decoy files with randomized extensions in %s", count, stageDir),
 		fmt.Sprintf("AES-256-GCM encrypt each in place, appending %q and removing the original (T1486)", extension),
-		fmt.Sprintf("drop ransom note %s in %s", ransomNoteName, stageDir),
 	}
 }
 

--- a/modules/file/encrypt_test.go
+++ b/modules/file/encrypt_test.go
@@ -1,0 +1,151 @@
+package file
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// decrypt reverses encryptFile, proving the operation is a faithful (reversible)
+// encryption rather than corruption.
+func decrypt(t *testing.T, ciphertext, key []byte) []byte {
+	t.Helper()
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := gcm.NonceSize()
+	if len(ciphertext) < ns {
+		t.Fatalf("ciphertext too short: %d < nonce %d", len(ciphertext), ns)
+	}
+	nonce, ct := ciphertext[:ns], ciphertext[ns:]
+	pt, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	return pt
+}
+
+func TestEncryptFile_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	plaintext := []byte("top secret victim data")
+	if err := os.WriteFile(path, plaintext, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+
+	encPath, err := encryptFile(path, ".locked", key)
+	if err != nil {
+		t.Fatalf("encryptFile: %v", err)
+	}
+
+	// The original plaintext must be gone and the encrypted file must exist.
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("original plaintext should be removed, stat err = %v", err)
+	}
+	if encPath != path+".locked" {
+		t.Errorf("encrypted path = %q, want %q", encPath, path+".locked")
+	}
+
+	ciphertext, err := os.ReadFile(encPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// It must not be stored in the clear.
+	if strings.Contains(string(ciphertext), "victim data") {
+		t.Error("ciphertext still contains plaintext")
+	}
+	// And it must decrypt back to exactly the original with the run's key.
+	if got := decrypt(t, ciphertext, key); string(got) != string(plaintext) {
+		t.Errorf("decrypted = %q, want %q", got, plaintext)
+	}
+}
+
+func TestGenerate_EncryptsAllAndDropsNote(t *testing.T) {
+	stage := filepath.Join(t.TempDir(), "enc")
+
+	var events []module.TelemetryEvent
+	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	f := &fileEncrypt{}
+	if err := f.Generate(context.Background(), module.Params{"stage_dir": stage, "file_count": "4"}, emit); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var encEvents, noteEvents int
+	for _, ev := range events {
+		switch ev.EventType {
+		case "file_encrypt":
+			encEvents++
+			if !ev.Success {
+				t.Errorf("file_encrypt failed: %s", ev.Message)
+			}
+		case "ransom_note_drop":
+			noteEvents++
+			if ev.Details["files_encrypted"] != 4 {
+				t.Errorf("files_encrypted = %v, want 4", ev.Details["files_encrypted"])
+			}
+		}
+	}
+	if encEvents != 4 {
+		t.Errorf("emitted %d file_encrypt events, want 4", encEvents)
+	}
+	if noteEvents != 1 {
+		t.Errorf("emitted %d ransom_note_drop events, want 1", noteEvents)
+	}
+
+	// No plaintext decoys should remain; only .locked files and the note.
+	entries, err := os.ReadDir(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".dat") {
+			t.Errorf("plaintext decoy %s was left behind", e.Name())
+		}
+	}
+	if _, err := os.Stat(filepath.Join(stage, ransomNoteName)); err != nil {
+		t.Errorf("ransom note not written: %v", err)
+	}
+}
+
+func TestEncryptDryRun(t *testing.T) {
+	steps := (&fileEncrypt{}).DryRun(module.Params{"file_count": "9", "extension": ".crypted"})
+	if len(steps) != 3 {
+		t.Fatalf("dry run = %v, want 3 steps", steps)
+	}
+	joined := strings.Join(steps, "\n")
+	for _, want := range []string{"9 decoy files", ".crypted", "T1486", ransomNoteName} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("dry run missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestEncryptCleanup_RemovesStageDir(t *testing.T) {
+	stage := filepath.Join(t.TempDir(), "enc")
+	if err := os.MkdirAll(stage, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f := &fileEncrypt{stageDir: stage}
+	if err := f.Cleanup(); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(stage); !os.IsNotExist(err) {
+		t.Errorf("stage dir should be removed, stat err = %v", err)
+	}
+}

--- a/modules/file/encrypt_test.go
+++ b/modules/file/encrypt_test.go
@@ -76,7 +76,32 @@ func TestEncryptFile_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestGenerate_EncryptsAllAndDropsNote(t *testing.T) {
+func TestStageDecoyFiles_CreatesPlaintextFilesWithRandomExtensions(t *testing.T) {
+	dir := t.TempDir()
+	paths, err := stageDecoyFiles(dir, 8)
+	if err != nil {
+		t.Fatalf("stageDecoyFiles: %v", err)
+	}
+	if len(paths) != 8 {
+		t.Fatalf("staged %d paths, want 8", len(paths))
+	}
+
+	for _, path := range paths {
+		if !containsDecoyExtension(filepath.Ext(path)) {
+			t.Errorf("staged file %q has an unexpected extension", path)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read staged file %q: %v", path, err)
+			continue
+		}
+		if !strings.Contains(string(content), "simulated victim data") {
+			t.Errorf("staged file %q is not plaintext decoy content", path)
+		}
+	}
+}
+
+func TestGenerate_StagesThenEncryptsAll(t *testing.T) {
 	stage := filepath.Join(t.TempDir(), "enc")
 
 	var events []module.TelemetryEvent
@@ -86,7 +111,7 @@ func TestGenerate_EncryptsAllAndDropsNote(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 
-	var encEvents, noteEvents int
+	var encEvents int
 	for _, ev := range events {
 		switch ev.EventType {
 		case "file_encrypt":
@@ -94,46 +119,50 @@ func TestGenerate_EncryptsAllAndDropsNote(t *testing.T) {
 			if !ev.Success {
 				t.Errorf("file_encrypt failed: %s", ev.Message)
 			}
-		case "ransom_note_drop":
-			noteEvents++
-			if ev.Details["files_encrypted"] != 4 {
-				t.Errorf("files_encrypted = %v, want 4", ev.Details["files_encrypted"])
+			original, _ := ev.Details["original"].(string)
+			if !containsDecoyExtension(filepath.Ext(original)) {
+				t.Errorf("encrypted unexpected source file %q", original)
 			}
 		}
 	}
 	if encEvents != 4 {
 		t.Errorf("emitted %d file_encrypt events, want 4", encEvents)
 	}
-	if noteEvents != 1 {
-		t.Errorf("emitted %d ransom_note_drop events, want 1", noteEvents)
-	}
-
-	// No plaintext decoys should remain; only .locked files and the note.
+	// No plaintext decoys should remain; each staged file has been encrypted.
 	entries, err := os.ReadDir(stage)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, e := range entries {
-		if strings.HasSuffix(e.Name(), ".dat") {
-			t.Errorf("plaintext decoy %s was left behind", e.Name())
-		}
+	if len(entries) != 4 {
+		t.Fatalf("found %d entries, want 4 encrypted files", len(entries))
 	}
-	if _, err := os.Stat(filepath.Join(stage, ransomNoteName)); err != nil {
-		t.Errorf("ransom note not written: %v", err)
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".locked") {
+			t.Errorf("unencrypted file %s was left behind", e.Name())
+		}
 	}
 }
 
 func TestEncryptDryRun(t *testing.T) {
 	steps := (&fileEncrypt{}).DryRun(module.Params{"file_count": "9", "extension": ".crypted"})
-	if len(steps) != 3 {
-		t.Fatalf("dry run = %v, want 3 steps", steps)
+	if len(steps) != 2 {
+		t.Fatalf("dry run = %v, want 2 steps", steps)
 	}
 	joined := strings.Join(steps, "\n")
-	for _, want := range []string{"9 decoy files", ".crypted", "T1486", ransomNoteName} {
+	for _, want := range []string{"9 plaintext decoy files", "randomized extensions", ".crypted", "T1486"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("dry run missing %q:\n%s", want, joined)
 		}
 	}
+}
+
+func containsDecoyExtension(extension string) bool {
+	for _, candidate := range decoyExtensions {
+		if extension == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func TestEncryptCleanup_RemovesStageDir(t *testing.T) {


### PR DESCRIPTION
Adds `file_encrypt`, a ransomware-style telemetry module. Stages decoy `.dat` files, AES-256-GCM encrypts each in place (nonce-prepended for reversibility), and drops a ransom note carrying the recovery key hex. Run ID is folded into the staging dir path. Emits `file_encrypt` per file and `ransom_note_drop` with full key details. Wires both event types into the OCSF classifier.