### PR TITLE
refactor: isolate module execution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - name: Run unit tests
         run: make test
@@ -46,10 +46,10 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - name: Run integration tests
-        run: make test-integration
+        run: go test -tags integration -race -count=1 ./...
 
   build:
     name: Build
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - name: Build darwin/${{ matrix.goarch }}
         run: make build-${{ matrix.goarch }}

--- a/AI-GUIDANCE.md
+++ b/AI-GUIDANCE.md
@@ -103,18 +103,18 @@ MacNoise is structured in five distinct layers. When reasoning about where a cha
 | File | Purpose |
 |------|---------|
 | `internal/config/config.go` | `Config` struct (`DefaultFormat`, `DefaultTimeout`, `OutputFile`, `AuditLog`); `Defaults()`, `Load(path)` |
-| `internal/prereqs/checker.go` | `IsMacOS`, `IsRoot`, `IsAdmin`, `HasCommand`; error-returning variants `CheckMacOS`, `CheckRoot`, `CheckCommand`; called from module `CheckPrereqs()` implementations |
+| `internal/prereqs/checker.go` | `IsMacOS`, `IsRoot`, `IsAdmin`, `HasCommand`; error-returning variants `CheckMacOS`, `CheckRoot`, `CheckCommand`; called from module `CheckPrereqs(ctx, params)` implementations |
 
 ### Configs and Scenarios
 
 | File | Purpose |
 |------|---------|
 | `configs/defaults.yaml` | Example config file — set `default_format`, `default_timeout`, `audit_log`, `output_file` |
-| `configs/scenarios/network_only.yaml` | All five network modules |
+| `configs/scenarios/network_only.yaml` | Selected connection, listener, DNS, and beacon modules |
 | `configs/scenarios/edr_validation.yaml` | Broad EDR detection coverage across process, network, file, persistence, TCC |
-| `configs/scenarios/full_sweep.yaml` | All 19 modules across all categories |
+| `configs/scenarios/full_sweep.yaml` | Broad sweep across all categories, excluding root-only modules |
 | `configs/scenarios/lazarus_group.yaml` | DPRK-style implant chain (T1574.006, T1071, T1059.004, T1543) |
-| `configs/scenarios/amos_atomic_stealer.yaml` | AMOS 2025 variant — 10 phases, 17 modules, full infostealer kill chain |
+| `configs/scenarios/amos_atomic_stealer.yaml` | AMOS 2025 variant with a 10-phase infostealer kill chain |
 
 ---
 
@@ -126,17 +126,17 @@ Every module is a Go struct that satisfies `module.Generator`:
 type Generator interface {
     Info()         ModuleInfo     // Static metadata: name, category, tags, privileges, MITRE
     ParamSpecs()   []ParamSpec    // Accepted parameters with defaults and examples
-    CheckPrereqs() error          // Fail fast if OS/privilege/command requirements aren't met
+    CheckPrereqs(ctx context.Context, params Params) error // Fail fast if requirements aren't met
     Generate(ctx context.Context, params Params, emit EventEmitter) error
     DryRun(params Params) []string // Human-readable description of actions; no side-effects
-    Cleanup() error               // Fully revert any persistent changes made by Generate
+    Cleanup(ctx context.Context) error // Fully revert persistent changes made by Generate
 }
 ```
 
 **Registration** — every module file has an `init()` function:
 ```go
 func init() {
-    module.Register(&myModule{})
+    module.Register(func() module.Generator { return &myModule{} })
 }
 ```
 
@@ -154,14 +154,14 @@ Adding a blank import there is the only change needed to the CLI when a new modu
 `RunSingle` in `internal/runner/runner.go` drives every module through this sequence:
 
 ```
-CheckPrereqs()
-  └─ fail → emit error, write audit lifecycle record, return
 DryRun mode?
   └─ yes → print actions, write audit dry-run record, return
+CheckPrereqs(ctx, params)
+  └─ fail → write audit lifecycle record, return error
 Generate(ctx, params, auditWrappedEmit)
   └─ each emit() call → telemetry event to stdout/file
                       → audit.LogEvent() (if --audit-log active)
-Cleanup()
+Cleanup(cleanupCtx)
   └─ write audit lifecycle record with full outcome data
 ```
 
@@ -217,12 +217,12 @@ The audit system is entirely transparent to module code. The runner owns it:
 
 ## Build and Platform Notes
 
-- **Target platform**: macOS (darwin). The binary is meaningless on other OSes.
+- **Target execution platform**: macOS (darwin). Other platforms support the complete catalog, scenario validation, and dry runs.
 - **Development environment**: Cross-compilation from any OS is supported via `GOOS=darwin`.
-- **Darwin-only code**: Modules that use `SIGSTOP`/`SIGCONT`, `launchctl`, or other Darwin-only syscalls carry a `//go:build darwin` tag.
+- **Darwin-only code**: Keep module metadata and registration portable, and isolate native syscall implementations behind `//go:build darwin` when required.
 - **CGO**: Not used. The build is pure Go.
 - **Version injection**: `make build` passes `-ldflags "-X main.version=$(VERSION)"`. Do not hardcode version strings.
-- **Unit tests run on any OS**: `go test ./pkg/... ./internal/...` — these packages avoid OS-specific syscalls.
+- **Unit tests run on any OS**: `go test ./...` covers the portable catalog and all cross-platform packages.
 - **Integration tests**: Tagged `//go:build integration && darwin` and require a real macOS system.
 
 ```bash
@@ -230,7 +230,7 @@ The audit system is entirely transparent to module code. The runner owns it:
 GOOS=darwin GOARCH=arm64 go build ./cmd/macnoise
 
 # Unit tests (any OS)
-go test ./pkg/... ./internal/...
+go test ./...
 
 # Lint
 golangci-lint run ./...
@@ -243,7 +243,7 @@ golangci-lint run ./...
 1. Create `modules/<category>/<name>.go`.
 2. Define a private struct and implement all 6 `Generator` methods.
 3. Populate `ModuleInfo` accurately — `Name` (unique, snake_case), `Category`, `Tags`, `Privileges`, `MITRE`.
-4. Add `func init() { module.Register(&myStruct{}) }`.
+4. Add `func init() { module.Register(func() module.Generator { return &myStruct{} }) }`.
 5. Add a blank import in `cmd/macnoise/main.go` (only needed for new *packages*).
 6. If the module emits a new `eventType` string that should map to a non-default OCSF activity, add a case in `internal/audit/classify.go`.
 7. Add a doc comment on the struct (required by `revive:exported` lint rule).
@@ -273,7 +273,7 @@ golangci-lint run ./...
 | No stdout from modules | All module output goes through `emit(ev)` |
 | No global state | Only the module registry (`pkg/module/registry.go`) uses package-level state; it is protected by `sync.RWMutex` |
 | Params access | Always `params.Get("key", "default")` — never index `params` directly |
-| Build tags | Darwin-only code: `//go:build darwin` on the first line |
+| Build tags | Keep metadata and registration portable; isolate Darwin-only implementation code behind `//go:build darwin` |
 | File names | One module per file, named after the module (`net_connect.go` → `net_connect` module) |
 | Package names | Module packages use the category name (e.g. `package network`), not the module name |
 
@@ -287,7 +287,7 @@ golangci-lint run ./...
 - **Missing `Cleanup()`** — every state change in `Generate()` must be reversible. If `Cleanup()` is a no-op because nothing persists, that is fine; it must still exist.
 - **Registering with a duplicate name** — `Register()` panics on collision. Module names are global and must be unique.
 - **Missing blank import** — a new category package won't register its modules unless imported in `cmd/macnoise/main.go`.
-- **Forgetting the darwin build tag** — Darwin-only syscalls in a file without `//go:build darwin` will cause `go test ./...` to fail on the dev machine.
+- **Hiding metadata behind a darwin build tag** - keep metadata and registration portable, and put only native implementation code behind `//go:build darwin`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,10 @@ Thanks for your interest in contributing! This guide covers how to add new telem
 type Generator interface {
     Info() ModuleInfo
     ParamSpecs() []ParamSpec
-    CheckPrereqs() error
+    CheckPrereqs(ctx context.Context, params Params) error
     Generate(ctx context.Context, params Params, emit EventEmitter) error
     DryRun(params Params) []string
-    Cleanup() error
+    Cleanup(ctx context.Context) error
 }
 ```
 
@@ -27,7 +27,7 @@ type Generator interface {
 
 ```go
 func init() {
-    module.Register(&myModule{})
+    module.Register(func() module.Generator { return &myModule{} })
 }
 ```
 
@@ -44,9 +44,9 @@ _ "github.com/0xv1n/macnoise/modules/mynewcategory"
 - [ ] Implements all 6 methods of `Generator`
 - [ ] `Info()` has accurate `Category`, `Tags`, `Privileges`, and `MITRE` entries
 - [ ] `ParamSpecs()` documents every accepted parameter with defaults and examples
-- [ ] `CheckPrereqs()` returns a clear error when requirements aren't met
+- [ ] `CheckPrereqs(ctx, params)` returns a clear error when requirements aren't met
 - [ ] `DryRun()` describes every action without executing side-effects
-- [ ] `Cleanup()` fully reverts any persistent changes
+- [ ] `Cleanup(ctx)` fully reverts any persistent changes
 - [ ] Module emits events via `emit()`, never writes directly to stdout
 - [ ] Registered in `cmd/macnoise/main.go` via blank import
 - [ ] Integration test file added

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Scenarios chain modules into ordered sequences - a single YAML file that replays
 
 | File | Description |
 |------|-------------|
-| `network_only.yaml` | All network modules |
+| `network_only.yaml` | Selected connection, listener, DNS, and beacon modules |
 | `edr_validation.yaml` | Comprehensive EDR detection coverage |
 | `full_sweep.yaml` | All categories |
 | `lazarus_group.yaml` | Lazarus Group: dylib injection, service discovery, reverse shell, plist persistence |
@@ -153,6 +153,7 @@ The two APT scenarios follow real documented intrusion sequences, technique by t
 **Writing your own:**
 ```yaml
 name: My Custom Scenario
+on_error: stop
 steps:
   - module: net_connect
     params:
@@ -162,6 +163,8 @@ steps:
     params:
       base_dir: "/tmp/test"
 ```
+
+`on_error` defaults to `stop`. Set it to `continue` only when a coverage sweep should attempt later module invocations after a failure.
 
 ## Contributing
 

--- a/cmd/macnoise/docs_test.go
+++ b/cmd/macnoise/docs_test.go
@@ -3,24 +3,11 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/0xv1n/macnoise/pkg/module"
 )
-
-// requireFullRegistry skips a check that needs every module registered.
-// proc_osascript and proc_signal carry //go:build darwin, so off a Mac they are
-// not compiled in and the registry is a subset. A completeness check run
-// against that subset either misses modules or, worse, reports a scenario's
-// valid reference as unregistered.
-func requireFullRegistry(t *testing.T) {
-	t.Helper()
-	if runtime.GOOS != "darwin" {
-		t.Skip("registry is incomplete off darwin; this runs in the macOS job")
-	}
-}
 
 // readRepoFile reads a path relative to the repository root. Tests run in their
 // own package directory, so the two levels up are cmd/macnoise.
@@ -47,8 +34,6 @@ func readRepoFile(t *testing.T, parts ...string) string {
 // This package blank-imports every module package, so module.All() here is the
 // same set the binary exposes.
 func TestDocsListEveryRegisteredModule(t *testing.T) {
-	requireFullRegistry(t)
-
 	readme := readRepoFile(t, "README.md")
 
 	categoryDocs := map[module.Category]string{}
@@ -75,8 +60,6 @@ func TestDocsListEveryRegisteredModule(t *testing.T) {
 // renamed out from under a scenario fails at run time partway through the
 // chain, after earlier steps have already made changes on the host.
 func TestScenariosReferenceRegisteredModules(t *testing.T) {
-	requireFullRegistry(t)
-
 	dir := filepath.Join("..", "..", "configs", "scenarios")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -98,6 +81,14 @@ func TestScenariosReferenceRegisteredModules(t *testing.T) {
 			if _, found := module.Get(name); !found {
 				t.Errorf("%s references unregistered module %q", e.Name(), name)
 			}
+		}
+	}
+}
+
+func TestPortableRegistryIncludesNativeModules(t *testing.T) {
+	for _, name := range []string{"proc_osascript", "proc_signal"} {
+		if _, ok := module.Get(name); !ok {
+			t.Errorf("portable registry is missing %s", name)
 		}
 	}
 }

--- a/cmd/macnoise/event_types_test.go
+++ b/cmd/macnoise/event_types_test.go
@@ -47,10 +47,14 @@ func TestModuleEventTypesMatchEmitted(t *testing.T) {
 			return nil // helper file, or event type built from a variable
 		}
 
-		declared := map[string]bool{}
-		if m := eventTypesLiteralRe.FindStringSubmatch(text); m != nil {
-			for _, q := range quotedStringRe.FindAllStringSubmatch(m[1], -1) {
-				declared[q[1]] = true
+		declared := declaredEventTypes(text)
+		if len(declared) == 0 {
+			commonPath := strings.TrimSuffix(path, ".go") + "_common.go"
+			commonSrc, readErr := os.ReadFile(commonPath)
+			if readErr == nil {
+				declared = declaredEventTypes(string(commonSrc))
+			} else if !os.IsNotExist(readErr) {
+				return readErr
 			}
 		}
 
@@ -66,9 +70,19 @@ func TestModuleEventTypesMatchEmitted(t *testing.T) {
 	}
 }
 
+func declaredEventTypes(src string) map[string]bool {
+	declared := map[string]bool{}
+	if m := eventTypesLiteralRe.FindStringSubmatch(src); m != nil {
+		for _, q := range quotedStringRe.FindAllStringSubmatch(m[1], -1) {
+			declared[q[1]] = true
+		}
+	}
+	return declared
+}
+
 // Every registered module must declare at least one event type, since every
-// module emits telemetry. Off darwin the registry is a subset (some modules are
-// build-tagged), which is fine: this checks whatever is registered.
+// module emits telemetry. The registry is portable, so this covers the complete
+// catalog on every supported development platform.
 func TestAllModulesDeclareEventTypes(t *testing.T) {
 	for _, g := range module.All() {
 		if len(g.Info().EventTypes) == 0 {

--- a/configs/scenarios/network_only.yaml
+++ b/configs/scenarios/network_only.yaml
@@ -1,5 +1,5 @@
 name: Network Telemetry Sweep
-description: Runs all network category modules to generate comprehensive network telemetry
+description: Runs selected network modules to generate connection, listener, DNS, and beacon telemetry
 
 steps:
   - module: net_connect

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -395,14 +395,14 @@ func lifecycleSeverity(data LifecycleData) (int, string) {
 	if data.PrereqResult == "fail" {
 		return 2, "Low"
 	}
-	if data.GenerateError != "" {
+	if data.GenerateError != "" || data.CleanupError != "" {
 		return 3, "Medium"
 	}
 	return 1, "Informational"
 }
 
 func lifecycleStatus(data LifecycleData) (int, string) {
-	if data.PrereqResult == "fail" || data.GenerateError != "" {
+	if data.PrereqResult == "fail" || data.GenerateError != "" || data.CleanupError != "" {
 		return 2, "Failure"
 	}
 	return 1, "Success"
@@ -415,8 +415,14 @@ func lifecycleMessage(recordType, moduleName string, data LifecycleData) string 
 	case "module_dry_run":
 		return fmt.Sprintf("Module %s dry-run completed", moduleName)
 	default:
+		if data.GenerateError != "" && data.CleanupError != "" {
+			return fmt.Sprintf("Module %s failed: %s; cleanup failed: %s", moduleName, data.GenerateError, data.CleanupError)
+		}
 		if data.GenerateError != "" {
 			return fmt.Sprintf("Module %s failed: %s", moduleName, data.GenerateError)
+		}
+		if data.CleanupError != "" {
+			return fmt.Sprintf("Module %s cleanup failed: %s", moduleName, data.CleanupError)
 		}
 		return fmt.Sprintf("Module %s completed successfully (%d events emitted)", moduleName, data.EventsEmitted)
 	}

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -205,6 +206,38 @@ func TestLogLifecycle_ModuleRun(t *testing.T) {
 	}
 	if rec.StatusID != 1 {
 		t.Errorf("expected status_id 1 (Success), got %d", rec.StatusID)
+	}
+}
+
+func TestLogLifecycle_CleanupFail(t *testing.T) {
+	l, path := newTestLogger(t)
+
+	info := module.ModuleInfo{Name: "file_create", Category: "file", Privileges: module.PrivilegeNone}
+	data := LifecycleData{
+		StartTime:     time.Now(),
+		EndTime:       time.Now(),
+		PrereqResult:  "pass",
+		CleanupResult: "error",
+		CleanupError:  "remove artifact: permission denied",
+	}
+
+	l.LogLifecycle("module_run", info, module.Params{}, data)
+	if err := l.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	records := readRecords(t, path)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].SeverityID != 3 {
+		t.Errorf("severity_id = %d, want 3 (Medium)", records[0].SeverityID)
+	}
+	if records[0].StatusID != 2 {
+		t.Errorf("status_id = %d, want 2 (Failure)", records[0].StatusID)
+	}
+	if !strings.Contains(records[0].Message, "cleanup failed") {
+		t.Errorf("message = %q, want cleanup failure", records[0].Message)
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -7,7 +7,9 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/0xv1n/macnoise/internal/audit"
@@ -16,7 +18,8 @@ import (
 
 // Options controls module execution behaviour in RunSingle, RunMany, and RunScenario.
 type Options struct {
-	DryRun bool
+	Registry *module.Registry
+	DryRun   bool
 	// NoCleanup leaves module artifacts in place after Generate. Validation
 	// workflows need the installed artifact to persist so the persistence
 	// itself can be detected, not just the install event.
@@ -31,7 +34,7 @@ type Options struct {
 }
 
 // RunSingle executes one module through its full lifecycle (prereqs → generate → cleanup).
-func RunSingle(ctx context.Context, gen module.Generator, params module.Params, emit module.EventEmitter, opts Options) error {
+func RunSingle(ctx context.Context, gen module.Generator, params module.Params, emit module.EventEmitter, opts Options) (resultErr error) {
 	info := gen.Info()
 	startTime := time.Now()
 
@@ -40,14 +43,25 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 		DryRun:    opts.DryRun,
 	}
 
-	if err := gen.CheckPrereqs(); err != nil {
-		lifecycle.PrereqResult = "fail"
-		lifecycle.PrereqError = err.Error()
-		if opts.AuditLog != nil {
-			lifecycle.EndTime = time.Now()
-			opts.AuditLog.LogLifecycle("module_prereq_fail", info, params, lifecycle)
+	runCtx := module.ContextWithRunID(ctx, opts.RunID)
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(runCtx, opts.Timeout)
+		defer cancel()
+	}
+	if err := runCtx.Err(); err != nil {
+		return err
+	}
+	if !opts.DryRun {
+		if err := gen.CheckPrereqs(runCtx, params); err != nil {
+			lifecycle.PrereqResult = "fail"
+			lifecycle.PrereqError = err.Error()
+			if opts.AuditLog != nil {
+				lifecycle.EndTime = time.Now()
+				opts.AuditLog.LogLifecycle("module_prereq_fail", info, params, lifecycle)
+			}
+			return fmt.Errorf("[%s] prereqs: %w", info.Name, err)
 		}
-		return fmt.Errorf("[%s] prereqs: %w", info.Name, err)
 	}
 	lifecycle.PrereqResult = "pass"
 
@@ -68,13 +82,6 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 		auditEmit = opts.AuditLog.WrapEmitter(emit, info, params, &eventsEmitted)
 	}
 
-	runCtx := module.ContextWithRunID(ctx, opts.RunID)
-	var cancel context.CancelFunc
-	if opts.Timeout > 0 {
-		runCtx, cancel = context.WithTimeout(runCtx, opts.Timeout)
-		defer cancel()
-	}
-
 	var generateErr error
 	defer func() {
 		cleanupResult := "ok"
@@ -87,12 +94,13 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 			cleanupResult = "skipped"
 			fmt.Printf("[%s] cleanup skipped (--no-cleanup); artifacts left in place, see 'macnoise info %s'\n", info.Name, info.Name)
 		default:
-			if err := gen.Cleanup(); err != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(runCtx), 10*time.Second)
+			defer cancel()
+			if err := gen.Cleanup(cleanupCtx); err != nil {
 				cleanupResult = "error"
 				cleanupErrStr = err.Error()
-				if opts.Verbose {
-					fmt.Printf("[%s] cleanup error: %v\n", info.Name, err)
-				}
+				resultErr = errors.Join(resultErr, fmt.Errorf("[%s] cleanup: %w", info.Name, err))
+				fmt.Fprintf(os.Stderr, "[%s] cleanup error: %v\n", info.Name, err)
 			}
 		}
 		if opts.AuditLog != nil {
@@ -108,6 +116,9 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 	}()
 
 	generateErr = gen.Generate(runCtx, params, auditEmit)
+	if runCtx.Err() != nil {
+		generateErr = errors.Join(generateErr, runCtx.Err())
+	}
 	return generateErr
 }
 
@@ -132,6 +143,10 @@ func RunMany(ctx context.Context, gens []module.Generator, params module.Params,
 
 // RunScenario loads the YAML scenario at path and executes its steps in order.
 func RunScenario(ctx context.Context, path string, emit module.EventEmitter, opts Options) error {
+	registry := opts.Registry
+	if registry == nil {
+		registry = &module.DefaultRegistry
+	}
 	sc, err := LoadScenario(path)
 	if err != nil {
 		return err
@@ -169,7 +184,7 @@ stepLoop:
 		var stepErr error
 		switch {
 		case step.Module != "":
-			gen, ok := module.Get(step.Module)
+			gen, ok := registry.Get(step.Module)
 			if !ok {
 				stepErr = fmt.Errorf("scenario step %d: module %q not found", i+1, step.Module)
 			} else {
@@ -178,23 +193,35 @@ stepLoop:
 
 		case step.Category != "":
 			cat := module.Category(step.Category)
-			gens := module.ByCategory(cat)
+			gens := registry.ByCategory(cat)
 			if len(gens) == 0 {
 				stepErr = fmt.Errorf("scenario step %d: no modules found for category %q", i+1, step.Category)
-			} else {
+			} else if sc.OnError == "continue" {
 				stepErr = RunMany(ctx, gens, params, emit, opts)
+			} else {
+				for _, gen := range gens {
+					if stepErr = RunSingle(ctx, gen, params, emit, opts); stepErr != nil {
+						break
+					}
+				}
 			}
 
 		default:
 			stepErr = fmt.Errorf("scenario step %d: must specify either 'module' or 'category'", i+1)
 		}
 
+		if err := ctx.Err(); err != nil {
+			interruptErr = fmt.Errorf("scenario %q: interrupted during step %d of %d: %w",
+				sc.Name, i+1, len(sc.Steps), err)
+			break stepLoop
+		}
+
 		if stepErr != nil {
 			stepsFailed++
-			if opts.AuditLog == nil {
-				return stepErr
+			fmt.Fprintf(os.Stderr, "step %d error: %v\n", i+1, stepErr)
+			if sc.OnError != "continue" {
+				break stepLoop
 			}
-			fmt.Printf("step %d error: %v\n", i+1, stepErr)
 		} else {
 			stepsPassed++
 		}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,29 +17,40 @@ import (
 )
 
 type mockGen struct {
-	name        string
-	prereqErr   error
-	generateErr error
-	cleanupErr  error
-	events      []module.TelemetryEvent
-	dryRunLines []string
-	cleanedUp   bool
+	name         string
+	category     module.Category
+	prereqErr    error
+	generateErr  error
+	cleanupErr   error
+	events       []module.TelemetryEvent
+	dryRunLines  []string
+	onGenerate   func()
+	cleanedUp    bool
+	cleanupRunID string
 }
 
 func (m *mockGen) Info() module.ModuleInfo {
-	return module.ModuleInfo{Name: m.name, Category: "test"}
+	category := m.category
+	if category == "" {
+		category = "test"
+	}
+	return module.ModuleInfo{Name: m.name, Category: category}
 }
-func (m *mockGen) ParamSpecs() []module.ParamSpec { return nil }
-func (m *mockGen) CheckPrereqs() error            { return m.prereqErr }
+func (m *mockGen) ParamSpecs() []module.ParamSpec                               { return nil }
+func (m *mockGen) CheckPrereqs(ctx context.Context, params module.Params) error { return m.prereqErr }
 func (m *mockGen) Generate(_ context.Context, _ module.Params, emit module.EventEmitter) error {
+	if m.onGenerate != nil {
+		m.onGenerate()
+	}
 	for _, ev := range m.events {
 		emit(ev)
 	}
 	return m.generateErr
 }
 func (m *mockGen) DryRun(_ module.Params) []string { return m.dryRunLines }
-func (m *mockGen) Cleanup() error {
+func (m *mockGen) Cleanup(ctx context.Context) error {
 	m.cleanedUp = true
+	m.cleanupRunID = module.RunIDFromContext(ctx)
 	return m.cleanupErr
 }
 
@@ -65,6 +77,59 @@ func TestRunSingleSuccess(t *testing.T) {
 	}
 }
 
+func TestRunSingleReturnsCleanupError(t *testing.T) {
+	want := errors.New("cleanup failed")
+	gen := &mockGen{name: "cleanup_error", cleanupErr: want}
+	err := runner.RunSingle(context.Background(), gen, nil, func(module.TelemetryEvent) {}, runner.Options{})
+	if !errors.Is(err, want) {
+		t.Fatalf("RunSingle = %v, want cleanup failure", err)
+	}
+}
+
+func TestRunSingleJoinsGenerateAndCleanupErrors(t *testing.T) {
+	generateErr := errors.New("generation failed")
+	cleanupErr := errors.New("cleanup failed")
+	gen := &mockGen{name: "joined_errors", generateErr: generateErr, cleanupErr: cleanupErr}
+	err := runner.RunSingle(context.Background(), gen, nil, func(module.TelemetryEvent) {}, runner.Options{})
+	if !errors.Is(err, generateErr) || !errors.Is(err, cleanupErr) {
+		t.Fatalf("RunSingle = %v, want both generation and cleanup failures", err)
+	}
+}
+
+func TestRunScenarioAuditDoesNotChangeFailurePolicy(t *testing.T) {
+	for _, auditEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprint(auditEnabled), func(t *testing.T) {
+			name := fmt.Sprintf("failed_step_%v", auditEnabled)
+			var registry module.Registry
+			registry.Register(func() module.Generator {
+				return &mockGen{
+					name:        name,
+					generateErr: errors.New("execution failed"),
+					events:      []module.TelemetryEvent{{Success: true}},
+				}
+			})
+			var logger *audit.Logger
+			if auditEnabled {
+				var err error
+				logger, err = audit.NewLogger(filepath.Join(t.TempDir(), "audit.jsonl"), "test", "run")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer logger.Close()
+			}
+			path := writeScenario(t, name, 2, "")
+			calls := 0
+			err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) { calls++ }, runner.Options{
+				Registry: &registry,
+				AuditLog: logger,
+			})
+			if err == nil || calls != 1 {
+				t.Fatalf("error = %v, steps executed = %d; want one failed step", err, calls)
+			}
+		})
+	}
+}
+
 func TestRunSinglePrereqFails(t *testing.T) {
 	gen := &mockGen{
 		name:      "mock_prereq_fail",
@@ -79,6 +144,7 @@ func TestRunSinglePrereqFails(t *testing.T) {
 func TestRunSingleDryRun(t *testing.T) {
 	gen := &mockGen{
 		name:        "mock_dryrun",
+		prereqErr:   errors.New("native prerequisites should not run during preview"),
 		dryRunLines: []string{"action one", "action two"},
 		generateErr: errors.New("should not run"),
 	}
@@ -95,8 +161,11 @@ func TestRunSingleTimeout(t *testing.T) {
 	slowGen := &slowMockGen{name: "mock_slow", delay: 2 * time.Second}
 
 	err := runner.RunSingle(context.Background(), slowGen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{Timeout: 50 * time.Millisecond})
-	if err == nil {
-		t.Error("expected timeout error")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("RunSingle = %v, want context deadline exceeded", err)
+	}
+	if !slowGen.cleanedUp || slowGen.cleanupCtxErr != nil {
+		t.Errorf("cleanup called = %v, cleanup context error = %v", slowGen.cleanedUp, slowGen.cleanupCtxErr)
 	}
 }
 
@@ -112,14 +181,15 @@ func TestRunManyCollectsErrors(t *testing.T) {
 }
 
 type slowMockGen struct {
-	name      string
-	delay     time.Duration
-	cleanedUp bool
+	name          string
+	delay         time.Duration
+	cleanedUp     bool
+	cleanupCtxErr error
 }
 
-func (s *slowMockGen) Info() module.ModuleInfo        { return module.ModuleInfo{Name: s.name} }
-func (s *slowMockGen) ParamSpecs() []module.ParamSpec { return nil }
-func (s *slowMockGen) CheckPrereqs() error            { return nil }
+func (s *slowMockGen) Info() module.ModuleInfo                                      { return module.ModuleInfo{Name: s.name} }
+func (s *slowMockGen) ParamSpecs() []module.ParamSpec                               { return nil }
+func (s *slowMockGen) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 func (s *slowMockGen) Generate(ctx context.Context, _ module.Params, _ module.EventEmitter) error {
 	select {
 	case <-ctx.Done():
@@ -129,8 +199,9 @@ func (s *slowMockGen) Generate(ctx context.Context, _ module.Params, _ module.Ev
 	}
 }
 func (s *slowMockGen) DryRun(_ module.Params) []string { return nil }
-func (s *slowMockGen) Cleanup() error {
+func (s *slowMockGen) Cleanup(ctx context.Context) error {
 	s.cleanedUp = true
+	s.cleanupCtxErr = ctx.Err()
 	return nil
 }
 
@@ -153,36 +224,41 @@ func TestRunSingleCleansUpOnCancel(t *testing.T) {
 	if !gen.cleanedUp {
 		t.Error("expected Cleanup to run after cancellation")
 	}
+	if gen.cleanupCtxErr != nil {
+		t.Errorf("cleanup context error = %v, want independent context", gen.cleanupCtxErr)
+	}
 }
 
 // countingGen records how many times Generate was invoked and can trigger a
 // side-effect (used here to cancel the scenario context mid-run).
 type countingGen struct {
 	name   string
-	calls  int
 	onCall func()
 }
 
 func (c *countingGen) Info() module.ModuleInfo {
 	return module.ModuleInfo{Name: c.name, Category: "test"}
 }
-func (c *countingGen) ParamSpecs() []module.ParamSpec { return nil }
-func (c *countingGen) CheckPrereqs() error            { return nil }
+func (c *countingGen) ParamSpecs() []module.ParamSpec                               { return nil }
+func (c *countingGen) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 func (c *countingGen) Generate(_ context.Context, _ module.Params, _ module.EventEmitter) error {
-	c.calls++
 	if c.onCall != nil {
 		c.onCall()
 	}
 	return nil
 }
-func (c *countingGen) DryRun(_ module.Params) []string { return nil }
-func (c *countingGen) Cleanup() error                  { return nil }
+func (c *countingGen) DryRun(_ module.Params) []string   { return nil }
+func (c *countingGen) Cleanup(ctx context.Context) error { return nil }
 
 // writeScenario builds a temp scenario file invoking moduleName stepCount times.
-func writeScenario(t *testing.T, moduleName string, stepCount int) string {
+func writeScenario(t *testing.T, moduleName string, stepCount int, onError string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "scenario.yaml")
-	body := "name: cancel test\nsteps:\n" +
+	body := "name: cancel test\n"
+	if onError != "" {
+		body += "on_error: " + onError + "\n"
+	}
+	body += "steps:\n" +
 		strings.Repeat("  - module: "+moduleName+"\n", stepCount)
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write scenario: %v", err)
@@ -193,20 +269,36 @@ func writeScenario(t *testing.T, moduleName string, stepCount int) string {
 // An interrupted scenario must stop at the step it reached rather than
 // fast-failing through every remaining step.
 func TestRunScenarioStopsOnCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	for _, tc := range []struct {
+		name    string
+		onError string
+	}{
+		{name: "stop"},
+		{name: "continue", onError: "continue"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	gen := &countingGen{name: "mock_scenario_step", onCall: cancel}
-	module.Register(gen)
+			calls := 0
+			name := "mock_scenario_step_" + tc.name
+			var registry module.Registry
+			registry.Register(func() module.Generator {
+				return &countingGen{name: name, onCall: func() {
+					calls++
+					cancel()
+				}}
+			})
 
-	path := writeScenario(t, gen.name, 4)
-
-	err := runner.RunScenario(ctx, path, func(module.TelemetryEvent) {}, runner.Options{})
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled, got %v", err)
-	}
-	if gen.calls != 1 {
-		t.Errorf("expected scenario to stop after 1 step, ran %d", gen.calls)
+			path := writeScenario(t, name, 4, tc.onError)
+			err := runner.RunScenario(ctx, path, func(module.TelemetryEvent) {}, runner.Options{Registry: &registry})
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("expected context.Canceled, got %v", err)
+			}
+			if calls != 1 {
+				t.Errorf("expected scenario to stop after 1 step, ran %d", calls)
+			}
+		})
 	}
 }
 
@@ -216,8 +308,11 @@ func TestRunScenarioAuditsInterrupt(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	gen := &countingGen{name: "mock_audited_step", onCall: cancel}
-	module.Register(gen)
+	name := "mock_audited_step"
+	var registry module.Registry
+	registry.Register(func() module.Generator {
+		return &countingGen{name: name, onCall: cancel}
+	})
 
 	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
 	logger, err := audit.NewLogger(auditPath, "test", "")
@@ -225,8 +320,11 @@ func TestRunScenarioAuditsInterrupt(t *testing.T) {
 		t.Fatalf("new audit logger: %v", err)
 	}
 
-	path := writeScenario(t, gen.name, 5)
-	runErr := runner.RunScenario(ctx, path, func(module.TelemetryEvent) {}, runner.Options{AuditLog: logger})
+	path := writeScenario(t, name, 5, "")
+	runErr := runner.RunScenario(ctx, path, func(module.TelemetryEvent) {}, runner.Options{
+		Registry: &registry,
+		AuditLog: logger,
+	})
 	if !errors.Is(runErr, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", runErr)
 	}
@@ -257,8 +355,11 @@ func TestRunScenarioAuditsInterrupt(t *testing.T) {
 	}
 
 	unmapped := scenarioRec["unmapped"].(map[string]any)
-	if got := unmapped["steps_passed"]; got != float64(1) {
-		t.Errorf("steps_passed = %v, want 1", got)
+	if got := unmapped["steps_passed"]; got != float64(0) {
+		t.Errorf("steps_passed = %v, want 0", got)
+	}
+	if got := unmapped["steps_failed"]; got != float64(0) {
+		t.Errorf("steps_failed = %v, want 0", got)
 	}
 	if got := unmapped["total_steps"]; got != float64(5) {
 		t.Errorf("total_steps = %v, want 5", got)
@@ -296,5 +397,69 @@ func TestRunSingle_RunIDInContext(t *testing.T) {
 	}
 	if gen.capturedRunID != "test_run_id_1234" {
 		t.Errorf("RunIDFromContext = %q, want test_run_id_1234", gen.capturedRunID)
+	}
+	if gen.cleanupRunID != "test_run_id_1234" {
+		t.Errorf("cleanup RunIDFromContext = %q, want test_run_id_1234", gen.cleanupRunID)
+	}
+}
+
+func TestRunScenarioCategoryHonorsOnErrorPerInvocation(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		onError   string
+		wantCalls int
+	}{
+		{name: "default_stop", wantCalls: 1},
+		{name: "explicit_stop", onError: "stop", wantCalls: 1},
+		{name: "continue", onError: "continue", wantCalls: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			const category = module.Category("category_policy")
+			calls := 0
+			var registry module.Registry
+			registry.Register(func() module.Generator {
+				return &mockGen{
+					name:        "a_fail",
+					category:    category,
+					generateErr: errors.New("execution failed"),
+					onGenerate:  func() { calls++ },
+				}
+			})
+			registry.Register(func() module.Generator {
+				return &mockGen{
+					name:       "b_after",
+					category:   category,
+					onGenerate: func() { calls++ },
+				}
+			})
+
+			path := filepath.Join(t.TempDir(), "scenario.yaml")
+			body := "name: category policy\n"
+			if tt.onError != "" {
+				body += "on_error: " + tt.onError + "\n"
+			}
+			body += "steps:\n  - category: " + string(category) + "\n"
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) {}, runner.Options{Registry: &registry})
+			if err == nil {
+				t.Fatal("expected scenario failure")
+			}
+			if calls != tt.wantCalls {
+				t.Errorf("module calls = %d, want %d", calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestLoadScenarioRejectsInvalidOnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scenario.yaml")
+	if err := os.WriteFile(path, []byte("name: invalid\non_error: retry\nsteps:\n  - module: example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runner.LoadScenario(path); err == nil || !strings.Contains(err.Error(), "invalid on_error") {
+		t.Fatalf("LoadScenario error = %v, want invalid on_error", err)
 	}
 }

--- a/internal/runner/scenario.go
+++ b/internal/runner/scenario.go
@@ -16,6 +16,7 @@ type ScenarioStep struct {
 
 // Scenario is the top-level structure parsed from a scenario YAML file.
 type Scenario struct {
+	OnError     string         `yaml:"on_error,omitempty"`
 	Name        string         `yaml:"name"`
 	Description string         `yaml:"description"`
 	AuditLog    string         `yaml:"audit_log,omitempty"`
@@ -34,6 +35,9 @@ func LoadScenario(path string) (Scenario, error) {
 	}
 	if len(sc.Steps) == 0 {
 		return Scenario{}, fmt.Errorf("scenario: %s contains no steps", path)
+	}
+	if sc.OnError != "" && sc.OnError != "stop" && sc.OnError != "continue" {
+		return Scenario{}, fmt.Errorf("scenario: invalid on_error %q", sc.OnError)
 	}
 	return sc, nil
 }

--- a/modules/endpoint_security/es_file.go
+++ b/modules/endpoint_security/es_file.go
@@ -41,7 +41,7 @@ func (e *esFile) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (e *esFile) CheckPrereqs() error { return nil }
+func (e *esFile) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (e *esFile) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	workDir := module.TagPath(params.Get("work_dir", "/tmp/macnoise_es"), module.RunIDFromContext(ctx))
@@ -157,7 +157,7 @@ func (e *esFile) DryRun(params module.Params) []string {
 	}
 }
 
-func (e *esFile) Cleanup() error {
+func (e *esFile) Cleanup(ctx context.Context) error {
 	if e.createdPath != "" {
 		return os.Remove(e.createdPath)
 	}
@@ -165,5 +165,5 @@ func (e *esFile) Cleanup() error {
 }
 
 func init() {
-	module.Register(&esFile{})
+	module.Register(func() module.Generator { return &esFile{} })
 }

--- a/modules/endpoint_security/es_file_test.go
+++ b/modules/endpoint_security/es_file_test.go
@@ -20,7 +20,7 @@ func TestESFile_GenerateEmitsFullFileEventCycle(t *testing.T) {
 	if err := e.Generate(context.Background(), module.Params{"work_dir": workDir}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	defer e.Cleanup() //nolint:errcheck
+	defer e.Cleanup(context.Background()) //nolint:errcheck
 
 	// Order is load-bearing, not incidental: setmode and rename have to happen
 	// while the file still exists, and rename has to precede the unlink that
@@ -73,7 +73,7 @@ func TestESFile_CleanupRemovesTrackedRenamedPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := e.Cleanup(); err != nil {
+	if err := e.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(renamed); !os.IsNotExist(err) {
@@ -89,7 +89,7 @@ func TestESFile_CleanupAfterSuccessfulUnlinkIsNoOp(t *testing.T) {
 	if err := e.Generate(context.Background(), module.Params{"work_dir": workDir}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	if err := e.Cleanup(); err != nil {
+	if err := e.Cleanup(context.Background()); err != nil {
 		t.Errorf("Cleanup after a successful unlink must not error, got %v", err)
 	}
 }

--- a/modules/endpoint_security/es_mount.go
+++ b/modules/endpoint_security/es_mount.go
@@ -53,7 +53,7 @@ func (e *esMount) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (e *esMount) CheckPrereqs() error { return nil }
+func (e *esMount) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // attachResult is what hdiutil attach reports back about the image it mounted.
 type attachResult struct {
@@ -228,11 +228,11 @@ func (e *esMount) DryRun(params module.Params) []string {
 // Cleanup detaches the image only if Generate actually mounted one, so a run
 // that never got that far does not report a detach failure for a volume that
 // was never there.
-func (e *esMount) Cleanup() error {
+func (e *esMount) Cleanup(ctx context.Context) error {
 	var errs []error
 
 	if target := e.detachTarget(); target != "" {
-		if out, err := exec.Command("hdiutil", detachArgs(target)...).CombinedOutput(); err != nil {
+		if out, err := exec.CommandContext(ctx, "hdiutil", detachArgs(target)...).CombinedOutput(); err != nil {
 			errs = append(errs, fmt.Errorf("detach %s: %v: %s", target, err, strings.TrimSpace(string(out))))
 		} else {
 			e.mountPoint, e.device = "", ""
@@ -260,5 +260,5 @@ func (e *esMount) detachTarget() string {
 }
 
 func init() {
-	module.Register(&esMount{})
+	module.Register(func() module.Generator { return &esMount{} })
 }

--- a/modules/endpoint_security/es_mount_integration_test.go
+++ b/modules/endpoint_security/es_mount_integration_test.go
@@ -22,7 +22,7 @@ func runMount(t *testing.T, e *esMount, workDir string) []module.TelemetryEvent 
 	// Registered before Generate so a panic or an assertion failure part-way
 	// through still detaches the image, rather than leaving a mounted volume
 	// behind for every subsequent run on the same machine.
-	t.Cleanup(func() { _ = e.Cleanup() })
+	t.Cleanup(func() { _ = e.Cleanup(context.Background()) })
 
 	if err := e.Generate(context.Background(), module.Params{"work_dir": workDir}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -114,7 +114,7 @@ func TestESMount_CleanupRemovesTheDiskImage(t *testing.T) {
 	if _, err := os.Stat(dmgPath); err != nil {
 		t.Fatalf("expected %s to exist before Cleanup: %v", dmgPath, err)
 	}
-	if err := e.Cleanup(); err != nil {
+	if err := e.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(dmgPath); !os.IsNotExist(err) {

--- a/modules/endpoint_security/es_mount_test.go
+++ b/modules/endpoint_security/es_mount_test.go
@@ -1,6 +1,7 @@
 package endpointsecurity
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -105,7 +106,7 @@ func TestCleanupIsNoOpWhenNothingWasMounted(t *testing.T) {
 	if target := (&esMount{}).detachTarget(); target != "" {
 		t.Errorf("detach target = %q, want empty when nothing was mounted", target)
 	}
-	if err := (&esMount{}).Cleanup(); err != nil {
+	if err := (&esMount{}).Cleanup(context.Background()); err != nil {
 		t.Errorf("Cleanup on an untouched module returned %v", err)
 	}
 }

--- a/modules/endpoint_security/es_process.go
+++ b/modules/endpoint_security/es_process.go
@@ -33,7 +33,7 @@ func (e *esProcess) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (e *esProcess) CheckPrereqs() error { return nil }
+func (e *esProcess) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // buildExecChainArgs nests depth-1 levels of `sh -c '"$@"' sh <rest>` around
 // a final `echo es_exit`. The '"$@"' script just re-execs its own
@@ -94,8 +94,8 @@ func (e *esProcess) DryRun(params module.Params) []string {
 	}
 }
 
-func (e *esProcess) Cleanup() error { return nil }
+func (e *esProcess) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&esProcess{})
+	module.Register(func() module.Generator { return &esProcess{} })
 }

--- a/modules/endpoint_security/es_process_exec_test.go
+++ b/modules/endpoint_security/es_process_exec_test.go
@@ -90,7 +90,7 @@ func TestESProcessGenerate_Chains(t *testing.T) {
 			if err != nil || string(data) != strings.Repeat("sh\n", tt.wantDepth-1) {
 				t.Errorf("shell trace = %q, %v; want %d wrappers", data, err, tt.wantDepth-1)
 			}
-			if err := p.Cleanup(); err != nil {
+			if err := p.Cleanup(context.Background()); err != nil {
 				t.Fatalf("Cleanup: %v", err)
 			}
 		})

--- a/modules/evasion/log_clear.go
+++ b/modules/evasion/log_clear.go
@@ -48,7 +48,7 @@ func (e *evadeLogClear) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (e *evadeLogClear) CheckPrereqs() error { return nil }
+func (e *evadeLogClear) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // timestomp creates a file and sets its mtime to a date in the past.
 // The os.Chtimes call generates the utimes syscall that an EDR fires on,
@@ -178,7 +178,7 @@ func (e *evadeLogClear) DryRun(params module.Params) []string {
 	}
 }
 
-func (e *evadeLogClear) Cleanup() error {
+func (e *evadeLogClear) Cleanup(ctx context.Context) error {
 	if e.stageDir == "" {
 		return nil
 	}
@@ -186,5 +186,5 @@ func (e *evadeLogClear) Cleanup() error {
 }
 
 func init() {
-	module.Register(&evadeLogClear{})
+	module.Register(func() module.Generator { return &evadeLogClear{} })
 }

--- a/modules/evasion/log_clear_exec_test.go
+++ b/modules/evasion/log_clear_exec_test.go
@@ -62,7 +62,7 @@ func TestLogClearGenerate_RealExecution(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(stage, ".zsh_history")); !os.IsNotExist(err) {
 		t.Errorf("history not removed: %v", err)
 	}
-	if err := g.Cleanup(); err != nil {
+	if err := g.Cleanup(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(stage); !os.IsNotExist(err) {
@@ -86,7 +86,7 @@ func TestLogClearGenerate_CancelBetweenOperations(t *testing.T) {
 	if !errors.Is(err, context.Canceled) || len(events) != 1 || events[0].EventType != "file_timestomp" {
 		t.Fatalf("Generate = %v, events = %+v", err, events)
 	}
-	if err := g.Cleanup(); err != nil {
+	if err := g.Cleanup(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(stage); !os.IsNotExist(err) {

--- a/modules/evasion/log_clear_test.go
+++ b/modules/evasion/log_clear_test.go
@@ -1,6 +1,7 @@
 package evasion
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,7 +78,7 @@ func TestCleanupRemovesStagingDir(t *testing.T) {
 	}
 
 	mod := &evadeLogClear{stageDir: stageDir}
-	if err := mod.Cleanup(); err != nil {
+	if err := mod.Cleanup(context.Background()); err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
 	if _, err := os.Stat(stageDir); !os.IsNotExist(err) {

--- a/modules/evasion/masquerade.go
+++ b/modules/evasion/masquerade.go
@@ -51,7 +51,7 @@ func (e *evadeMasquerade) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (e *evadeMasquerade) CheckPrereqs() error { return nil }
+func (e *evadeMasquerade) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // copyExecutable copies src to dst with executable permissions. It is the pure,
 // cross-platform-testable half of the module; the exec that follows is the
@@ -141,7 +141,7 @@ func (e *evadeMasquerade) DryRun(params module.Params) []string {
 	}
 }
 
-func (e *evadeMasquerade) Cleanup() error {
+func (e *evadeMasquerade) Cleanup(ctx context.Context) error {
 	if e.stageDir == "" {
 		return nil
 	}
@@ -149,5 +149,5 @@ func (e *evadeMasquerade) Cleanup() error {
 }
 
 func init() {
-	module.Register(&evadeMasquerade{})
+	module.Register(func() module.Generator { return &evadeMasquerade{} })
 }

--- a/modules/evasion/masquerade_integration_test.go
+++ b/modules/evasion/masquerade_integration_test.go
@@ -24,7 +24,7 @@ func TestMasqueradeGenerate_CopiesAndExecutes(t *testing.T) {
 	if err := e.Generate(ctx, params, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	t.Cleanup(func() { _ = e.Cleanup() })
+	t.Cleanup(func() { _ = e.Cleanup(context.Background()) })
 
 	if len(events) != 2 {
 		t.Fatalf("emitted %d events, want 2: %+v", len(events), events)

--- a/modules/evasion/masquerade_test.go
+++ b/modules/evasion/masquerade_test.go
@@ -1,6 +1,7 @@
 package evasion
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,7 +73,7 @@ func TestMasqueradeCleanup_RemovesStageDir(t *testing.T) {
 	}
 
 	e := &evadeMasquerade{stageDir: dir}
-	if err := e.Cleanup(); err != nil {
+	if err := e.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {

--- a/modules/file/archive.go
+++ b/modules/file/archive.go
@@ -41,7 +41,7 @@ func (f *fileArchive) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (f *fileArchive) CheckPrereqs() error { return nil }
+func (f *fileArchive) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (f *fileArchive) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
@@ -115,7 +115,7 @@ func (f *fileArchive) DryRun(params module.Params) []string {
 	}
 }
 
-func (f *fileArchive) Cleanup() error {
+func (f *fileArchive) Cleanup(ctx context.Context) error {
 	var lastErr error
 	if f.outputPath != "" {
 		if err := os.Remove(f.outputPath); err != nil && !os.IsNotExist(err) {
@@ -131,5 +131,5 @@ func (f *fileArchive) Cleanup() error {
 }
 
 func init() {
-	module.Register(&fileArchive{})
+	module.Register(func() module.Generator { return &fileArchive{} })
 }

--- a/modules/file/archive_test.go
+++ b/modules/file/archive_test.go
@@ -42,7 +42,7 @@ func TestFileArchive_GenerateAndCleanup(t *testing.T) {
 		t.Error("expected a successful archive_create event")
 	}
 
-	if err := f.Cleanup(); err != nil {
+	if err := f.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {

--- a/modules/file/browser_creds.go
+++ b/modules/file/browser_creds.go
@@ -144,7 +144,7 @@ func (f *fileBrowserCreds) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (f *fileBrowserCreds) CheckPrereqs() error { return nil }
+func (f *fileBrowserCreds) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func browserTargets() ([]browserTarget, error) {
 	home, err := os.UserHomeDir()
@@ -255,8 +255,8 @@ func (f *fileBrowserCreds) DryRun(params module.Params) []string {
 	}
 }
 
-func (f *fileBrowserCreds) Cleanup() error { return nil }
+func (f *fileBrowserCreds) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&fileBrowserCreds{})
+	module.Register(func() module.Generator { return &fileBrowserCreds{} })
 }

--- a/modules/file/create.go
+++ b/modules/file/create.go
@@ -43,7 +43,7 @@ func (f *fileCreate) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (f *fileCreate) CheckPrereqs() error { return nil }
+func (f *fileCreate) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // stampedFileName builds the file name, folding the run ID in after the prefix
 // when one is set so a consumer can correlate the file back to the run.
@@ -130,7 +130,7 @@ func (f *fileCreate) DryRun(params module.Params) []string {
 	}
 }
 
-func (f *fileCreate) Cleanup() error {
+func (f *fileCreate) Cleanup(ctx context.Context) error {
 	var lastErr error
 	for _, p := range f.createdPaths {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
@@ -142,5 +142,5 @@ func (f *fileCreate) Cleanup() error {
 }
 
 func init() {
-	module.Register(&fileCreate{})
+	module.Register(func() module.Generator { return &fileCreate{} })
 }

--- a/modules/file/create_named_test.go
+++ b/modules/file/create_named_test.go
@@ -39,7 +39,7 @@ func TestFileCreate_GenerateNamedFile(t *testing.T) {
 		t.Errorf("created %d files, want 1", len(entries))
 	}
 
-	if err := f.Cleanup(); err != nil {
+	if err := f.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/modules/file/create_test.go
+++ b/modules/file/create_test.go
@@ -39,7 +39,7 @@ func TestFileCreate_GenerateAndCleanup(t *testing.T) {
 		t.Errorf("expected 3 successful file_create events, got %d", successCount)
 	}
 
-	if err := f.Cleanup(); err != nil {
+	if err := f.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	entries, err = os.ReadDir(dir)

--- a/modules/file/cred_files.go
+++ b/modules/file/cred_files.go
@@ -49,7 +49,7 @@ func (f *fileCredFiles) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (f *fileCredFiles) CheckPrereqs() error { return nil }
+func (f *fileCredFiles) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // sshKeyPaths lists the SSH private keys to probe. The well-known names are
 // always included so an absent key still produces telemetry, and a glob catches
@@ -197,8 +197,8 @@ func (f *fileCredFiles) DryRun(params module.Params) []string {
 	return lines
 }
 
-func (f *fileCredFiles) Cleanup() error { return nil }
+func (f *fileCredFiles) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&fileCredFiles{})
+	module.Register(func() module.Generator { return &fileCredFiles{} })
 }

--- a/modules/file/encrypt.go
+++ b/modules/file/encrypt.go
@@ -52,7 +52,7 @@ func (f *fileEncrypt) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (f *fileEncrypt) CheckPrereqs() error { return nil }
+func (f *fileEncrypt) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // stageDecoyFiles writes all plaintext decoys into dir before encryption begins.
 // Only these macnoise-created decoys are ever encrypted; the module never reads
@@ -179,7 +179,7 @@ func (f *fileEncrypt) DryRun(params module.Params) []string {
 	}
 }
 
-func (f *fileEncrypt) Cleanup() error {
+func (f *fileEncrypt) Cleanup(ctx context.Context) error {
 	if f.stageDir == "" {
 		return nil
 	}
@@ -187,5 +187,5 @@ func (f *fileEncrypt) Cleanup() error {
 }
 
 func init() {
-	module.Register(&fileEncrypt{})
+	module.Register(func() module.Generator { return &fileEncrypt{} })
 }

--- a/modules/file/encrypt_test.go
+++ b/modules/file/encrypt_test.go
@@ -171,7 +171,7 @@ func TestEncryptCleanup_RemovesStageDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	f := &fileEncrypt{stageDir: stage}
-	if err := f.Cleanup(); err != nil {
+	if err := f.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(stage); !os.IsNotExist(err) {

--- a/modules/file/hide.go
+++ b/modules/file/hide.go
@@ -43,7 +43,7 @@ func (f *fileHide) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (f *fileHide) CheckPrereqs() error { return nil }
+func (f *fileHide) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (f *fileHide) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	workDir := module.TagPath(params.Get("work_dir", "/tmp/macnoise_hide"), module.RunIDFromContext(ctx))
@@ -91,7 +91,7 @@ func (f *fileHide) DryRun(params module.Params) []string {
 	}
 }
 
-func (f *fileHide) Cleanup() error {
+func (f *fileHide) Cleanup(ctx context.Context) error {
 	if f.workDir != "" {
 		return os.RemoveAll(f.workDir)
 	}
@@ -99,5 +99,5 @@ func (f *fileHide) Cleanup() error {
 }
 
 func init() {
-	module.Register(&fileHide{})
+	module.Register(func() module.Generator { return &fileHide{} })
 }

--- a/modules/file/hide_test.go
+++ b/modules/file/hide_test.go
@@ -45,7 +45,7 @@ func TestFileHide_GenerateAndCleanup(t *testing.T) {
 		t.Error("expected a successful file_hide_dotfile event")
 	}
 
-	if err := f.Cleanup(); err != nil {
+	if err := f.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(workDir); !os.IsNotExist(err) {

--- a/modules/file/keychain_copy.go
+++ b/modules/file/keychain_copy.go
@@ -72,7 +72,7 @@ func (f *fileKeychainCopy) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (f *fileKeychainCopy) CheckPrereqs() error { return nil }
+func (f *fileKeychainCopy) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // defaultKeychainTargets lists the keychain databases to copy. Both directories
 // are parameters so tests can point the enumeration at temp directories.
@@ -266,7 +266,7 @@ func (f *fileKeychainCopy) DryRun(params module.Params) []string {
 // Cleanup removes the staged copies. Leaving real credential stores duplicated
 // on disk is not an acceptable default, so this runs unless --no-cleanup is
 // passed, which announces itself.
-func (f *fileKeychainCopy) Cleanup() error {
+func (f *fileKeychainCopy) Cleanup(ctx context.Context) error {
 	if f.stageDir == "" {
 		return nil
 	}
@@ -274,5 +274,5 @@ func (f *fileKeychainCopy) Cleanup() error {
 }
 
 func init() {
-	module.Register(&fileKeychainCopy{})
+	module.Register(func() module.Generator { return &fileKeychainCopy{} })
 }

--- a/modules/file/keychain_copy_integration_test.go
+++ b/modules/file/keychain_copy_integration_test.go
@@ -143,7 +143,7 @@ func TestKeychainCopy_CleanupRemovesStagedCopies(t *testing.T) {
 		t.Fatal("nothing was staged, so cleanup would pass vacuously")
 	}
 
-	if err := mod.Cleanup(); err != nil {
+	if err := mod.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(stageDir); !os.IsNotExist(err) {

--- a/modules/file/modify.go
+++ b/modules/file/modify.go
@@ -40,7 +40,7 @@ func (f *fileModify) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (f *fileModify) CheckPrereqs() error { return nil }
+func (f *fileModify) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (f *fileModify) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
@@ -101,7 +101,7 @@ func (f *fileModify) DryRun(params module.Params) []string {
 	}
 }
 
-func (f *fileModify) Cleanup() error {
+func (f *fileModify) Cleanup(ctx context.Context) error {
 	if f.targetPath == "" {
 		return nil
 	}
@@ -115,5 +115,5 @@ func (f *fileModify) Cleanup() error {
 }
 
 func init() {
-	module.Register(&fileModify{})
+	module.Register(func() module.Generator { return &fileModify{} })
 }

--- a/modules/file/modify_test.go
+++ b/modules/file/modify_test.go
@@ -28,7 +28,7 @@ func TestFileModify_CleanupRemovesFileItCreated(t *testing.T) {
 		t.Fatalf("expected Generate to create %s: %v", target, err)
 	}
 
-	if err := f.Cleanup(); err != nil {
+	if err := f.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 
@@ -60,7 +60,7 @@ func TestFileModify_CleanupRestoresPriorContent(t *testing.T) {
 		t.Fatal("Generate did not modify the file, test setup is invalid")
 	}
 
-	if err := f.Cleanup(); err != nil {
+	if err := f.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 

--- a/modules/network/beacon.go
+++ b/modules/network/beacon.go
@@ -60,7 +60,7 @@ func jitterInterval(base time.Duration, jitterPct int, rnd *rand.Rand) time.Dura
 	return out
 }
 
-func (c *c2Beacon) CheckPrereqs() error { return nil }
+func (c *c2Beacon) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	target := tagURL(params.Get("target", "http://example.com"), module.RunIDFromContext(ctx))
@@ -128,8 +128,8 @@ func (c *c2Beacon) DryRun(params module.Params) []string {
 	}
 }
 
-func (c *c2Beacon) Cleanup() error { return nil }
+func (c *c2Beacon) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&c2Beacon{})
+	module.Register(func() module.Generator { return &c2Beacon{} })
 }

--- a/modules/network/connect.go
+++ b/modules/network/connect.go
@@ -39,7 +39,7 @@ func (n *netConnect) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (n *netConnect) CheckPrereqs() error { return nil }
+func (n *netConnect) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netConnect) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	target := params.Get("target", "127.0.0.1")
@@ -92,8 +92,8 @@ func (n *netConnect) DryRun(params module.Params) []string {
 	}
 }
 
-func (n *netConnect) Cleanup() error { return nil }
+func (n *netConnect) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&netConnect{})
+	module.Register(func() module.Generator { return &netConnect{} })
 }

--- a/modules/network/dns.go
+++ b/modules/network/dns.go
@@ -40,7 +40,7 @@ func (n *netDNS) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (n *netDNS) CheckPrereqs() error { return nil }
+func (n *netDNS) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netDNS) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	domainsStr := params.Get("domains", "example.com,google.com,github.com")
@@ -75,8 +75,8 @@ func (n *netDNS) DryRun(params module.Params) []string {
 	}
 }
 
-func (n *netDNS) Cleanup() error { return nil }
+func (n *netDNS) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&netDNS{})
+	module.Register(func() module.Generator { return &netDNS{} })
 }

--- a/modules/network/dns_exfil.go
+++ b/modules/network/dns_exfil.go
@@ -54,7 +54,7 @@ func (n *netDNSExfil) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (n *netDNSExfil) CheckPrereqs() error { return nil }
+func (n *netDNSExfil) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // encodeExfilPayload base32-encodes a payload and returns it lowercased
 // with padding stripped. The resulting charset (a-z2-7) is DNS-safe.
@@ -155,8 +155,8 @@ func (n *netDNSExfil) DryRun(params module.Params) []string {
 	return steps
 }
 
-func (n *netDNSExfil) Cleanup() error { return nil }
+func (n *netDNSExfil) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&netDNSExfil{})
+	module.Register(func() module.Generator { return &netDNSExfil{} })
 }

--- a/modules/network/dns_exfil_exec_test.go
+++ b/modules/network/dns_exfil_exec_test.go
@@ -148,7 +148,7 @@ func TestDNSExfilGenerate_QueriesAndOutcomes(t *testing.T) {
 					t.Errorf("event %d details = %+v", i, ev.Details)
 				}
 			}
-			if err := mod.Cleanup(); err != nil {
+			if err := mod.Cleanup(context.Background()); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/modules/network/exfil.go
+++ b/modules/network/exfil.go
@@ -38,7 +38,7 @@ func (n *netExfil) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (n *netExfil) CheckPrereqs() error { return nil }
+func (n *netExfil) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netExfil) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	target := tagURL(params.Get("target", "http://127.0.0.1:8080/upload"), module.RunIDFromContext(ctx))
@@ -100,8 +100,8 @@ func (n *netExfil) DryRun(params module.Params) []string {
 	}
 }
 
-func (n *netExfil) Cleanup() error { return nil }
+func (n *netExfil) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&netExfil{})
+	module.Register(func() module.Generator { return &netExfil{} })
 }

--- a/modules/network/listen.go
+++ b/modules/network/listen.go
@@ -37,7 +37,7 @@ func (n *netListen) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (n *netListen) CheckPrereqs() error { return nil }
+func (n *netListen) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netListen) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	port := params.Get("port", "8080")
@@ -110,7 +110,7 @@ func (n *netListen) DryRun(params module.Params) []string {
 	}
 }
 
-func (n *netListen) Cleanup() error {
+func (n *netListen) Cleanup(ctx context.Context) error {
 	if n.listener != nil {
 		return n.listener.Close()
 	}
@@ -118,5 +118,5 @@ func (n *netListen) Cleanup() error {
 }
 
 func init() {
-	module.Register(&netListen{})
+	module.Register(func() module.Generator { return &netListen{} })
 }

--- a/modules/network/listen_test.go
+++ b/modules/network/listen_test.go
@@ -21,7 +21,7 @@ func TestNetListen_AcceptsSelfConnection(t *testing.T) {
 	if err := n.Generate(ctx, module.Params{"port": "18081"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	defer n.Cleanup() //nolint:errcheck
+	defer n.Cleanup(context.Background()) //nolint:errcheck
 
 	if len(events) != 2 {
 		t.Fatalf("expected 2 events (tcp_listen, tcp_accept), got %d", len(events))
@@ -48,7 +48,7 @@ func TestNetListen_RespectsContextCancellation(t *testing.T) {
 	start := time.Now()
 	err := n.Generate(ctx, module.Params{"port": "18082"}, emit)
 	elapsed := time.Since(start)
-	defer n.Cleanup() //nolint:errcheck
+	defer n.Cleanup(context.Background()) //nolint:errcheck
 
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("err = %v, want context.Canceled", err)
@@ -68,7 +68,7 @@ func TestNetListen_DefaultBindsLoopback(t *testing.T) {
 	if err := n.Generate(ctx, module.Params{"port": "18083"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	defer n.Cleanup() //nolint:errcheck
+	defer n.Cleanup(context.Background()) //nolint:errcheck
 
 	addr, ok := n.listener.Addr().(*net.TCPAddr)
 	if !ok {
@@ -90,7 +90,7 @@ func TestNetListen_CustomBindAddr(t *testing.T) {
 	if err := n.Generate(ctx, params, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	defer n.Cleanup() //nolint:errcheck
+	defer n.Cleanup(context.Background()) //nolint:errcheck
 
 	addr, ok := n.listener.Addr().(*net.TCPAddr)
 	if !ok {

--- a/modules/network/revshell.go
+++ b/modules/network/revshell.go
@@ -36,7 +36,7 @@ func (n *netRevShell) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (n *netRevShell) CheckPrereqs() error { return nil }
+func (n *netRevShell) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netRevShell) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	target := params.Get("target", "127.0.0.1")
@@ -95,8 +95,8 @@ func (n *netRevShell) DryRun(params module.Params) []string {
 	}
 }
 
-func (n *netRevShell) Cleanup() error { return nil }
+func (n *netRevShell) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&netRevShell{})
+	module.Register(func() module.Generator { return &netRevShell{} })
 }

--- a/modules/network/revshell_exec_test.go
+++ b/modules/network/revshell_exec_test.go
@@ -83,7 +83,7 @@ func TestRevShellGenerate_ConnectedExecution(t *testing.T) {
 			if events[0].Details["address"] != listener.Addr().String() {
 				t.Errorf("address = %v", events[0].Details["address"])
 			}
-			if err := g.Cleanup(); err != nil {
+			if err := g.Cleanup(context.Background()); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/modules/network/tls.go
+++ b/modules/network/tls.go
@@ -49,7 +49,7 @@ func (n *netTLS) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (n *netTLS) CheckPrereqs() error { return nil }
+func (n *netTLS) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // tlsConnect dials one target and returns the event. Extracted so the
 // handshake metadata parsing is testable against a local TLS server.
@@ -144,8 +144,8 @@ func (n *netTLS) DryRun(params module.Params) []string {
 	return steps
 }
 
-func (n *netTLS) Cleanup() error { return nil }
+func (n *netTLS) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&netTLS{})
+	module.Register(func() module.Generator { return &netTLS{} })
 }

--- a/modules/network/tls_exec_test.go
+++ b/modules/network/tls_exec_test.go
@@ -72,7 +72,7 @@ func TestTLSGenerate_Handshakes(t *testing.T) {
 					t.Errorf("untrusted certificate result = %+v", ev)
 				}
 			}
-			if err := mod.Cleanup(); err != nil {
+			if err := mod.Cleanup(context.Background()); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/modules/plist/create.go
+++ b/modules/plist/create.go
@@ -44,7 +44,7 @@ func (p *plistCreate) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (p *plistCreate) CheckPrereqs() error { return nil }
+func (p *plistCreate) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
@@ -135,7 +135,7 @@ func (p *plistCreate) DryRun(params module.Params) []string {
 	}
 }
 
-func (p *plistCreate) Cleanup() error {
+func (p *plistCreate) Cleanup(ctx context.Context) error {
 	if p.createdPath == "" {
 		return nil
 	}
@@ -148,5 +148,5 @@ func (p *plistCreate) Cleanup() error {
 }
 
 func init() {
-	module.Register(&plistCreate{})
+	module.Register(func() module.Generator { return &plistCreate{} })
 }

--- a/modules/plist/create_cleanup_test.go
+++ b/modules/plist/create_cleanup_test.go
@@ -1,6 +1,7 @@
 package plistmod
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,7 @@ func TestCleanup_RemovesEmptyParentDir(t *testing.T) {
 	}
 
 	p := &plistCreate{createdPath: fpath}
-	if err := p.Cleanup(); err != nil {
+	if err := p.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 
@@ -46,7 +47,7 @@ func TestCleanup_LeavesNonEmptyParentDir(t *testing.T) {
 	}
 
 	p := &plistCreate{createdPath: fpath}
-	if err := p.Cleanup(); err != nil {
+	if err := p.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 

--- a/modules/plist/create_test.go
+++ b/modules/plist/create_test.go
@@ -46,7 +46,7 @@ func TestPlistCreate_GenerateAndCleanup(t *testing.T) {
 		t.Error("expected a successful plist_create event")
 	}
 
-	if err := p.Cleanup(); err != nil {
+	if err := p.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
@@ -68,7 +68,7 @@ func TestPlistCreate_LaunchAgentMode(t *testing.T) {
 	if err := p.Generate(context.Background(), params, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	defer p.Cleanup() //nolint:errcheck
+	defer p.Cleanup(context.Background()) //nolint:errcheck
 
 	f, err := os.Open(outPath)
 	if err != nil {

--- a/modules/plist/modify.go
+++ b/modules/plist/modify.go
@@ -90,7 +90,7 @@ func (p *plistModify) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (p *plistModify) CheckPrereqs() error {
+func (p *plistModify) CheckPrereqs(ctx context.Context, params module.Params) error {
 	return prereqs.CheckCommand("defaults")
 }
 
@@ -150,18 +150,18 @@ func (p *plistModify) DryRun(params module.Params) []string {
 	}
 }
 
-func (p *plistModify) Cleanup() error {
+func (p *plistModify) Cleanup(ctx context.Context) error {
 	if p.domain == "" || p.key == "" {
 		return nil
 	}
 	if p.priorExisted {
-		out, err := exec.Command("defaults", "write", p.domain, p.key, "-string", p.priorValue).CombinedOutput()
+		out, err := exec.CommandContext(ctx, "defaults", "write", p.domain, p.key, "-string", p.priorValue).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("defaults write %s %s (restore prior value): %v: %s", p.domain, p.key, err, out)
 		}
 		return nil
 	}
-	out, err := exec.Command("defaults", "delete", p.domain, p.key).CombinedOutput()
+	out, err := exec.CommandContext(ctx, "defaults", "delete", p.domain, p.key).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("defaults delete %s %s: %v: %s", p.domain, p.key, err, out)
 	}
@@ -169,5 +169,5 @@ func (p *plistModify) Cleanup() error {
 }
 
 func init() {
-	module.Register(&plistModify{})
+	module.Register(func() module.Generator { return &plistModify{} })
 }

--- a/modules/plist/modify_exec_test.go
+++ b/modules/plist/modify_exec_test.go
@@ -67,7 +67,7 @@ func TestPlistModifyGenerate_WriteAndCleanup(t *testing.T) {
 					t.Errorf("write details[%s] = %v, want %q", k, got, want)
 				}
 			}
-			if err := p.Cleanup(); err != nil {
+			if err := p.Cleanup(context.Background()); err != nil {
 				t.Fatalf("Cleanup: %v", err)
 			}
 			if existing {
@@ -112,7 +112,7 @@ func TestPlistModifyGenerate_RunID(t *testing.T) {
 	if len(events) != 2 || events[1].Details["domain"] != stamped || !events[1].Success {
 		t.Errorf("events = %+v, want successful write to stamped domain", events)
 	}
-	if err := p.Cleanup(); err != nil {
+	if err := p.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if got := defaultsCommand(t, "read", domain, "MacnoiseTest"); got != "base untouched" {
@@ -142,7 +142,7 @@ func TestPlistModifyGenerate_RefusesComplexValues(t *testing.T) {
 			if len(events) != 1 || events[0].EventType != "plist_read_prior" || events[0].Success || events[0].Error == "" {
 				t.Errorf("events = %+v, want failed prior read only", events)
 			}
-			if err := p.Cleanup(); err != nil {
+			if err := p.Cleanup(context.Background()); err != nil {
 				t.Fatalf("Cleanup after refusal: %v", err)
 			}
 			if after := defaultsCommand(t, "export", domain, "-"); after != before {

--- a/modules/process/discovery.go
+++ b/modules/process/discovery.go
@@ -81,7 +81,7 @@ func (p *procDiscovery) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (p *procDiscovery) CheckPrereqs() error { return nil }
+func (p *procDiscovery) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (p *procDiscovery) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	commandsParam := params.Get("commands", strings.Join(defaultDiscoveryCommands, ","))
@@ -132,8 +132,8 @@ func (p *procDiscovery) DryRun(params module.Params) []string {
 	return steps
 }
 
-func (p *procDiscovery) Cleanup() error { return nil }
+func (p *procDiscovery) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&procDiscovery{})
+	module.Register(func() module.Generator { return &procDiscovery{} })
 }

--- a/modules/process/discovery_exec_test.go
+++ b/modules/process/discovery_exec_test.go
@@ -58,7 +58,7 @@ func TestDiscoveryGenerate_Commands(t *testing.T) {
 			t.Errorf("successful command %d has error: %+v", i, events[i])
 		}
 	}
-	if err := p.Cleanup(); err != nil {
+	if err := p.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	// Discovery cleanup is a no-op, including for effects of custom commands.

--- a/modules/process/gatekeeper.go
+++ b/modules/process/gatekeeper.go
@@ -43,7 +43,7 @@ func (p *procGatekeeper) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (p *procGatekeeper) CheckPrereqs() error { return nil }
+func (p *procGatekeeper) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
@@ -113,7 +113,7 @@ func (p *procGatekeeper) DryRun(params module.Params) []string {
 	}
 }
 
-func (p *procGatekeeper) Cleanup() error {
+func (p *procGatekeeper) Cleanup(ctx context.Context) error {
 	if p.targetPath != "" {
 		if err := os.Remove(p.targetPath); err != nil && !os.IsNotExist(err) {
 			return err
@@ -123,5 +123,5 @@ func (p *procGatekeeper) Cleanup() error {
 }
 
 func init() {
-	module.Register(&procGatekeeper{})
+	module.Register(func() module.Generator { return &procGatekeeper{} })
 }

--- a/modules/process/gatekeeper_integration_test.go
+++ b/modules/process/gatekeeper_integration_test.go
@@ -23,7 +23,7 @@ func TestGatekeeperGenerate_FullCycle(t *testing.T) {
 	if err := p.Generate(ctx, module.Params{"target_path": target}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	t.Cleanup(func() { _ = p.Cleanup() })
+	t.Cleanup(func() { _ = p.Cleanup(context.Background()) })
 
 	byType := map[string]module.TelemetryEvent{}
 	for _, ev := range events {

--- a/modules/process/gatekeeper_test.go
+++ b/modules/process/gatekeeper_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +30,7 @@ func TestGatekeeperCleanup_RemovesTargetFile(t *testing.T) {
 	}
 
 	p := &procGatekeeper{targetPath: path}
-	if err := p.Cleanup(); err != nil {
+	if err := p.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -39,12 +40,12 @@ func TestGatekeeperCleanup_RemovesTargetFile(t *testing.T) {
 
 func TestGatekeeperCleanup_ToleratesMissingAndEmpty(t *testing.T) {
 	// No target path recorded (Generate never ran).
-	if err := (&procGatekeeper{}).Cleanup(); err != nil {
+	if err := (&procGatekeeper{}).Cleanup(context.Background()); err != nil {
 		t.Errorf("Cleanup with no target should be a no-op, got %v", err)
 	}
 	// Target recorded but already gone.
 	p := &procGatekeeper{targetPath: filepath.Join(t.TempDir(), "never_created")}
-	if err := p.Cleanup(); err != nil {
+	if err := p.Cleanup(context.Background()); err != nil {
 		t.Errorf("Cleanup of an absent file should tolerate IsNotExist, got %v", err)
 	}
 }

--- a/modules/process/inject.go
+++ b/modules/process/inject.go
@@ -45,7 +45,7 @@ func (p *procInject) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (p *procInject) CheckPrereqs() error { return nil }
+func (p *procInject) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // defaultTarget returns macnoise's own executable.
 //
@@ -143,8 +143,8 @@ func (p *procInject) DryRun(params module.Params) []string {
 	}
 }
 
-func (p *procInject) Cleanup() error { return nil }
+func (p *procInject) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&procInject{})
+	module.Register(func() module.Generator { return &procInject{} })
 }

--- a/modules/process/osascript.go
+++ b/modules/process/osascript.go
@@ -1,11 +1,10 @@
-//go:build darwin
-
 package process
 
 import (
 	"context"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/0xv1n/macnoise/internal/output"
@@ -73,7 +72,12 @@ func (p *procOsascript) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (p *procOsascript) CheckPrereqs() error { return nil }
+func (p *procOsascript) CheckPrereqs(ctx context.Context, params module.Params) error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("proc_osascript is only supported on macOS")
+	}
+	return nil
+}
 
 // stampScript appends the run ID as a language-appropriate comment so it lands
 // in the osascript argv (what detection keys on) without altering execution.
@@ -121,8 +125,8 @@ func (p *procOsascript) DryRun(params module.Params) []string {
 	return []string{fmt.Sprintf("osascript -l %s -e %q", language, script)}
 }
 
-func (p *procOsascript) Cleanup() error { return nil }
+func (p *procOsascript) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&procOsascript{})
+	module.Register(func() module.Generator { return &procOsascript{} })
 }

--- a/modules/process/osascript_exec_test.go
+++ b/modules/process/osascript_exec_test.go
@@ -60,7 +60,7 @@ func TestOsascriptGenerate_Execution(t *testing.T) {
 			if wantError := strings.Contains(tt.name, "error"); hasError != wantError {
 				t.Errorf("error detail present = %t, want %t: %+v", hasError, wantError, ev)
 			}
-			if err := p.Cleanup(); err != nil {
+			if err := p.Cleanup(context.Background()); err != nil {
 				t.Fatalf("Cleanup: %v", err)
 			}
 		})

--- a/modules/process/signal.go
+++ b/modules/process/signal.go
@@ -14,32 +14,6 @@ import (
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
-type procSignal struct{}
-
-func (p *procSignal) Info() module.ModuleInfo {
-	return module.ModuleInfo{
-		Name:        "proc_signal",
-		EventTypes:  []string{"process_fork", "signal_send"},
-		Description: "Forks a process then sends signals (SIGTERM, SIGSTOP, SIGCONT) to generate signal telemetry",
-		Category:    module.CategoryProcess,
-		Tags:        []string{"signal", "process", "fork"},
-		Privileges:  module.PrivilegeNone,
-		MITRE: []module.MITRE{
-			{Technique: "T1106", Name: "Native API"},
-		},
-		Author:   "0xv1n",
-		MinMacOS: "12.0",
-	}
-}
-
-func (p *procSignal) ParamSpecs() []module.ParamSpec {
-	return []module.ParamSpec{
-		{Name: "target_command", Description: "Command to spawn as signal target", Required: false, DefaultValue: "sleep 30", Example: "sleep 60"},
-	}
-}
-
-func (p *procSignal) CheckPrereqs() error { return nil }
-
 func (p *procSignal) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	targetCmd := stampCommand(params.Get("target_command", "sleep 30"), module.RunIDFromContext(ctx))
 	info := p.Info()
@@ -82,18 +56,4 @@ func (p *procSignal) Generate(ctx context.Context, params module.Params, emit mo
 
 	cmd.Wait() //nolint:errcheck
 	return nil
-}
-
-func (p *procSignal) DryRun(params module.Params) []string {
-	targetCmd := params.Get("target_command", "sleep 30")
-	return []string{
-		fmt.Sprintf("fork: sh -c %q", targetCmd),
-		"send SIGSTOP, SIGCONT, SIGTERM to forked PID",
-	}
-}
-
-func (p *procSignal) Cleanup() error { return nil }
-
-func init() {
-	module.Register(&procSignal{})
 }

--- a/modules/process/signal_common.go
+++ b/modules/process/signal_common.go
@@ -1,0 +1,54 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+type procSignal struct{}
+
+func (p *procSignal) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "proc_signal",
+		EventTypes:  []string{"process_fork", "signal_send"},
+		Description: "Forks a process then sends signals (SIGTERM, SIGSTOP, SIGCONT) to generate signal telemetry",
+		Category:    module.CategoryProcess,
+		Tags:        []string{"signal", "process", "fork"},
+		Privileges:  module.PrivilegeNone,
+		MITRE: []module.MITRE{
+			{Technique: "T1106", Name: "Native API"},
+		},
+		Author:   "0xv1n",
+		MinMacOS: "12.0",
+	}
+}
+
+func (p *procSignal) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{Name: "target_command", Description: "Command to spawn as signal target", Required: false, DefaultValue: "sleep 30", Example: "sleep 60"},
+	}
+}
+
+func (p *procSignal) CheckPrereqs(ctx context.Context, params module.Params) error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("proc_signal is only supported on macOS")
+	}
+	return nil
+}
+
+func (p *procSignal) DryRun(params module.Params) []string {
+	targetCmd := params.Get("target_command", "sleep 30")
+	return []string{
+		fmt.Sprintf("fork: sh -c %q", targetCmd),
+		"send SIGSTOP, SIGCONT, SIGTERM to forked PID",
+	}
+}
+
+func (p *procSignal) Cleanup(ctx context.Context) error { return nil }
+
+func init() {
+	module.Register(func() module.Generator { return &procSignal{} })
+}

--- a/modules/process/signal_unsupported.go
+++ b/modules/process/signal_unsupported.go
@@ -1,0 +1,14 @@
+//go:build !darwin
+
+package process
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func (p *procSignal) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	return fmt.Errorf("proc_signal is only supported on macOS")
+}

--- a/modules/process/spawn.go
+++ b/modules/process/spawn.go
@@ -36,7 +36,7 @@ func (p *procSpawn) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (p *procSpawn) CheckPrereqs() error { return nil }
+func (p *procSpawn) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // stampCommand appends the run ID as a shell comment. It is inert to execution
 // but lands in the process argv, where a consumer's EDR captures it and can
@@ -72,8 +72,8 @@ func (p *procSpawn) DryRun(params module.Params) []string {
 	return []string{fmt.Sprintf("exec: sh -c %q", command)}
 }
 
-func (p *procSpawn) Cleanup() error { return nil }
+func (p *procSpawn) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&procSpawn{})
+	module.Register(func() module.Generator { return &procSpawn{} })
 }

--- a/modules/service/cron.go
+++ b/modules/service/cron.go
@@ -37,7 +37,7 @@ func (s *svcCron) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (s *svcCron) CheckPrereqs() error { return nil }
+func (s *svcCron) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // noCrontabMarker is the substring `crontab -l` prints to stderr when a user
 // genuinely has no crontab yet (e.g. "crontab: no crontab for alice"). It is
@@ -135,11 +135,11 @@ func (s *svcCron) DryRun(params module.Params) []string {
 	}
 }
 
-func (s *svcCron) Cleanup() error {
+func (s *svcCron) Cleanup(ctx context.Context) error {
 	if s.addedEntry == "" {
 		return nil
 	}
-	out, err := exec.Command("crontab", "-l").CombinedOutput()
+	out, err := exec.CommandContext(ctx, "crontab", "-l").CombinedOutput()
 	existing, safe := classifyCrontabList(out, err)
 	if !safe {
 		// Leave addedEntry set: we don't know whether our entry is still
@@ -156,7 +156,7 @@ func (s *svcCron) Cleanup() error {
 		}
 	}
 	newCrontab := strings.Join(filtered, "\n")
-	cmd := exec.Command("crontab", "-")
+	cmd := exec.CommandContext(ctx, "crontab", "-")
 	cmd.Stdin = strings.NewReader(newCrontab)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("svc_cron: failed to reinstall filtered crontab during cleanup: %w", err)
@@ -166,5 +166,5 @@ func (s *svcCron) Cleanup() error {
 }
 
 func init() {
-	module.Register(&svcCron{})
+	module.Register(func() module.Generator { return &svcCron{} })
 }

--- a/modules/service/cron_exec_test.go
+++ b/modules/service/cron_exec_test.go
@@ -114,14 +114,14 @@ func TestCronGenerate_InstallAndCleanup(t *testing.T) {
 			// A later writer's entry must survive cleanup too.
 			const later = "0 0 2 1 * /usr/bin/true # keep later entry\n"
 			cronInstall(t, installed+later)
-			if err := s.Cleanup(); err != nil {
+			if err := s.Cleanup(context.Background()); err != nil {
 				t.Fatalf("Cleanup: %v", err)
 			}
 			want = strings.TrimRight(baseline, "\n") + "\n" + later
 			if got, _ := cronRead(t); got != want {
 				t.Errorf("crontab after cleanup = %q, want %q", got, want)
 			}
-			if err := s.Cleanup(); err != nil {
+			if err := s.Cleanup(context.Background()); err != nil {
 				t.Fatalf("second Cleanup: %v", err)
 			}
 			if got, _ := cronRead(t); got != want {
@@ -153,7 +153,7 @@ func TestCronGenerate_InvalidSchedule(t *testing.T) {
 	if got, _ := cronRead(t); got != baseline {
 		t.Errorf("failed install changed crontab: %q", got)
 	}
-	if err := s.Cleanup(); err != nil {
+	if err := s.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup after failed install: %v", err)
 	}
 	if got, _ := cronRead(t); got != baseline {

--- a/modules/service/launch_agent.go
+++ b/modules/service/launch_agent.go
@@ -44,7 +44,7 @@ func (s *svcLaunchAgent) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (s *svcLaunchAgent) CheckPrereqs() error {
+func (s *svcLaunchAgent) CheckPrereqs(ctx context.Context, params module.Params) error {
 	return nil
 }
 
@@ -140,10 +140,10 @@ func (s *svcLaunchAgent) DryRun(params module.Params) []string {
 // failure there says nothing about whether cleanup worked. Reporting it
 // anyway would mark every run on a host without a GUI session as a cleanup
 // error while leaving nothing behind.
-func (s *svcLaunchAgent) Cleanup() error {
+func (s *svcLaunchAgent) Cleanup(ctx context.Context) error {
 	var bootoutErr error
 	if s.loaded {
-		out, err := exec.Command("launchctl", bootoutArgs(guiDomain(), s.label)...).CombinedOutput()
+		out, err := exec.CommandContext(ctx, "launchctl", bootoutArgs(guiDomain(), s.label)...).CombinedOutput()
 		if err != nil {
 			bootoutErr = fmt.Errorf("launchctl bootout %s: %v: %s", s.label, err, out)
 		}
@@ -157,5 +157,5 @@ func (s *svcLaunchAgent) Cleanup() error {
 }
 
 func init() {
-	module.Register(&svcLaunchAgent{})
+	module.Register(func() module.Generator { return &svcLaunchAgent{} })
 }

--- a/modules/service/launch_agent_test.go
+++ b/modules/service/launch_agent_test.go
@@ -62,7 +62,7 @@ func TestSvcLaunchAgent_GenerateAndCleanup(t *testing.T) {
 	// session, which a CI runner has no guarantee of, and the module already
 	// treats a bootstrap failure as valid telemetry rather than an error.
 
-	if err := s.Cleanup(); err != nil {
+	if err := s.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(plistPath); !os.IsNotExist(err) {

--- a/modules/service/launch_daemon.go
+++ b/modules/service/launch_daemon.go
@@ -42,7 +42,7 @@ func (s *svcLaunchDaemon) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (s *svcLaunchDaemon) CheckPrereqs() error {
+func (s *svcLaunchDaemon) CheckPrereqs(ctx context.Context, params module.Params) error {
 	return prereqs.CheckRoot()
 }
 
@@ -114,10 +114,10 @@ func (s *svcLaunchDaemon) DryRun(params module.Params) []string {
 
 // Cleanup boots the daemon out before removing its plist. As with the agent, a
 // bootout failure is only reported when Generate actually loaded it.
-func (s *svcLaunchDaemon) Cleanup() error {
+func (s *svcLaunchDaemon) Cleanup(ctx context.Context) error {
 	var bootoutErr error
 	if s.loaded {
-		out, err := exec.Command("launchctl", bootoutArgs(systemDomain, s.label)...).CombinedOutput()
+		out, err := exec.CommandContext(ctx, "launchctl", bootoutArgs(systemDomain, s.label)...).CombinedOutput()
 		if err != nil {
 			bootoutErr = fmt.Errorf("launchctl bootout %s: %v: %s", s.label, err, out)
 		}
@@ -131,5 +131,5 @@ func (s *svcLaunchDaemon) Cleanup() error {
 }
 
 func init() {
-	module.Register(&svcLaunchDaemon{})
+	module.Register(func() module.Generator { return &svcLaunchDaemon{} })
 }

--- a/modules/service/launch_daemon_test.go
+++ b/modules/service/launch_daemon_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSvcLaunchDaemon_PrereqRequiresRoot(t *testing.T) {
 	s := &svcLaunchDaemon{}
-	err := s.CheckPrereqs()
+	err := s.CheckPrereqs(context.Background(), nil)
 	if os.Getuid() == 0 {
 		if err != nil {
 			t.Errorf("CheckPrereqs as root: %v, want nil", err)
@@ -72,7 +72,7 @@ func TestSvcLaunchDaemon_GenerateAndCleanup(t *testing.T) {
 		t.Error("expected a successful launchdaemon_create event")
 	}
 
-	if err := s.Cleanup(); err != nil {
+	if err := s.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if _, err := os.Stat(plistPath); !os.IsNotExist(err) {

--- a/modules/service/launchctl_test.go
+++ b/modules/service/launchctl_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -94,10 +95,10 @@ func TestDryRun_AdvertisesBootstrap(t *testing.T) {
 // failure as a cleanup error would mark those runs failed while nothing was
 // actually left behind.
 func TestCleanup_SkipsBootoutWhenNeverLoaded(t *testing.T) {
-	if err := (&svcLaunchAgent{label: "com.macnoise.never", loaded: false}).Cleanup(); err != nil {
+	if err := (&svcLaunchAgent{label: "com.macnoise.never", loaded: false}).Cleanup(context.Background()); err != nil {
 		t.Errorf("agent Cleanup() = %v, want nil when the agent was never loaded", err)
 	}
-	if err := (&svcLaunchDaemon{label: "com.macnoise.never", loaded: false}).Cleanup(); err != nil {
+	if err := (&svcLaunchDaemon{label: "com.macnoise.never", loaded: false}).Cleanup(context.Background()); err != nil {
 		t.Errorf("daemon Cleanup() = %v, want nil when the daemon was never loaded", err)
 	}
 }

--- a/modules/service/login_item.go
+++ b/modules/service/login_item.go
@@ -39,7 +39,7 @@ func (s *svcLoginItem) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (s *svcLoginItem) CheckPrereqs() error { return nil }
+func (s *svcLoginItem) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // The AppleScript builders are shared by Generate, Cleanup, and DryRun so the
 // advertised commands cannot drift from the executed ones.
@@ -185,11 +185,11 @@ func (s *svcLoginItem) DryRun(params module.Params) []string {
 // Cleanup removes the login item only if Generate actually added one. A run
 // that was refused or could not reach a GUI session added nothing, so issuing
 // the delete would report a failure for an item that never existed.
-func (s *svcLoginItem) Cleanup() error {
+func (s *svcLoginItem) Cleanup(ctx context.Context) error {
 	if !s.added || s.name == "" {
 		return nil
 	}
-	if out, err := exec.Command("osascript", "-e", deleteLoginItemScript(s.name)).CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "osascript", "-e", deleteLoginItemScript(s.name)).CombinedOutput(); err != nil {
 		return fmt.Errorf("delete login item %q: %v: %s", s.name, err, strings.TrimSpace(string(out)))
 	}
 	s.added = false
@@ -197,5 +197,5 @@ func (s *svcLoginItem) Cleanup() error {
 }
 
 func init() {
-	module.Register(&svcLoginItem{})
+	module.Register(func() module.Generator { return &svcLoginItem{} })
 }

--- a/modules/service/login_item_integration_test.go
+++ b/modules/service/login_item_integration_test.go
@@ -15,7 +15,7 @@ func runLoginItem(t *testing.T, e *svcLoginItem, params module.Params) module.Te
 
 	var events []module.TelemetryEvent
 	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
-	t.Cleanup(func() { _ = e.Cleanup() })
+	t.Cleanup(func() { _ = e.Cleanup(context.Background()) })
 
 	if err := e.Generate(context.Background(), params, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -72,7 +72,7 @@ func TestLoginItem_FullCycleWithGUISession(t *testing.T) {
 	if present, ok := ev.Details["verified_present"].(bool); !ok || !present {
 		t.Errorf("login item %q was not found in the list after add", name)
 	}
-	if err := e.Cleanup(); err != nil {
+	if err := e.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 

--- a/modules/service/login_item_test.go
+++ b/modules/service/login_item_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -139,10 +140,10 @@ func TestDryRunMatchesExecutedScripts(t *testing.T) {
 // Cleanup must be a no-op when nothing was added, or a refused run on a headless
 // host reports a delete failure for an item that never existed.
 func TestCleanupIsNoOpWhenNothingAdded(t *testing.T) {
-	if err := (&svcLoginItem{}).Cleanup(); err != nil {
+	if err := (&svcLoginItem{}).Cleanup(context.Background()); err != nil {
 		t.Errorf("Cleanup with nothing added returned %v", err)
 	}
-	if err := (&svcLoginItem{name: "X", added: false}).Cleanup(); err != nil {
+	if err := (&svcLoginItem{name: "X", added: false}).Cleanup(context.Background()); err != nil {
 		t.Errorf("Cleanup with added=false returned %v", err)
 	}
 }

--- a/modules/service/shell_profile.go
+++ b/modules/service/shell_profile.go
@@ -43,7 +43,7 @@ func (s *svcShellProfile) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (s *svcShellProfile) CheckPrereqs() error { return nil }
+func (s *svcShellProfile) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (s *svcShellProfile) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	target := params.Get("target", "~/.zshrc")
@@ -101,7 +101,7 @@ func (s *svcShellProfile) DryRun(params module.Params) []string {
 	}
 }
 
-func (s *svcShellProfile) Cleanup() error {
+func (s *svcShellProfile) Cleanup(ctx context.Context) error {
 	if s.targetFile == "" {
 		return nil
 	}
@@ -136,5 +136,5 @@ func (s *svcShellProfile) Cleanup() error {
 }
 
 func init() {
-	module.Register(&svcShellProfile{})
+	module.Register(func() module.Generator { return &svcShellProfile{} })
 }

--- a/modules/service/shell_profile_test.go
+++ b/modules/service/shell_profile_test.go
@@ -43,7 +43,7 @@ func TestSvcShellProfile_CleanupRestoresOriginalContent(t *testing.T) {
 		t.Errorf("expected one successful shell_profile_modify event, got %+v", events)
 	}
 
-	if err := s.Cleanup(); err != nil {
+	if err := s.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	restored, err := os.ReadFile(target)
@@ -74,7 +74,7 @@ func TestSvcShellProfile_CleanupRemovesRepeatedBlocks(t *testing.T) {
 		}
 	}
 
-	if err := s.Cleanup(); err != nil {
+	if err := s.Cleanup(context.Background()); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	restored, err := os.ReadFile(target)

--- a/modules/tcc/accessibility.go
+++ b/modules/tcc/accessibility.go
@@ -37,7 +37,7 @@ func (t *tccAccessibility) Info() module.ModuleInfo {
 
 func (t *tccAccessibility) ParamSpecs() []module.ParamSpec { return nil }
 
-func (t *tccAccessibility) CheckPrereqs() error { return nil }
+func (t *tccAccessibility) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // accessibilityProbeScript reads the menu bar items of the frontmost process
 // through System Events. Reading any process's UI elements requires the
@@ -109,8 +109,8 @@ func (t *tccAccessibility) DryRun(params module.Params) []string {
 	return []string{fmt.Sprintf("osascript -e '%s' (probes Accessibility permission)", accessibilityProbeScript())}
 }
 
-func (t *tccAccessibility) Cleanup() error { return nil }
+func (t *tccAccessibility) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&tccAccessibility{})
+	module.Register(func() module.Generator { return &tccAccessibility{} })
 }

--- a/modules/tcc/contacts.go
+++ b/modules/tcc/contacts.go
@@ -40,7 +40,7 @@ func (t *tccContacts) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (t *tccContacts) CheckPrereqs() error { return nil }
+func (t *tccContacts) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (t *tccContacts) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	abPath := params.Get("addressbook_path", "")
@@ -82,8 +82,8 @@ func (t *tccContacts) DryRun(params module.Params) []string {
 	return []string{"enumerate ~/Library/Application Support/AddressBook (probes Contacts TCC permission)"}
 }
 
-func (t *tccContacts) Cleanup() error { return nil }
+func (t *tccContacts) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&tccContacts{})
+	module.Register(func() module.Generator { return &tccContacts{} })
 }

--- a/modules/tcc/fda.go
+++ b/modules/tcc/fda.go
@@ -44,7 +44,7 @@ func (t *tccFDA) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (t *tccFDA) CheckPrereqs() error { return nil }
+func (t *tccFDA) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 // defaultFDAPath returns the per-user TCC database.
 //
@@ -107,8 +107,8 @@ func (t *tccFDA) DryRun(params module.Params) []string {
 	return []string{fmt.Sprintf("open %s for reading (probes FDA permission)", path)}
 }
 
-func (t *tccFDA) Cleanup() error { return nil }
+func (t *tccFDA) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&tccFDA{})
+	module.Register(func() module.Generator { return &tccFDA{} })
 }

--- a/modules/tcc/keychain.go
+++ b/modules/tcc/keychain.go
@@ -48,7 +48,7 @@ func (t *tccKeychain) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (t *tccKeychain) CheckPrereqs() error { return nil }
+func (t *tccKeychain) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (t *tccKeychain) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	keychainPath := params.Get("keychain_path", "")
@@ -120,8 +120,8 @@ func (t *tccKeychain) DryRun(params module.Params) []string {
 	}
 }
 
-func (t *tccKeychain) Cleanup() error { return nil }
+func (t *tccKeychain) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&tccKeychain{})
+	module.Register(func() module.Generator { return &tccKeychain{} })
 }

--- a/modules/tcc/screen_recording.go
+++ b/modules/tcc/screen_recording.go
@@ -31,7 +31,9 @@ func (t *tccScreenRecording) Info() module.ModuleInfo {
 
 func (t *tccScreenRecording) ParamSpecs() []module.ParamSpec { return nil }
 
-func (t *tccScreenRecording) CheckPrereqs() error { return nil }
+func (t *tccScreenRecording) CheckPrereqs(ctx context.Context, params module.Params) error {
+	return nil
+}
 
 // screenCaptureOutcome classifies a screencapture run.
 //
@@ -110,8 +112,8 @@ func (t *tccScreenRecording) DryRun(params module.Params) []string {
 	return []string{"screencapture -x <tempfile> then delete it (probes Screen Recording, contents discarded)"}
 }
 
-func (t *tccScreenRecording) Cleanup() error { return nil }
+func (t *tccScreenRecording) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&tccScreenRecording{})
+	module.Register(func() module.Generator { return &tccScreenRecording{} })
 }

--- a/modules/xpc/enumerate.go
+++ b/modules/xpc/enumerate.go
@@ -40,7 +40,7 @@ func (x *xpcEnumerate) ParamSpecs() []module.ParamSpec {
 	}
 }
 
-func (x *xpcEnumerate) CheckPrereqs() error {
+func (x *xpcEnumerate) CheckPrereqs(ctx context.Context, params module.Params) error {
 	return prereqs.CheckCommand("launchctl")
 }
 
@@ -144,8 +144,8 @@ func (x *xpcEnumerate) DryRun(params module.Params) []string {
 	}
 }
 
-func (x *xpcEnumerate) Cleanup() error { return nil }
+func (x *xpcEnumerate) Cleanup(ctx context.Context) error { return nil }
 
 func init() {
-	module.Register(&xpcEnumerate{})
+	module.Register(func() module.Generator { return &xpcEnumerate{} })
 }

--- a/pkg/module/catalog_test.go
+++ b/pkg/module/catalog_test.go
@@ -26,10 +26,10 @@ func (catalogTestGen) ParamSpecs() []ParamSpec {
 		{Name: "target", Description: "the target", Required: true, DefaultValue: "1.2.3.4", Example: "10.0.0.1"},
 	}
 }
-func (catalogTestGen) CheckPrereqs() error                                  { return nil }
-func (catalogTestGen) Generate(context.Context, Params, EventEmitter) error { return nil }
-func (catalogTestGen) DryRun(Params) []string                               { return nil }
-func (catalogTestGen) Cleanup() error                                       { return nil }
+func (catalogTestGen) CheckPrereqs(ctx context.Context, params Params) error { return nil }
+func (catalogTestGen) Generate(context.Context, Params, EventEmitter) error  { return nil }
+func (catalogTestGen) DryRun(Params) []string                                { return nil }
+func (catalogTestGen) Cleanup(ctx context.Context) error                     { return nil }
 
 func TestNewCatalogEntry(t *testing.T) {
 	e := NewCatalogEntry(catalogTestGen{})

--- a/pkg/module/interface.go
+++ b/pkg/module/interface.go
@@ -133,8 +133,8 @@ type EventEmitter func(TelemetryEvent)
 type Generator interface {
 	Info() ModuleInfo
 	ParamSpecs() []ParamSpec
-	CheckPrereqs() error
+	CheckPrereqs(ctx context.Context, params Params) error
 	Generate(ctx context.Context, params Params, emit EventEmitter) error
 	DryRun(params Params) []string
-	Cleanup() error
+	Cleanup(ctx context.Context) error
 }

--- a/pkg/module/registry.go
+++ b/pkg/module/registry.go
@@ -6,86 +6,111 @@ import (
 	"sync"
 )
 
-var (
-	mu       sync.RWMutex
-	registry = map[string]Generator{}
-)
+// Factory constructs an independent module invocation with no runtime state.
+type Factory func() Generator
 
-// Register adds g to the global module registry. It panics on duplicate names.
-func Register(g Generator) {
-	mu.Lock()
-	defer mu.Unlock()
-	name := g.Info().Name
-	if _, exists := registry[name]; exists {
+// Registry stores constructors, never module instances. Its zero value is usable.
+type Registry struct {
+	mu        sync.RWMutex
+	factories map[string]Factory
+}
+
+// DefaultRegistry holds the built-in module constructors.
+var DefaultRegistry Registry
+
+// Register adds a constructor to the built-in registry.
+func Register(newGenerator Factory) { DefaultRegistry.Register(newGenerator) }
+
+// Register adds a constructor, panicking on duplicate or empty names.
+func (r *Registry) Register(newGenerator Factory) {
+	name := newGenerator().Info().Name
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if name == "" {
+		panic("module: empty registration name")
+	}
+	if r.factories == nil {
+		r.factories = make(map[string]Factory)
+	}
+	if _, exists := r.factories[name]; exists {
 		panic(fmt.Sprintf("module: duplicate registration for %q", name))
 	}
-	registry[name] = g
+	r.factories[name] = newGenerator
 }
 
-// Get looks up a module by name, returning it and a found boolean.
-func Get(name string) (Generator, bool) {
-	mu.RLock()
-	defer mu.RUnlock()
-	g, ok := registry[name]
-	return g, ok
-}
-
-// All returns every registered module sorted by name.
-func All() []Generator {
-	mu.RLock()
-	defer mu.RUnlock()
-	out := make([]Generator, 0, len(registry))
-	for _, g := range registry {
-		out = append(out, g)
+// Get constructs a new invocation of a registered module.
+func (r *Registry) Get(name string) (Generator, bool) {
+	r.mu.RLock()
+	newGenerator, ok := r.factories[name]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, false
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].Info().Name < out[j].Info().Name
-	})
-	return out
+	return newGenerator(), true
 }
 
-// ByCategory returns all registered modules in the given category, sorted by name.
-func ByCategory(cat Category) []Generator {
-	mu.RLock()
-	defer mu.RUnlock()
+// Get constructs a new invocation from the built-in registry.
+func Get(name string) (Generator, bool) { return DefaultRegistry.Get(name) }
+
+// All constructs every registered module in name order.
+func (r *Registry) All() []Generator {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.factories))
+	for name := range r.factories {
+		names = append(names, name)
+	}
+	r.mu.RUnlock()
+	sort.Strings(names)
+	all := make([]Generator, 0, len(names))
+	for _, name := range names {
+		g, _ := r.Get(name)
+		all = append(all, g)
+	}
+	return all
+}
+
+// All constructs every built-in module in name order.
+func All() []Generator { return DefaultRegistry.All() }
+
+// ByCategory constructs the modules belonging to a category.
+func (r *Registry) ByCategory(cat Category) []Generator {
 	var out []Generator
-	for _, g := range registry {
+	for _, g := range r.All() {
 		if g.Info().Category == cat {
 			out = append(out, g)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].Info().Name < out[j].Info().Name
-	})
 	return out
 }
 
-// ByTag returns all registered modules that carry the given tag, sorted by name.
-func ByTag(tag string) []Generator {
-	mu.RLock()
-	defer mu.RUnlock()
+// ByCategory constructs built-in modules belonging to a category.
+func ByCategory(cat Category) []Generator { return DefaultRegistry.ByCategory(cat) }
+
+// ByTag constructs the modules carrying tag.
+func (r *Registry) ByTag(tag string) []Generator {
 	var out []Generator
-	for _, g := range registry {
-		for _, t := range g.Info().Tags {
-			if t == tag {
+	for _, g := range r.All() {
+		for _, candidate := range g.Info().Tags {
+			if candidate == tag {
 				out = append(out, g)
 				break
 			}
 		}
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].Info().Name < out[j].Info().Name
-	})
 	return out
 }
 
-// CategoryCounts returns a map from Category to the number of registered modules in that category.
-func CategoryCounts() map[Category]int {
-	mu.RLock()
-	defer mu.RUnlock()
-	counts := map[Category]int{}
-	for _, g := range registry {
+// ByTag constructs built-in modules carrying tag.
+func ByTag(tag string) []Generator { return DefaultRegistry.ByTag(tag) }
+
+// CategoryCounts reports the number of modules in each category.
+func (r *Registry) CategoryCounts() map[Category]int {
+	counts := make(map[Category]int)
+	for _, g := range r.All() {
 		counts[g.Info().Category]++
 	}
 	return counts
 }
+
+// CategoryCounts reports the number of built-in modules in each category.
+func CategoryCounts() map[Category]int { return DefaultRegistry.CategoryCounts() }

--- a/pkg/module/registry_test.go
+++ b/pkg/module/registry_test.go
@@ -21,19 +21,21 @@ func (t *testGen) Info() module.ModuleInfo {
 		Privileges: module.PrivilegeNone,
 	}
 }
-func (t *testGen) ParamSpecs() []module.ParamSpec { return nil }
-func (t *testGen) CheckPrereqs() error            { return nil }
+func (t *testGen) ParamSpecs() []module.ParamSpec                               { return nil }
+func (t *testGen) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 func (t *testGen) Generate(_ context.Context, _ module.Params, _ module.EventEmitter) error {
 	return nil
 }
-func (t *testGen) DryRun(_ module.Params) []string { return nil }
-func (t *testGen) Cleanup() error                  { return nil }
+func (t *testGen) DryRun(_ module.Params) []string   { return nil }
+func (t *testGen) Cleanup(ctx context.Context) error { return nil }
 
 func TestRegisterAndGet(t *testing.T) {
-	gen := &testGen{name: "test_reg_get", category: "network"}
-	module.Register(gen)
+	var registry module.Registry
+	registry.Register(func() module.Generator {
+		return &testGen{name: "test_reg_get", category: "network"}
+	})
 
-	got, ok := module.Get("test_reg_get")
+	got, ok := registry.Get("test_reg_get")
 	if !ok {
 		t.Fatal("expected to find registered module")
 	}
@@ -42,18 +44,31 @@ func TestRegisterAndGet(t *testing.T) {
 	}
 }
 
+func TestRegistryReturnsIndependentInvocations(t *testing.T) {
+	var registry module.Registry
+	registry.Register(func() module.Generator { return &testGen{name: "test_independent"} })
+	first, _ := registry.Get("test_independent")
+	second, _ := registry.Get("test_independent")
+	first.(*testGen).tags = []string{"mutated"}
+	if len(second.Info().Tags) != 0 {
+		t.Fatal("registry reused mutable invocation state")
+	}
+}
+
 func TestGetMissing(t *testing.T) {
-	_, ok := module.Get("does_not_exist_xyz")
+	var registry module.Registry
+	_, ok := registry.Get("does_not_exist_xyz")
 	if ok {
 		t.Error("expected ok=false for non-existent module")
 	}
 }
 
 func TestAllSorted(t *testing.T) {
-	module.Register(&testGen{name: "test_all_b", category: "process"})
-	module.Register(&testGen{name: "test_all_a", category: "process"})
+	var registry module.Registry
+	registry.Register(func() module.Generator { return &testGen{name: "test_all_b", category: "process"} })
+	registry.Register(func() module.Generator { return &testGen{name: "test_all_a", category: "process"} })
 
-	all := module.All()
+	all := registry.All()
 	for i := 1; i < len(all); i++ {
 		if all[i-1].Info().Name > all[i].Info().Name {
 			t.Errorf("All() not sorted: %q > %q", all[i-1].Info().Name, all[i].Info().Name)
@@ -62,10 +77,11 @@ func TestAllSorted(t *testing.T) {
 }
 
 func TestByCategory(t *testing.T) {
-	module.Register(&testGen{name: "test_cat_net", category: "network_test_cat"})
-	module.Register(&testGen{name: "test_cat_proc", category: "process_test_cat"})
+	var registry module.Registry
+	registry.Register(func() module.Generator { return &testGen{name: "test_cat_net", category: "network_test_cat"} })
+	registry.Register(func() module.Generator { return &testGen{name: "test_cat_proc", category: "process_test_cat"} })
 
-	nets := module.ByCategory("network_test_cat")
+	nets := registry.ByCategory("network_test_cat")
 	if len(nets) != 1 {
 		t.Errorf("expected 1 network_test_cat module, got %d", len(nets))
 	}
@@ -75,10 +91,15 @@ func TestByCategory(t *testing.T) {
 }
 
 func TestByTag(t *testing.T) {
-	module.Register(&testGen{name: "test_tag_a", category: "file", tags: []string{"dns", "outbound"}})
-	module.Register(&testGen{name: "test_tag_b", category: "file", tags: []string{"tcp"}})
+	var registry module.Registry
+	registry.Register(func() module.Generator {
+		return &testGen{name: "test_tag_a", category: "file", tags: []string{"dns", "outbound"}}
+	})
+	registry.Register(func() module.Generator {
+		return &testGen{name: "test_tag_b", category: "file", tags: []string{"tcp"}}
+	})
 
-	tagged := module.ByTag("dns")
+	tagged := registry.ByTag("dns")
 	if len(tagged) != 1 {
 		t.Errorf("expected 1 dns-tagged module, got %d", len(tagged))
 	}
@@ -90,16 +111,21 @@ func TestDuplicateRegistrationPanics(t *testing.T) {
 			t.Error("expected panic on duplicate registration")
 		}
 	}()
-	gen := &testGen{name: "test_dup_panic", category: "network"}
-	module.Register(gen)
-	module.Register(gen)
+	var registry module.Registry
+	registry.Register(func() module.Generator {
+		return &testGen{name: "test_dup_panic", category: "network"}
+	})
+	registry.Register(func() module.Generator {
+		return &testGen{name: "test_dup_panic", category: "network"}
+	})
 }
 
 func TestCategoryCounts(t *testing.T) {
-	module.Register(&testGen{name: "test_count_1", category: "xpc_test"})
-	module.Register(&testGen{name: "test_count_2", category: "xpc_test"})
+	var registry module.Registry
+	registry.Register(func() module.Generator { return &testGen{name: "test_count_1", category: "xpc_test"} })
+	registry.Register(func() module.Generator { return &testGen{name: "test_count_2", category: "xpc_test"} })
 
-	counts := module.CategoryCounts()
+	counts := registry.CategoryCounts()
 	if counts["xpc_test"] != 2 {
 		t.Errorf("expected count 2 for xpc_test, got %d", counts["xpc_test"])
 	}


### PR DESCRIPTION
Replaces singleton module registrations with fresh factories and makes prerequisites and cleanup context-aware for isolated state, bounded cleanup, reliable cancellation, and audit-neutral failure handling. Makes the complete catalog portable and expands macOS CI to all packages on Go 1.26. Validation: go test ./...; go vet ./...; golangci-lint run ./...; govulncheck ./...; Darwin amd64 and arm64 builds; Mac integration tests with race detection and vet.