### PR TITLE
refactor: add typed module inputs

### DIFF
--- a/AI-GUIDANCE.md
+++ b/AI-GUIDANCE.md
@@ -272,7 +272,7 @@ golangci-lint run ./...
 | Error returns | Never silently discard. Use `_ = f.Close()` or `defer func() { _ = f.Close() }()` for intentionally ignored returns (enforced by `errcheck`) |
 | No stdout from modules | All module output goes through `emit(ev)` |
 | No global state | Only the module registry (`pkg/module/registry.go`) uses package-level state; it is protected by `sync.RWMutex` |
-| Params access | Always `params.Get("key", "default")` — never index `params` directly |
+| Params access | Use the typed `params.String`, `Int`, `Bool`, `Strings`, or `Paths` accessor that matches `ParamSpecs()` |
 | Build tags | Keep metadata and registration portable; isolate Darwin-only implementation code behind `//go:build darwin` |
 | File names | One module per file, named after the module (`net_connect.go` → `net_connect` module) |
 | Package names | Module packages use the category name (e.g. `package network`), not the module name |
@@ -283,7 +283,7 @@ golangci-lint run ./...
 
 - **Writing to stdout from a module** — breaks JSONL output mode and bypasses the audit wrapper.
 - **Calling `audit.Logger` methods from a module** — the runner owns the logger. Modules must not import `internal/audit`.
-- **Hardcoding OS paths** — use `params.Get(...)` with a sensible default so callers can override.
+- **Hardcoding OS paths** — declare a path parameter and use `params.String(...)` so callers can override it.
 - **Missing `Cleanup()`** — every state change in `Generate()` must be reversible. If `Cleanup()` is a no-op because nothing persists, that is fine; it must still exist.
 - **Registering with a duplicate name** — `Register()` panics on collision. Module names are global and must be unique.
 - **Missing blank import** — a new category package won't register its modules unless imported in `cmd/macnoise/main.go`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ _ "github.com/0xv1n/macnoise/modules/mynewcategory"
 
 - [ ] Implements all 6 methods of `Generator`
 - [ ] `Info()` has accurate `Category`, `Tags`, `Privileges`, and `MITRE` entries
-- [ ] `ParamSpecs()` documents every accepted parameter with defaults and examples
+- [ ] `ParamSpecs()` declares the type of every accepted parameter, with defaults and examples
 - [ ] `CheckPrereqs(ctx, params)` returns a clear error when requirements aren't met
 - [ ] `DryRun()` describes every action without executing side-effects
 - [ ] `Cleanup(ctx)` fully reverts any persistent changes

--- a/README.md
+++ b/README.md
@@ -158,13 +158,16 @@ steps:
   - module: net_connect
     params:
       target: "192.168.1.1"
-      port: "443"
-  - category: file
+      port: 443
+  - module: file_create
     params:
       base_dir: "/tmp/test"
 ```
 
-`on_error` defaults to `stop`. Set it to `continue` only when a coverage sweep should attempt later module invocations after a failure.
+Parameters are checked against each module's declared string, integer, boolean,
+path, or list type before preview or execution. Unknown names and invalid values
+are rejected. `on_error` defaults to `stop`. Set it to `continue` only when a
+coverage sweep should attempt later module invocations after a failure.
 
 ## Contributing
 

--- a/cmd/macnoise/docs_test.go
+++ b/cmd/macnoise/docs_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/0xv1n/macnoise/internal/runner"
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
@@ -56,10 +57,9 @@ func TestDocsListEveryRegisteredModule(t *testing.T) {
 	}
 }
 
-// Scenario files must only reference modules that exist. A typo or a module
-// renamed out from under a scenario fails at run time partway through the
-// chain, after earlier steps have already made changes on the host.
-func TestScenariosReferenceRegisteredModules(t *testing.T) {
+// Stock scenarios must parse strictly and provide valid parameters for every
+// module they invoke.
+func TestStockScenariosHaveValidInputs(t *testing.T) {
 	dir := filepath.Join("..", "..", "configs", "scenarios")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -70,16 +70,36 @@ func TestScenariosReferenceRegisteredModules(t *testing.T) {
 		if !strings.HasSuffix(e.Name(), ".yaml") {
 			continue
 		}
-		body := readRepoFile(t, "configs", "scenarios", e.Name())
-		for _, line := range strings.Split(body, "\n") {
-			line = strings.TrimSpace(line)
-			name, ok := strings.CutPrefix(line, "- module:")
-			if !ok {
+		path := filepath.Join(dir, e.Name())
+		scenario, err := runner.LoadScenario(path)
+		if err != nil {
+			t.Errorf("%s: %v", e.Name(), err)
+			continue
+		}
+		for i, step := range scenario.Steps {
+			var generators []module.Generator
+			switch {
+			case step.Module != "":
+				gen, found := module.Get(step.Module)
+				if !found {
+					t.Errorf("%s step %d references unregistered module %q", e.Name(), i+1, step.Module)
+					continue
+				}
+				generators = []module.Generator{gen}
+			case step.Category != "":
+				generators = module.ByCategory(module.Category(step.Category))
+				if len(generators) == 0 {
+					t.Errorf("%s step %d references empty category %q", e.Name(), i+1, step.Category)
+					continue
+				}
+			default:
+				t.Errorf("%s step %d has neither module nor category", e.Name(), i+1)
 				continue
 			}
-			name = strings.TrimSpace(name)
-			if _, found := module.Get(name); !found {
-				t.Errorf("%s references unregistered module %q", e.Name(), name)
+			for _, gen := range generators {
+				if _, err := module.NormalizeParams(gen.ParamSpecs(), step.Params); err != nil {
+					t.Errorf("%s step %d (%s): %v", e.Name(), i+1, gen.Info().Name, err)
+				}
 			}
 		}
 	}

--- a/cmd/macnoise/main.go
+++ b/cmd/macnoise/main.go
@@ -219,6 +219,10 @@ func buildRun() *cobra.Command {
   macnoise run --category network
   macnoise run --all --format jsonl`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			params, err := parseParams(paramFlags)
+			if err != nil {
+				return err
+			}
 			em, closeEM, err := buildEmitter()
 			if err != nil {
 				return err
@@ -234,7 +238,6 @@ func buildRun() *cobra.Command {
 
 			fmt.Fprintf(os.Stderr, "run_id=%s\n", runID)
 
-			params := parseParams(paramFlags)
 			opts := buildRunOpts(auditLogger, runID)
 			ctx, stop := signalContext()
 			defer stop()
@@ -354,12 +357,12 @@ func buildInfo() *cobra.Command {
 					if s.Required {
 						req = " (required)"
 					}
-					fmt.Printf("  %-20s %s%s\n", s.Name, s.Description, req)
-					if s.DefaultValue != "" {
-						fmt.Printf("    default: %s\n", s.DefaultValue)
+					fmt.Printf("  %-20s %s%s\n", s.Name+" ("+string(s.Type)+")", s.Description, req)
+					if s.Default != nil {
+						fmt.Printf("    default: %v\n", s.Default)
 					}
-					if s.Example != "" {
-						fmt.Printf("    example: %s\n", s.Example)
+					if s.Example != nil {
+						fmt.Printf("    example: %v\n", s.Example)
 					}
 				}
 			}
@@ -429,13 +432,22 @@ func buildVersion() *cobra.Command {
 	}
 }
 
-func parseParams(flags []string) module.Params {
+func parseParams(flags []string) (module.Params, error) {
 	p := module.Params{}
 	for _, f := range flags {
 		parts := strings.SplitN(f, "=", 2)
-		if len(parts) == 2 {
-			p[parts[0]] = parts[1]
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, fmt.Errorf("invalid --param %q: expected key=value", f)
 		}
+		if existing, exists := p[parts[0]]; exists {
+			if values, ok := existing.([]any); ok {
+				p[parts[0]] = append(values, parts[1])
+			} else {
+				p[parts[0]] = []any{existing, parts[1]}
+			}
+			continue
+		}
+		p[parts[0]] = parts[1]
 	}
-	return p
+	return p, nil
 }

--- a/cmd/macnoise/params_test.go
+++ b/cmd/macnoise/params_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/0xv1n/macnoise/internal/runner"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestParseParamsRejectsMalformedFlags(t *testing.T) {
+	for _, flags := range [][]string{{"missing-separator"}, {"=value"}} {
+		if _, err := parseParams(flags); err == nil {
+			t.Errorf("parseParams(%q) returned nil error", flags)
+		}
+	}
+}
+
+func TestParseParamsPreservesRepeatedListValues(t *testing.T) {
+	raw, err := parseParams([]string{"paths=/tmp/one,part", "paths=/tmp/two"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	params, err := module.NormalizeParams([]module.ParamSpec{{Name: "paths", Type: module.ParamPathList}}, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := params.Paths("paths", nil)
+	if len(paths) != 2 || paths[0] != "/tmp/one,part" || paths[1] != "/tmp/two" {
+		t.Fatalf("paths = %#v", paths)
+	}
+}
+
+func TestParseParamsPreservesExplicitEmptyValue(t *testing.T) {
+	params, err := parseParams([]string{"filter="})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := params["filter"]; !ok || value != "" {
+		t.Fatalf("filter = %#v, present = %v", value, ok)
+	}
+}
+
+func TestNegativePayloadSizeIsRejectedBeforeExecution(t *testing.T) {
+	gen, ok := module.Get("net_exfil")
+	if !ok {
+		t.Fatal("net_exfil is not registered")
+	}
+
+	err := runner.RunSingle(context.Background(), gen, module.Params{"payload_size": "-1"}, func(module.TelemetryEvent) {}, runner.Options{})
+	if err == nil || !strings.Contains(err.Error(), `parameter "payload_size" must be at least 0`) {
+		t.Fatalf("RunSingle error = %v", err)
+	}
+}

--- a/configs/scenarios/full_sweep.yaml
+++ b/configs/scenarios/full_sweep.yaml
@@ -7,8 +7,6 @@ steps:
   - category: process
 
   - category: file
-    params:
-      base_dir: "/tmp/macnoise_sweep"
 
   # service category is not run wholesale: svc_launch_daemon requires root
   # and this scenario is scoped to run without elevated privileges.

--- a/configs/scenarios/network_only.yaml
+++ b/configs/scenarios/network_only.yaml
@@ -13,7 +13,10 @@ steps:
 
   - module: net_dns
     params:
-      domains: "example.com,google.com,github.com"
+      domains:
+        - example.com
+        - google.com
+        - github.com
 
   - module: net_beacon
     params:

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -112,7 +112,7 @@ func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, para
 		Unmapped: UnmappedData{
 			Module:         info.Name,
 			ModuleCategory: string(info.Category),
-			Params:         map[string]string(params),
+			Params:         map[string]any(params),
 			Privileges:     string(info.Privileges),
 			Outcome:        string(outcome),
 		},
@@ -150,7 +150,7 @@ func (l *Logger) LogLifecycle(recordType string, info module.ModuleInfo, params 
 	unmapped := UnmappedData{
 		Module:         info.Name,
 		ModuleCategory: string(info.Category),
-		Params:         map[string]string(params),
+		Params:         map[string]any(params),
 		Privileges:     string(info.Privileges),
 		DryRun:         data.DryRun,
 		PrereqResult:   data.PrereqResult,

--- a/internal/audit/record.go
+++ b/internal/audit/record.go
@@ -110,10 +110,10 @@ type OCSFTactic struct {
 
 // UnmappedData holds macnoise-specific fields that have no direct OCSF mapping.
 type UnmappedData struct {
-	Module         string            `json:"module"`
-	ModuleCategory string            `json:"module_category"`
-	Params         map[string]string `json:"params,omitempty"`
-	Privileges     string            `json:"privileges"`
+	Module         string         `json:"module"`
+	ModuleCategory string         `json:"module_category"`
+	Params         map[string]any `json:"params,omitempty"`
+	Privileges     string         `json:"privileges"`
 	// Outcome preserves the four-way event outcome that OCSF status collapses:
 	// status cannot tell a refused action apart from a broken tool, since both
 	// are a Failure of the reported activity.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,9 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -39,7 +41,16 @@ func Load(path string) (Config, error) {
 	if err != nil {
 		return cfg, fmt.Errorf("config: read %s: %w", path, err)
 	}
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&cfg); err != nil {
+		return cfg, fmt.Errorf("config: parse %s: %w", path, err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple YAML documents are not supported")
+		}
 		return cfg, fmt.Errorf("config: parse %s: %w", path, err)
 	}
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/0xv1n/macnoise/internal/config"
@@ -79,5 +80,18 @@ func TestLoadInvalidYAMLReturnsError(t *testing.T) {
 	_, err := config.Load(path)
 	if err == nil {
 		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestLoadRejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unknown.yaml")
+	if err := os.WriteFile(path, []byte("default_timeout: 30\ndefault_timout: 60\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.Load(path)
+	if err == nil || !strings.Contains(err.Error(), "field default_timout not found") {
+		t.Fatalf("Load error = %v, want unknown-field error", err)
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -36,6 +36,11 @@ type Options struct {
 // RunSingle executes one module through its full lifecycle (prereqs → generate → cleanup).
 func RunSingle(ctx context.Context, gen module.Generator, params module.Params, emit module.EventEmitter, opts Options) (resultErr error) {
 	info := gen.Info()
+	normalized, err := module.NormalizeParams(gen.ParamSpecs(), params)
+	if err != nil {
+		return fmt.Errorf("[%s] params: %w", info.Name, err)
+	}
+	params = normalized
 	startTime := time.Now()
 
 	lifecycle := audit.LifecycleData{
@@ -176,7 +181,7 @@ stepLoop:
 		default:
 		}
 
-		params := module.Params(step.Params)
+		params := step.Params
 		if params == nil {
 			params = module.Params{}
 		}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -17,16 +18,21 @@ import (
 )
 
 type mockGen struct {
-	name         string
-	category     module.Category
-	prereqErr    error
-	generateErr  error
-	cleanupErr   error
-	events       []module.TelemetryEvent
-	dryRunLines  []string
-	onGenerate   func()
-	cleanedUp    bool
-	cleanupRunID string
+	name          string
+	category      module.Category
+	prereqErr     error
+	generateErr   error
+	cleanupErr    error
+	events        []module.TelemetryEvent
+	dryRunLines   []string
+	onGenerate    func()
+	cleanedUp     bool
+	cleanupRunID  string
+	paramSpecs    []module.ParamSpec
+	params        module.Params
+	prereqCalls   int
+	dryRunCalls   int
+	generateCalls int
 }
 
 func (m *mockGen) Info() module.ModuleInfo {
@@ -36,9 +42,14 @@ func (m *mockGen) Info() module.ModuleInfo {
 	}
 	return module.ModuleInfo{Name: m.name, Category: category}
 }
-func (m *mockGen) ParamSpecs() []module.ParamSpec                               { return nil }
-func (m *mockGen) CheckPrereqs(ctx context.Context, params module.Params) error { return m.prereqErr }
-func (m *mockGen) Generate(_ context.Context, _ module.Params, emit module.EventEmitter) error {
+func (m *mockGen) ParamSpecs() []module.ParamSpec { return m.paramSpecs }
+func (m *mockGen) CheckPrereqs(ctx context.Context, params module.Params) error {
+	m.prereqCalls++
+	return m.prereqErr
+}
+func (m *mockGen) Generate(_ context.Context, params module.Params, emit module.EventEmitter) error {
+	m.generateCalls++
+	m.params = params
 	if m.onGenerate != nil {
 		m.onGenerate()
 	}
@@ -47,11 +58,52 @@ func (m *mockGen) Generate(_ context.Context, _ module.Params, emit module.Event
 	}
 	return m.generateErr
 }
-func (m *mockGen) DryRun(_ module.Params) []string { return m.dryRunLines }
+func (m *mockGen) DryRun(params module.Params) []string {
+	m.dryRunCalls++
+	m.params = params
+	return m.dryRunLines
+}
 func (m *mockGen) Cleanup(ctx context.Context) error {
 	m.cleanedUp = true
 	m.cleanupRunID = module.RunIDFromContext(ctx)
 	return m.cleanupErr
+}
+
+func TestRunSingleRejectsInvalidParamsBeforePreviewOrExecution(t *testing.T) {
+	for _, dryRun := range []bool{false, true} {
+		t.Run(fmt.Sprintf("dry_run_%v", dryRun), func(t *testing.T) {
+			gen := &mockGen{
+				name:       "typed",
+				paramSpecs: []module.ParamSpec{{Name: "count", Type: module.ParamInteger}},
+			}
+
+			err := runner.RunSingle(context.Background(), gen, module.Params{"count": "many"}, func(module.TelemetryEvent) {}, runner.Options{DryRun: dryRun})
+			if err == nil || !strings.Contains(err.Error(), `parameter "count" must be an integer`) {
+				t.Fatalf("RunSingle error = %v", err)
+			}
+			if gen.prereqCalls != 0 || gen.dryRunCalls != 0 || gen.generateCalls != 0 || gen.cleanedUp {
+				t.Fatalf("invalid input reached lifecycle: %+v", gen)
+			}
+		})
+	}
+}
+
+func TestRunSingleUsesSameNormalizationForPreviewAndExecution(t *testing.T) {
+	for _, dryRun := range []bool{false, true} {
+		t.Run(fmt.Sprintf("dry_run_%v", dryRun), func(t *testing.T) {
+			gen := &mockGen{
+				name:       "typed",
+				paramSpecs: []module.ParamSpec{{Name: "count", Type: module.ParamInteger, Default: 3}},
+			}
+
+			if err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{DryRun: dryRun}); err != nil {
+				t.Fatal(err)
+			}
+			if got := gen.params.Int("count", 0); got != 3 {
+				t.Fatalf("normalized count = %d, want 3", got)
+			}
+		})
+	}
 }
 
 func TestRunSingleSuccess(t *testing.T) {
@@ -461,5 +513,65 @@ func TestLoadScenarioRejectsInvalidOnError(t *testing.T) {
 	}
 	if _, err := runner.LoadScenario(path); err == nil || !strings.Contains(err.Error(), "invalid on_error") {
 		t.Fatalf("LoadScenario error = %v, want invalid on_error", err)
+	}
+}
+
+func TestLoadScenarioRejectsUnknownField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scenario.yaml")
+	if err := os.WriteFile(path, []byte("name: invalid\ndescripton: typo\nsteps:\n  - module: example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runner.LoadScenario(path); err == nil || !strings.Contains(err.Error(), "field descripton not found") {
+		t.Fatalf("LoadScenario error = %v, want unknown-field error", err)
+	}
+}
+
+func TestRunScenarioNormalizesPathList(t *testing.T) {
+	const name = "path_list"
+	var invocation *mockGen
+	var registry module.Registry
+	registry.Register(func() module.Generator {
+		invocation = &mockGen{
+			name:       name,
+			paramSpecs: []module.ParamSpec{{Name: "paths", Type: module.ParamPathList}},
+		}
+		return invocation
+	})
+
+	path := filepath.Join(t.TempDir(), "scenario.yaml")
+	body := "name: typed list\nsteps:\n  - module: " + name + "\n    params:\n      paths:\n        - /tmp/one\n        - /tmp/two\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) {}, runner.Options{Registry: &registry}); err != nil {
+		t.Fatal(err)
+	}
+	if got := invocation.params.Paths("paths", nil); !reflect.DeepEqual(got, []string{"/tmp/one", "/tmp/two"}) {
+		t.Fatalf("paths = %#v", got)
+	}
+}
+
+func TestRunScenarioRejectsUnknownParamBeforeExecution(t *testing.T) {
+	const name = "strict_params"
+	var invocation *mockGen
+	var registry module.Registry
+	registry.Register(func() module.Generator {
+		invocation = &mockGen{
+			name:       name,
+			paramSpecs: []module.ParamSpec{{Name: "path", Type: module.ParamPath}},
+		}
+		return invocation
+	})
+
+	path := filepath.Join(t.TempDir(), "scenario.yaml")
+	body := "name: strict params\nsteps:\n  - module: " + name + "\n    params:\n      paht: /tmp/typo\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) {}, runner.Options{Registry: &registry})
+	if err == nil || invocation.generateCalls != 0 || invocation.cleanedUp {
+		t.Fatalf("RunScenario error = %v, invocation = %+v", err, invocation)
 	}
 }

--- a/internal/runner/scenario.go
+++ b/internal/runner/scenario.go
@@ -1,17 +1,20 @@
 package runner
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 
+	"github.com/0xv1n/macnoise/pkg/module"
 	"gopkg.in/yaml.v3"
 )
 
 // ScenarioStep defines a single module invocation within a scenario.
 type ScenarioStep struct {
-	Module   string            `yaml:"module"`
-	Category string            `yaml:"category"`
-	Params   map[string]string `yaml:"params"`
+	Module   string        `yaml:"module"`
+	Category string        `yaml:"category"`
+	Params   module.Params `yaml:"params"`
 }
 
 // Scenario is the top-level structure parsed from a scenario YAML file.
@@ -30,7 +33,16 @@ func LoadScenario(path string) (Scenario, error) {
 		return Scenario{}, fmt.Errorf("scenario: read %s: %w", path, err)
 	}
 	var sc Scenario
-	if err := yaml.Unmarshal(data, &sc); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&sc); err != nil {
+		return Scenario{}, fmt.Errorf("scenario: parse %s: %w", path, err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple YAML documents are not supported")
+		}
 		return Scenario{}, fmt.Errorf("scenario: parse %s: %w", path, err)
 	}
 	if len(sc.Steps) == 0 {

--- a/modules/endpoint_security/es_file.go
+++ b/modules/endpoint_security/es_file.go
@@ -37,14 +37,14 @@ func (e *esFile) Info() module.ModuleInfo {
 
 func (e *esFile) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "work_dir", Description: "Directory for ES file operations", Required: false, DefaultValue: "/tmp/macnoise_es", Example: "/var/tmp/es_test"},
+		{Name: "work_dir", Description: "Directory for ES file operations", Type: module.ParamPath, Default: "/tmp/macnoise_es", Example: "/var/tmp/es_test"},
 	}
 }
 
 func (e *esFile) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (e *esFile) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	workDir := module.TagPath(params.Get("work_dir", "/tmp/macnoise_es"), module.RunIDFromContext(ctx))
+	workDir := module.TagPath(params.String("work_dir", "/tmp/macnoise_es"), module.RunIDFromContext(ctx))
 	info := e.Info()
 
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
@@ -141,7 +141,7 @@ func (e *esFile) Generate(ctx context.Context, params module.Params, emit module
 }
 
 func (e *esFile) DryRun(params module.Params) []string {
-	workDir := params.Get("work_dir", "/tmp/macnoise_es")
+	workDir := params.String("work_dir", "/tmp/macnoise_es")
 	// path.Join, not filepath.Join: these are always macOS paths, and a
 	// Windows-compiled binary would otherwise advertise backslashes in a dry run
 	// it can never perform. Same trap es_mount hit.

--- a/modules/endpoint_security/es_mount.go
+++ b/modules/endpoint_security/es_mount.go
@@ -49,7 +49,7 @@ func (e *esMount) Info() module.ModuleInfo {
 
 func (e *esMount) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "work_dir", Description: "Directory to build the disk image in", Required: false, DefaultValue: "/tmp/macnoise_es", Example: "/var/tmp/es_test"},
+		{Name: "work_dir", Description: "Directory to build the disk image in", Type: module.ParamPath, Default: "/tmp/macnoise_es", Example: "/var/tmp/es_test"},
 	}
 }
 
@@ -109,7 +109,7 @@ func detachArgs(target string) []string {
 
 func (e *esMount) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
-	workDir := module.TagPath(params.Get("work_dir", "/tmp/macnoise_es"), runID)
+	workDir := module.TagPath(params.String("work_dir", "/tmp/macnoise_es"), runID)
 	info := e.Info()
 
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
@@ -214,7 +214,7 @@ func (e *esMount) emitVolumeExec(ctx context.Context, info module.ModuleInfo, em
 }
 
 func (e *esMount) DryRun(params module.Params) []string {
-	workDir := params.Get("work_dir", "/tmp/macnoise_es")
+	workDir := params.String("work_dir", "/tmp/macnoise_es")
 	dmgPath := path.Join(workDir, "macnoise_delivery.dmg")
 	mountPoint := path.Join("/Volumes", volumeName)
 	return []string{

--- a/modules/endpoint_security/es_process.go
+++ b/modules/endpoint_security/es_process.go
@@ -29,7 +29,7 @@ func (e *esProcess) Info() module.ModuleInfo {
 
 func (e *esProcess) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "chain_depth", Description: "Number of nested shell invocations", Required: false, DefaultValue: "3", Example: "5"},
+		{Name: "chain_depth", Description: "Number of nested shell invocations", Type: module.ParamInteger, Default: 3, Example: 5, Range: &module.IntegerRange{Min: 1, Max: 10}},
 	}
 }
 
@@ -56,9 +56,7 @@ func buildExecChainArgs(depth int, runID string) []string {
 }
 
 func (e *esProcess) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	depthStr := params.Get("chain_depth", "3")
-	depth := 3
-	fmt.Sscanf(depthStr, "%d", &depth) //nolint:errcheck
+	depth := params.Int("chain_depth", 3)
 	if depth > 10 {
 		depth = 10
 	}
@@ -88,9 +86,9 @@ func (e *esProcess) Generate(ctx context.Context, params module.Params, emit mod
 }
 
 func (e *esProcess) DryRun(params module.Params) []string {
-	depth := params.Get("chain_depth", "3")
+	depth := params.Int("chain_depth", 3)
 	return []string{
-		fmt.Sprintf("execute %s-deep nested sh -c chain → ES_EVENT_TYPE_NOTIFY_EXEC/FORK/EXIT", depth),
+		fmt.Sprintf("execute %d-deep nested sh -c chain → ES_EVENT_TYPE_NOTIFY_EXEC/FORK/EXIT", depth),
 	}
 }
 

--- a/modules/evasion/log_clear.go
+++ b/modules/evasion/log_clear.go
@@ -39,11 +39,11 @@ func (e *evadeLogClear) Info() module.ModuleInfo {
 func (e *evadeLogClear) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "stage_dir",
-			Description:  "Directory for staging evasion artifacts",
-			Required:     false,
-			DefaultValue: defaultEvasionStageDir,
-			Example:      "/var/tmp/macnoise_evasion",
+			Name:        "stage_dir",
+			Description: "Directory for staging evasion artifacts",
+			Type:        module.ParamPath,
+			Default:     defaultEvasionStageDir,
+			Example:     "/var/tmp/macnoise_evasion",
 		},
 	}
 }
@@ -138,7 +138,7 @@ func clearHistory(info module.ModuleInfo, stageDir string) module.TelemetryEvent
 
 func (e *evadeLogClear) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	info := e.Info()
-	stageDir := module.TagPath(params.Get("stage_dir", defaultEvasionStageDir), module.RunIDFromContext(ctx))
+	stageDir := module.TagPath(params.String("stage_dir", defaultEvasionStageDir), module.RunIDFromContext(ctx))
 	if err := os.MkdirAll(stageDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", stageDir, err)
 	}
@@ -169,7 +169,7 @@ func (e *evadeLogClear) Generate(ctx context.Context, params module.Params, emit
 }
 
 func (e *evadeLogClear) DryRun(params module.Params) []string {
-	stageDir := params.Get("stage_dir", defaultEvasionStageDir)
+	stageDir := params.String("stage_dir", defaultEvasionStageDir)
 	return []string{
 		fmt.Sprintf("mkdir -p %s", stageDir),
 		fmt.Sprintf("touch -t 200001010000 %s/timestomp_target (T1070.006)", stageDir),

--- a/modules/evasion/masquerade.go
+++ b/modules/evasion/masquerade.go
@@ -45,9 +45,9 @@ func (e *evadeMasquerade) Info() module.ModuleInfo {
 
 func (e *evadeMasquerade) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "stage_dir", Description: "Directory for the masqueraded binary", Required: false, DefaultValue: defaultMasqueradeStageDir, Example: "/var/tmp/macnoise_masquerade"},
-		{Name: "source_binary", Description: "Benign system utility to copy and run", Required: false, DefaultValue: defaultMasqueradeSource, Example: "/bin/cp"},
-		{Name: "masquerade_name", Description: "Legitimate-looking name to run the copy under", Required: false, DefaultValue: defaultMasqueradeName, Example: "mdworker_shared"},
+		{Name: "stage_dir", Description: "Directory for the masqueraded binary", Type: module.ParamPath, Default: defaultMasqueradeStageDir, Example: "/var/tmp/macnoise_masquerade"},
+		{Name: "source_binary", Description: "Benign system utility to copy and run", Type: module.ParamPath, Default: defaultMasqueradeSource, Example: "/bin/cp"},
+		{Name: "masquerade_name", Description: "Legitimate-looking name to run the copy under", Type: module.ParamString, Default: defaultMasqueradeName, Example: "mdworker_shared"},
 	}
 }
 
@@ -76,9 +76,9 @@ func copyExecutable(src, dst string) error {
 
 func (e *evadeMasquerade) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
-	stageDir := module.TagPath(params.Get("stage_dir", defaultMasqueradeStageDir), runID)
-	source := params.Get("source_binary", defaultMasqueradeSource)
-	masqName := params.Get("masquerade_name", defaultMasqueradeName)
+	stageDir := module.TagPath(params.String("stage_dir", defaultMasqueradeStageDir), runID)
+	source := params.String("source_binary", defaultMasqueradeSource)
+	masqName := params.String("masquerade_name", defaultMasqueradeName)
 	info := e.Info()
 
 	if err := os.MkdirAll(stageDir, 0o755); err != nil {
@@ -131,9 +131,9 @@ func (e *evadeMasquerade) Generate(ctx context.Context, params module.Params, em
 }
 
 func (e *evadeMasquerade) DryRun(params module.Params) []string {
-	source := params.Get("source_binary", defaultMasqueradeSource)
-	masqName := params.Get("masquerade_name", defaultMasqueradeName)
-	stageDir := params.Get("stage_dir", defaultMasqueradeStageDir)
+	source := params.String("source_binary", defaultMasqueradeSource)
+	masqName := params.String("masquerade_name", defaultMasqueradeName)
+	stageDir := params.String("stage_dir", defaultMasqueradeStageDir)
 	dest := filepath.Join(stageDir, masqName)
 	return []string{
 		fmt.Sprintf("copy %s to %s (T1036.003)", source, dest),

--- a/modules/file/archive.go
+++ b/modules/file/archive.go
@@ -35,9 +35,9 @@ func (f *fileArchive) Info() module.ModuleInfo {
 
 func (f *fileArchive) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "source_dir", Description: "Directory to archive", Required: false, DefaultValue: "/tmp/macnoise_archive_src", Example: "/var/tmp/stage"},
-		{Name: "output_path", Description: "Output archive path", Required: false, DefaultValue: "/tmp/macnoise_archive.zip", Example: "/var/tmp/out.zip"},
-		{Name: "tool", Description: "Archival tool: zip, ditto, or tar", Required: false, DefaultValue: "zip", Example: "ditto"},
+		{Name: "source_dir", Description: "Directory to archive", Type: module.ParamPath, Default: "/tmp/macnoise_archive_src", Example: "/var/tmp/stage"},
+		{Name: "output_path", Description: "Output archive path", Type: module.ParamPath, Default: "/tmp/macnoise_archive.zip", Example: "/var/tmp/out.zip"},
+		{Name: "tool", Description: "Archival tool: zip, ditto, or tar", Type: module.ParamString, Default: "zip", Example: "ditto", Choices: []string{"zip", "ditto", "tar"}},
 	}
 }
 
@@ -45,9 +45,9 @@ func (f *fileArchive) CheckPrereqs(ctx context.Context, params module.Params) er
 
 func (f *fileArchive) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
-	sourceDir := module.TagPath(params.Get("source_dir", "/tmp/macnoise_archive_src"), runID)
-	outputPath := module.TagPath(params.Get("output_path", "/tmp/macnoise_archive.zip"), runID)
-	tool := params.Get("tool", "zip")
+	sourceDir := module.TagPath(params.String("source_dir", "/tmp/macnoise_archive_src"), runID)
+	outputPath := module.TagPath(params.String("output_path", "/tmp/macnoise_archive.zip"), runID)
+	tool := params.String("tool", "zip")
 	f.sourceDir = sourceDir
 	f.outputPath = outputPath
 	info := f.Info()
@@ -106,9 +106,9 @@ func (f *fileArchive) Generate(ctx context.Context, params module.Params, emit m
 }
 
 func (f *fileArchive) DryRun(params module.Params) []string {
-	sourceDir := params.Get("source_dir", "/tmp/macnoise_archive_src")
-	outputPath := params.Get("output_path", "/tmp/macnoise_archive.zip")
-	tool := params.Get("tool", "zip")
+	sourceDir := params.String("source_dir", "/tmp/macnoise_archive_src")
+	outputPath := params.String("output_path", "/tmp/macnoise_archive.zip")
+	tool := params.String("tool", "zip")
 	return []string{
 		fmt.Sprintf("mkdir -p %s && create 3 staged files", sourceDir),
 		fmt.Sprintf("%s -r %s %s", tool, outputPath, sourceDir),

--- a/modules/file/browser_creds.go
+++ b/modules/file/browser_creds.go
@@ -135,11 +135,12 @@ func (f *fileBrowserCreds) Info() module.ModuleInfo {
 func (f *fileBrowserCreds) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "browsers",
-			Description:  "Comma-separated browser names to probe, or 'all'",
-			Required:     false,
-			DefaultValue: "all",
-			Example:      "chrome,firefox",
+			Name:        "browsers",
+			Description: "Browser names to probe, or 'all'",
+			Type:        module.ParamStringList,
+			Default:     []string{"all"},
+			Example:     []string{"chrome", "firefox"},
+			Choices:     []string{"all", "chrome", "chromecanary", "brave", "edge", "arc", "vivaldi", "opera", "operagx", "yandex", "firefox", "safari"},
 		},
 	}
 }
@@ -173,7 +174,7 @@ func browserTargets() ([]browserTarget, error) {
 }
 
 func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	browsersParam := params.Get("browsers", "all")
+	browsers := params.Strings("browsers", []string{"all"})
 	info := f.Info()
 
 	targets, err := browserTargets()
@@ -182,8 +183,8 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 	}
 
 	filter := map[string]bool{}
-	if browsersParam != "all" {
-		for _, b := range strings.Split(browsersParam, ",") {
+	if len(browsers) != 1 || browsers[0] != "all" {
+		for _, b := range browsers {
 			filter[strings.TrimSpace(strings.ToLower(b))] = true
 		}
 	}
@@ -249,9 +250,9 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 }
 
 func (f *fileBrowserCreds) DryRun(params module.Params) []string {
-	browsersParam := params.Get("browsers", "all")
+	browsers := params.Strings("browsers", []string{"all"})
 	return []string{
-		fmt.Sprintf("open and read browser credential files for: %s (contents discarded)", browsersParam),
+		fmt.Sprintf("open and read browser credential files for: %s (contents discarded)", strings.Join(browsers, ", ")),
 	}
 }
 

--- a/modules/file/create.go
+++ b/modules/file/create.go
@@ -35,11 +35,11 @@ func (f *fileCreate) Info() module.ModuleInfo {
 
 func (f *fileCreate) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "base_dir", Description: "Directory to create files in", Required: false, DefaultValue: "/tmp/macnoise_test", Example: "/var/tmp/macnoise"},
-		{Name: "count", Description: "Number of files to create", Required: false, DefaultValue: "3", Example: "10"},
-		{Name: "prefix", Description: "File name prefix", Required: false, DefaultValue: "mnfile_", Example: "test_"},
-		{Name: "filename", Description: "Exact name for a single file (overrides count and prefix)", Required: false, Example: "RECOVER_YOUR_FILES.txt"},
-		{Name: "content", Description: "Contents for a named file", Required: false, Example: "Your files have been encrypted."},
+		{Name: "base_dir", Description: "Directory to create files in", Type: module.ParamPath, Default: "/tmp/macnoise_test", Example: "/var/tmp/macnoise"},
+		{Name: "count", Description: "Number of files to create", Type: module.ParamInteger, Default: 3, Example: 10, Range: &module.IntegerRange{Min: 1}},
+		{Name: "prefix", Description: "File name prefix", Type: module.ParamString, Default: "mnfile_", Example: "test_"},
+		{Name: "filename", Description: "Exact name for a single file (overrides count and prefix)", Type: module.ParamString, Example: "RECOVER_YOUR_FILES.txt"},
+		{Name: "content", Description: "Contents for a named file", Type: module.ParamString, Example: "Your files have been encrypted."},
 	}
 }
 
@@ -55,15 +55,12 @@ func stampedFileName(prefix, runID, ts string, i int) string {
 }
 
 func (f *fileCreate) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	baseDir := params.Get("base_dir", "/tmp/macnoise_test")
-	countStr := params.Get("count", "3")
-	prefix := params.Get("prefix", "mnfile_")
-	filename := params.Get("filename", "")
-	content := params.Get("content", "")
+	baseDir := params.String("base_dir", "/tmp/macnoise_test")
+	count := params.Int("count", 3)
+	prefix := params.String("prefix", "mnfile_")
+	filename := params.String("filename", "")
+	content := params.String("content", "")
 	runID := module.RunIDFromContext(ctx)
-
-	count := 3
-	fmt.Sscanf(countStr, "%d", &count) //nolint:errcheck
 
 	info := f.Info()
 
@@ -114,10 +111,10 @@ func (f *fileCreate) Generate(ctx context.Context, params module.Params, emit mo
 }
 
 func (f *fileCreate) DryRun(params module.Params) []string {
-	baseDir := params.Get("base_dir", "/tmp/macnoise_test")
-	countStr := params.Get("count", "3")
-	prefix := params.Get("prefix", "mnfile_")
-	filename := params.Get("filename", "")
+	baseDir := params.String("base_dir", "/tmp/macnoise_test")
+	count := params.Int("count", 3)
+	prefix := params.String("prefix", "mnfile_")
+	filename := params.String("filename", "")
 	if filename != "" {
 		return []string{
 			fmt.Sprintf("mkdir -p %s", baseDir),
@@ -126,7 +123,7 @@ func (f *fileCreate) DryRun(params module.Params) []string {
 	}
 	return []string{
 		fmt.Sprintf("mkdir -p %s", baseDir),
-		fmt.Sprintf("create %s files with prefix %q in %s", countStr, prefix, baseDir),
+		fmt.Sprintf("create %d files with prefix %q in %s", count, prefix, baseDir),
 	}
 }
 

--- a/modules/file/cred_files.go
+++ b/modules/file/cred_files.go
@@ -40,11 +40,11 @@ func (f *fileCredFiles) Info() module.ModuleInfo {
 func (f *fileCredFiles) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "paths",
-			Description:  "Comma-separated extra file paths to probe, e.g. a project .env",
-			Required:     false,
-			DefaultValue: "",
-			Example:      "/Users/dev/project/.env,/Users/dev/.netrc",
+			Name:        "paths",
+			Description: "Extra file paths to probe, e.g. a project .env",
+			Type:        module.ParamPathList,
+			Default:     []string{},
+			Example:     []string{"/Users/dev/project/.env", "/Users/dev/.netrc"},
 		},
 	}
 }
@@ -99,21 +99,6 @@ func defaultCredTargets(home string) []credTarget {
 	return targets
 }
 
-// parseExtraPaths splits the user-supplied paths parameter, dropping empties so
-// a trailing comma or blank value does not produce a probe for "".
-func parseExtraPaths(param string) []string {
-	if param == "" {
-		return nil
-	}
-	var paths []string
-	for _, p := range strings.Split(param, ",") {
-		if p = strings.TrimSpace(p); p != "" {
-			paths = append(paths, p)
-		}
-	}
-	return paths
-}
-
 func (f *fileCredFiles) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	info := f.Info()
 
@@ -123,7 +108,7 @@ func (f *fileCredFiles) Generate(ctx context.Context, params module.Params, emit
 	}
 
 	targets := defaultCredTargets(home)
-	for _, p := range parseExtraPaths(params.Get("paths", "")) {
+	for _, p := range params.Paths("paths", nil) {
 		targets = append(targets, credTarget{kind: "custom", path: p})
 	}
 
@@ -187,7 +172,7 @@ func credEvent(info module.ModuleInfo, target credTarget) module.TelemetryEvent 
 }
 
 func (f *fileCredFiles) DryRun(params module.Params) []string {
-	extra := parseExtraPaths(params.Get("paths", ""))
+	extra := params.Paths("paths", nil)
 	lines := []string{
 		"open and read ~/.ssh/id_* (private keys only), ~/.aws/credentials, ~/.kube/config, ~/.docker/config.json, ~/.env (contents discarded)",
 	}

--- a/modules/file/cred_files_test.go
+++ b/modules/file/cred_files_test.go
@@ -94,29 +94,6 @@ func TestDefaultCredTargetsCoversEachKind(t *testing.T) {
 	}
 }
 
-func TestParseExtraPaths(t *testing.T) {
-	tests := []struct {
-		in   string
-		want []string
-	}{
-		{"", nil},
-		{"/a/.env", []string{"/a/.env"}},
-		{"/a/.env, /b/.netrc", []string{"/a/.env", "/b/.netrc"}},
-		{"/a,,  ,/b", []string{"/a", "/b"}},
-	}
-	for _, tt := range tests {
-		got := parseExtraPaths(tt.in)
-		if len(got) != len(tt.want) {
-			t.Fatalf("parseExtraPaths(%q) = %v, want %v", tt.in, got, tt.want)
-		}
-		for i := range got {
-			if got[i] != tt.want[i] {
-				t.Errorf("parseExtraPaths(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
-			}
-		}
-	}
-}
-
 // The read path: a present, readable credential file is reported as an executed
 // read with a byte count. Works on any OS, no chmod needed.
 func TestCredEventReadsPresentFile(t *testing.T) {

--- a/modules/file/encrypt.go
+++ b/modules/file/encrypt.go
@@ -46,9 +46,9 @@ func (f *fileEncrypt) Info() module.ModuleInfo {
 
 func (f *fileEncrypt) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "stage_dir", Description: "Directory used to stage and encrypt decoy files (only files here are touched)", Required: false, DefaultValue: defaultEncryptStageDir, Example: "/var/tmp/macnoise_encrypt"},
-		{Name: "file_count", Description: "Number of plaintext decoy files to stage before encrypting", Required: false, DefaultValue: "5", Example: "20"},
-		{Name: "extension", Description: "Extension appended to encrypted files", Required: false, DefaultValue: defaultEncryptExtension, Example: ".crypted"},
+		{Name: "stage_dir", Description: "Directory used to stage and encrypt decoy files (only files here are touched)", Type: module.ParamPath, Default: defaultEncryptStageDir, Example: "/var/tmp/macnoise_encrypt"},
+		{Name: "file_count", Description: "Number of plaintext decoy files to stage before encrypting", Type: module.ParamInteger, Default: 5, Example: 20, Range: &module.IntegerRange{Min: 1}},
+		{Name: "extension", Description: "Extension appended to encrypted files", Type: module.ParamString, Default: defaultEncryptExtension, Example: ".crypted"},
 	}
 }
 
@@ -118,10 +118,9 @@ func encryptFile(path, extension string, key []byte) (string, error) {
 
 func (f *fileEncrypt) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
-	stageDir := module.TagPath(params.Get("stage_dir", defaultEncryptStageDir), runID)
-	extension := params.Get("extension", defaultEncryptExtension)
-	count := defaultEncryptCount
-	fmt.Sscanf(params.Get("file_count", "5"), "%d", &count) //nolint:errcheck
+	stageDir := module.TagPath(params.String("stage_dir", defaultEncryptStageDir), runID)
+	extension := params.String("extension", defaultEncryptExtension)
+	count := params.Int("file_count", defaultEncryptCount)
 	if count < 1 {
 		count = 1
 	}
@@ -170,11 +169,11 @@ func (f *fileEncrypt) Generate(ctx context.Context, params module.Params, emit m
 }
 
 func (f *fileEncrypt) DryRun(params module.Params) []string {
-	stageDir := params.Get("stage_dir", defaultEncryptStageDir)
-	extension := params.Get("extension", defaultEncryptExtension)
-	count := params.Get("file_count", "5")
+	stageDir := params.String("stage_dir", defaultEncryptStageDir)
+	extension := params.String("extension", defaultEncryptExtension)
+	count := params.Int("file_count", defaultEncryptCount)
 	return []string{
-		fmt.Sprintf("stage %s plaintext decoy files with randomized extensions in %s", count, stageDir),
+		fmt.Sprintf("stage %d plaintext decoy files with randomized extensions in %s", count, stageDir),
 		fmt.Sprintf("AES-256-GCM encrypt each in place, appending %q and removing the original (T1486)", extension),
 	}
 }

--- a/modules/file/hide.go
+++ b/modules/file/hide.go
@@ -34,11 +34,11 @@ func (f *fileHide) Info() module.ModuleInfo {
 func (f *fileHide) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "work_dir",
-			Description:  "Working directory for hidden file creation",
-			Required:     false,
-			DefaultValue: "/tmp/macnoise_hide",
-			Example:      "/var/tmp/macnoise_hide",
+			Name:        "work_dir",
+			Description: "Working directory for hidden file creation",
+			Type:        module.ParamPath,
+			Default:     "/tmp/macnoise_hide",
+			Example:     "/var/tmp/macnoise_hide",
 		},
 	}
 }
@@ -46,7 +46,7 @@ func (f *fileHide) ParamSpecs() []module.ParamSpec {
 func (f *fileHide) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (f *fileHide) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	workDir := module.TagPath(params.Get("work_dir", "/tmp/macnoise_hide"), module.RunIDFromContext(ctx))
+	workDir := module.TagPath(params.String("work_dir", "/tmp/macnoise_hide"), module.RunIDFromContext(ctx))
 	f.workDir = workDir
 	info := f.Info()
 
@@ -83,7 +83,7 @@ func (f *fileHide) Generate(ctx context.Context, params module.Params, emit modu
 }
 
 func (f *fileHide) DryRun(params module.Params) []string {
-	workDir := params.Get("work_dir", "/tmp/macnoise_hide")
+	workDir := params.String("work_dir", "/tmp/macnoise_hide")
 	return []string{
 		fmt.Sprintf("mkdir -p %s", workDir),
 		fmt.Sprintf("create %s/visible_file.txt && chflags hidden %s/visible_file.txt", workDir, workDir),

--- a/modules/file/keychain_copy.go
+++ b/modules/file/keychain_copy.go
@@ -63,11 +63,11 @@ func (f *fileKeychainCopy) Info() module.ModuleInfo {
 func (f *fileKeychainCopy) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "stage_dir",
-			Description:  "Directory to stage the keychain copies in",
-			Required:     false,
-			DefaultValue: defaultKeychainStageDir,
-			Example:      "/var/tmp/macnoise_kc",
+			Name:        "stage_dir",
+			Description: "Directory to stage the keychain copies in",
+			Type:        module.ParamPath,
+			Default:     defaultKeychainStageDir,
+			Example:     "/var/tmp/macnoise_kc",
 		},
 	}
 }
@@ -232,7 +232,7 @@ func (f *fileKeychainCopy) Generate(ctx context.Context, params module.Params, e
 		return fmt.Errorf("cannot determine home directory: %w", err)
 	}
 
-	stageDir := module.TagPath(params.Get("stage_dir", defaultKeychainStageDir), module.RunIDFromContext(ctx))
+	stageDir := module.TagPath(params.String("stage_dir", defaultKeychainStageDir), module.RunIDFromContext(ctx))
 	if err := os.MkdirAll(stageDir, 0o700); err != nil {
 		return fmt.Errorf("mkdir %s: %w", stageDir, err)
 	}
@@ -255,7 +255,7 @@ func (f *fileKeychainCopy) Generate(ctx context.Context, params module.Params, e
 }
 
 func (f *fileKeychainCopy) DryRun(params module.Params) []string {
-	stageDir := params.Get("stage_dir", defaultKeychainStageDir)
+	stageDir := params.String("stage_dir", defaultKeychainStageDir)
 	return []string{
 		fmt.Sprintf("mkdir -p %s (mode 0700)", stageDir),
 		fmt.Sprintf("cp ~/Library/Keychains/login.keychain-db ~/Library/Keychains/<uuid>/keychain-2.db %s/System.keychain %s/system-keychain-2.db %s/ (mode 0600)",

--- a/modules/file/modify.go
+++ b/modules/file/modify.go
@@ -35,8 +35,8 @@ func (f *fileModify) Info() module.ModuleInfo {
 
 func (f *fileModify) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "target_path", Description: "File to modify (created if absent)", Required: false, DefaultValue: "/tmp/macnoise_modify_target.txt", Example: "/tmp/test.txt"},
-		{Name: "content", Description: "Content to append", Required: false, DefaultValue: "macnoise modification", Example: "injected data"},
+		{Name: "target_path", Description: "File to modify (created if absent)", Type: module.ParamPath, Default: "/tmp/macnoise_modify_target.txt", Example: "/tmp/test.txt"},
+		{Name: "content", Description: "Content to append", Type: module.ParamString, Default: "macnoise modification", Example: "injected data"},
 	}
 }
 
@@ -44,8 +44,8 @@ func (f *fileModify) CheckPrereqs(ctx context.Context, params module.Params) err
 
 func (f *fileModify) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
-	targetPath := module.TagPath(params.Get("target_path", "/tmp/macnoise_modify_target.txt"), runID)
-	content := params.Get("content", "macnoise modification")
+	targetPath := module.TagPath(params.String("target_path", "/tmp/macnoise_modify_target.txt"), runID)
+	content := params.String("content", "macnoise modification")
 	if runID != "" {
 		content += " mn:" + runID
 	}
@@ -93,8 +93,8 @@ func (f *fileModify) Generate(ctx context.Context, params module.Params, emit mo
 }
 
 func (f *fileModify) DryRun(params module.Params) []string {
-	target := params.Get("target_path", "/tmp/macnoise_modify_target.txt")
-	content := params.Get("content", "macnoise modification")
+	target := params.String("target_path", "/tmp/macnoise_modify_target.txt")
+	content := params.String("content", "macnoise modification")
 	return []string{
 		fmt.Sprintf("read original content of %s", target),
 		fmt.Sprintf("append %q with timestamp to %s", content, target),

--- a/modules/network/beacon.go
+++ b/modules/network/beacon.go
@@ -32,10 +32,10 @@ func (c *c2Beacon) Info() module.ModuleInfo {
 
 func (c *c2Beacon) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "target", Description: "Target URL or host", Required: false, DefaultValue: "http://example.com", Example: "http://10.0.0.1"},
-		{Name: "count", Description: "Number of beacon attempts", Required: false, DefaultValue: "3", Example: "5"},
-		{Name: "interval", Description: "Seconds between beacons", Required: false, DefaultValue: "2", Example: "10"},
-		{Name: "jitter", Description: "Percent to randomise each interval by, 0-100 (0 = fixed)", Required: false, DefaultValue: "0", Example: "30"},
+		{Name: "target", Description: "Target URL or host", Type: module.ParamString, Default: "http://example.com", Example: "http://10.0.0.1"},
+		{Name: "count", Description: "Number of beacon attempts", Type: module.ParamInteger, Default: 3, Example: 5, Range: &module.IntegerRange{Min: 1}},
+		{Name: "interval", Description: "Seconds between beacons", Type: module.ParamInteger, Default: 2, Example: 10, Range: &module.IntegerRange{Min: 0}},
+		{Name: "jitter", Description: "Percent to randomise each interval by, 0-100 (0 = fixed)", Type: module.ParamInteger, Default: 0, Example: 30, Range: &module.IntegerRange{Min: 0, Max: 100}},
 	}
 }
 
@@ -63,18 +63,11 @@ func jitterInterval(base time.Duration, jitterPct int, rnd *rand.Rand) time.Dura
 func (c *c2Beacon) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	target := tagURL(params.Get("target", "http://example.com"), module.RunIDFromContext(ctx))
-	countStr := params.Get("count", "3")
-	intervalStr := params.Get("interval", "2")
-	jitterStr := params.Get("jitter", "0")
-
-	count := 3
-	fmt.Sscanf(countStr, "%d", &count) //nolint:errcheck
-	intervalSecs := 2
-	fmt.Sscanf(intervalStr, "%d", &intervalSecs) //nolint:errcheck
+	target := tagURL(params.String("target", "http://example.com"), module.RunIDFromContext(ctx))
+	count := params.Int("count", 3)
+	intervalSecs := params.Int("interval", 2)
 	interval := time.Duration(intervalSecs) * time.Second
-	jitterPct := 0
-	fmt.Sscanf(jitterStr, "%d", &jitterPct)                //nolint:errcheck
+	jitterPct := params.Int("jitter", 0)
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // jitter timing, not security
 
 	info := c.Info()
@@ -119,12 +112,12 @@ func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit modu
 }
 
 func (c *c2Beacon) DryRun(params module.Params) []string {
-	target := params.Get("target", "http://example.com")
-	countStr := params.Get("count", "3")
-	intervalStr := params.Get("interval", "2")
-	jitterStr := params.Get("jitter", "0")
+	target := params.String("target", "http://example.com")
+	count := params.Int("count", 3)
+	interval := params.Int("interval", 2)
+	jitter := params.Int("jitter", 0)
 	return []string{
-		fmt.Sprintf("send %s HTTP GET requests to %s with %ss interval (jitter %s%%)", countStr, target, intervalStr, jitterStr),
+		fmt.Sprintf("send %d HTTP GET requests to %s with %ds interval (jitter %d%%)", count, target, interval, jitter),
 	}
 }
 

--- a/modules/network/connect.go
+++ b/modules/network/connect.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/0xv1n/macnoise/internal/output"
@@ -34,16 +35,16 @@ func (n *netConnect) Info() module.ModuleInfo {
 
 func (n *netConnect) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "target", Description: "Target IP or hostname", Required: false, DefaultValue: "127.0.0.1", Example: "10.0.0.1"},
-		{Name: "port", Description: "Target TCP port", Required: false, DefaultValue: "8080", Example: "443"},
+		{Name: "target", Description: "Target IP or hostname", Type: module.ParamString, Default: "127.0.0.1", Example: "10.0.0.1"},
+		{Name: "port", Description: "Target TCP port", Type: module.ParamInteger, Default: 8080, Example: 443, Range: &module.IntegerRange{Min: 1, Max: 65535}},
 	}
 }
 
 func (n *netConnect) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netConnect) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	target := params.Get("target", "127.0.0.1")
-	port := params.Get("port", "8080")
+	target := params.String("target", "127.0.0.1")
+	port := strconv.Itoa(params.Int("port", 8080))
 	address := net.JoinHostPort(target, port)
 
 	info := n.Info()
@@ -83,8 +84,8 @@ func (n *netConnect) Generate(ctx context.Context, params module.Params, emit mo
 }
 
 func (n *netConnect) DryRun(params module.Params) []string {
-	target := params.Get("target", "127.0.0.1")
-	port := params.Get("port", "8080")
+	target := params.String("target", "127.0.0.1")
+	port := strconv.Itoa(params.Int("port", 8080))
 	address := net.JoinHostPort(target, port)
 	return []string{
 		fmt.Sprintf("TCP dial %s with 3s timeout", address),

--- a/modules/network/dns.go
+++ b/modules/network/dns.go
@@ -31,11 +31,11 @@ func (n *netDNS) Info() module.ModuleInfo {
 func (n *netDNS) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "domains",
-			Description:  "Comma-separated list of domains to resolve",
-			Required:     false,
-			DefaultValue: "example.com,google.com,github.com",
-			Example:      "internal.corp,10.0.0.1.xip.io",
+			Name:        "domains",
+			Description: "Domains to resolve",
+			Type:        module.ParamStringList,
+			Default:     []string{"example.com", "google.com", "github.com"},
+			Example:     []string{"internal.corp", "10.0.0.1.xip.io"},
 		},
 	}
 }
@@ -43,8 +43,7 @@ func (n *netDNS) ParamSpecs() []module.ParamSpec {
 func (n *netDNS) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netDNS) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	domainsStr := params.Get("domains", "example.com,google.com,github.com")
-	domains := strings.Split(domainsStr, ",")
+	domains := params.Strings("domains", []string{"example.com", "google.com", "github.com"})
 	info := n.Info()
 
 	resolver := net.DefaultResolver
@@ -69,9 +68,9 @@ func (n *netDNS) Generate(ctx context.Context, params module.Params, emit module
 }
 
 func (n *netDNS) DryRun(params module.Params) []string {
-	domains := params.Get("domains", "example.com,google.com,github.com")
+	domains := params.Strings("domains", []string{"example.com", "google.com", "github.com"})
 	return []string{
-		fmt.Sprintf("DNS resolve: %s", domains),
+		fmt.Sprintf("DNS resolve: %s", strings.Join(domains, ",")),
 	}
 }
 

--- a/modules/network/dns_exfil.go
+++ b/modules/network/dns_exfil.go
@@ -38,18 +38,18 @@ func (n *netDNSExfil) Info() module.ModuleInfo {
 func (n *netDNSExfil) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "payload",
-			Description:  "String to exfiltrate via DNS subdomain encoding",
-			Required:     false,
-			DefaultValue: "macnoise-exfil-test",
-			Example:      "stolen-secret-data",
+			Name:        "payload",
+			Description: "String to exfiltrate via DNS subdomain encoding",
+			Type:        module.ParamString,
+			Default:     "macnoise-exfil-test",
+			Example:     "stolen-secret-data",
 		},
 		{
-			Name:         "base_domain",
-			Description:  "Base domain appended to each query (use .invalid TLD for offline safety)",
-			Required:     false,
-			DefaultValue: defaultExfilDomain,
-			Example:      "data.attacker.invalid",
+			Name:        "base_domain",
+			Description: "Base domain appended to each query (use .invalid TLD for offline safety)",
+			Type:        module.ParamString,
+			Default:     defaultExfilDomain,
+			Example:     "data.attacker.invalid",
 		},
 	}
 }
@@ -100,8 +100,8 @@ func exfilQueries(payload, baseDomain, runID string) []string {
 }
 
 func (n *netDNSExfil) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	payload := params.Get("payload", "macnoise-exfil-test")
-	baseDomain := params.Get("base_domain", defaultExfilDomain)
+	payload := params.String("payload", "macnoise-exfil-test")
+	baseDomain := params.String("base_domain", defaultExfilDomain)
 	info := n.Info()
 
 	queries := exfilQueries(payload, baseDomain, module.RunIDFromContext(ctx))
@@ -145,8 +145,8 @@ func (n *netDNSExfil) Generate(ctx context.Context, params module.Params, emit m
 }
 
 func (n *netDNSExfil) DryRun(params module.Params) []string {
-	payload := params.Get("payload", "macnoise-exfil-test")
-	baseDomain := params.Get("base_domain", defaultExfilDomain)
+	payload := params.String("payload", "macnoise-exfil-test")
+	baseDomain := params.String("base_domain", defaultExfilDomain)
 	queries := exfilQueries(payload, baseDomain, "")
 	steps := make([]string, len(queries))
 	for i, q := range queries {

--- a/modules/network/exfil.go
+++ b/modules/network/exfil.go
@@ -32,22 +32,19 @@ func (n *netExfil) Info() module.ModuleInfo {
 
 func (n *netExfil) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "target", Description: "Target URL for the POST request", Required: false, DefaultValue: "http://127.0.0.1:8080/upload", Example: "http://10.0.0.1/exfil"},
-		{Name: "payload_size", Description: "Payload size in bytes", Required: false, DefaultValue: "4096", Example: "1024"},
-		{Name: "content_type", Description: "Content-Type header value", Required: false, DefaultValue: "application/octet-stream", Example: "application/json"},
+		{Name: "target", Description: "Target URL for the POST request", Type: module.ParamString, Default: "http://127.0.0.1:8080/upload", Example: "http://10.0.0.1/exfil"},
+		{Name: "payload_size", Description: "Payload size in bytes", Type: module.ParamInteger, Default: 4096, Example: 1024, Range: &module.IntegerRange{Min: 0}},
+		{Name: "content_type", Description: "Content-Type header value", Type: module.ParamString, Default: "application/octet-stream", Example: "application/json"},
 	}
 }
 
 func (n *netExfil) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netExfil) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	target := tagURL(params.Get("target", "http://127.0.0.1:8080/upload"), module.RunIDFromContext(ctx))
-	payloadSizeStr := params.Get("payload_size", "4096")
-	contentType := params.Get("content_type", "application/octet-stream")
+	target := tagURL(params.String("target", "http://127.0.0.1:8080/upload"), module.RunIDFromContext(ctx))
+	payloadSize := params.Int("payload_size", 4096)
+	contentType := params.String("content_type", "application/octet-stream")
 	info := n.Info()
-
-	payloadSize := 4096
-	fmt.Sscanf(payloadSizeStr, "%d", &payloadSize) //nolint:errcheck
 
 	payload := make([]byte, payloadSize)
 	rand.Read(payload) //nolint:errcheck
@@ -92,11 +89,11 @@ func (n *netExfil) Generate(ctx context.Context, params module.Params, emit modu
 }
 
 func (n *netExfil) DryRun(params module.Params) []string {
-	target := params.Get("target", "http://127.0.0.1:8080/upload")
-	payloadSizeStr := params.Get("payload_size", "4096")
-	contentType := params.Get("content_type", "application/octet-stream")
+	target := params.String("target", "http://127.0.0.1:8080/upload")
+	payloadSize := params.Int("payload_size", 4096)
+	contentType := params.String("content_type", "application/octet-stream")
 	return []string{
-		fmt.Sprintf("HTTP POST %s bytes of %s to %s", payloadSizeStr, contentType, target),
+		fmt.Sprintf("HTTP POST %d bytes of %s to %s", payloadSize, contentType, target),
 	}
 }
 

--- a/modules/network/listen.go
+++ b/modules/network/listen.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/0xv1n/macnoise/internal/output"
@@ -32,16 +33,16 @@ func (n *netListen) Info() module.ModuleInfo {
 
 func (n *netListen) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "port", Description: "Local port to bind", Required: false, DefaultValue: "8080", Example: "9999"},
-		{Name: "bind_addr", Description: "Address to bind", Required: false, DefaultValue: "127.0.0.1", Example: "0.0.0.0"},
+		{Name: "port", Description: "Local port to bind", Type: module.ParamInteger, Default: 8080, Example: 9999, Range: &module.IntegerRange{Min: 1, Max: 65535}},
+		{Name: "bind_addr", Description: "Address to bind", Type: module.ParamString, Default: "127.0.0.1", Example: "0.0.0.0"},
 	}
 }
 
 func (n *netListen) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netListen) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	port := params.Get("port", "8080")
-	bindAddr := params.Get("bind_addr", "127.0.0.1")
+	port := strconv.Itoa(params.Int("port", 8080))
+	bindAddr := params.String("bind_addr", "127.0.0.1")
 	address := net.JoinHostPort(bindAddr, port)
 	info := n.Info()
 
@@ -102,8 +103,8 @@ func (n *netListen) Generate(ctx context.Context, params module.Params, emit mod
 }
 
 func (n *netListen) DryRun(params module.Params) []string {
-	port := params.Get("port", "8080")
-	bindAddr := params.Get("bind_addr", "127.0.0.1")
+	port := strconv.Itoa(params.Int("port", 8080))
+	bindAddr := params.String("bind_addr", "127.0.0.1")
 	return []string{
 		fmt.Sprintf("bind TCP %s:%s", bindAddr, port),
 		"accept one connection from self (127.0.0.1)",

--- a/modules/network/revshell.go
+++ b/modules/network/revshell.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"strconv"
 
 	"github.com/0xv1n/macnoise/internal/output"
 	"github.com/0xv1n/macnoise/pkg/module"
@@ -31,16 +32,16 @@ func (n *netRevShell) Info() module.ModuleInfo {
 
 func (n *netRevShell) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "target", Description: "Listener IP (must have nc/socat listening)", Required: false, DefaultValue: "127.0.0.1", Example: "10.0.0.1"},
-		{Name: "port", Description: "Listener port", Required: false, DefaultValue: "4444", Example: "4444"},
+		{Name: "target", Description: "Listener IP (must have nc/socat listening)", Type: module.ParamString, Default: "127.0.0.1", Example: "10.0.0.1"},
+		{Name: "port", Description: "Listener port", Type: module.ParamInteger, Default: 4444, Example: 4444, Range: &module.IntegerRange{Min: 1, Max: 65535}},
 	}
 }
 
 func (n *netRevShell) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (n *netRevShell) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	target := params.Get("target", "127.0.0.1")
-	port := params.Get("port", "4444")
+	target := params.String("target", "127.0.0.1")
+	port := strconv.Itoa(params.Int("port", 4444))
 	address := net.JoinHostPort(target, port)
 
 	info := n.Info()
@@ -87,8 +88,8 @@ func (n *netRevShell) Generate(ctx context.Context, params module.Params, emit m
 }
 
 func (n *netRevShell) DryRun(params module.Params) []string {
-	target := params.Get("target", "127.0.0.1")
-	port := params.Get("port", "4444")
+	target := params.String("target", "127.0.0.1")
+	port := strconv.Itoa(params.Int("port", 4444))
 	return []string{
 		fmt.Sprintf("dial TCP %s:%s", target, port),
 		"attach /bin/sh stdin/stdout/stderr to connection",

--- a/modules/network/tls.go
+++ b/modules/network/tls.go
@@ -33,18 +33,18 @@ func (n *netTLS) Info() module.ModuleInfo {
 func (n *netTLS) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "targets",
-			Description:  "Comma-separated host:port pairs to connect to",
-			Required:     false,
-			DefaultValue: "example.com:443,github.com:443",
-			Example:      "10.0.0.1:8443,c2.attacker.invalid:443",
+			Name:        "targets",
+			Description: "Host:port pairs to connect to",
+			Type:        module.ParamStringList,
+			Default:     []string{"example.com:443", "github.com:443"},
+			Example:     []string{"10.0.0.1:8443", "c2.attacker.invalid:443"},
 		},
 		{
-			Name:         "insecure",
-			Description:  "Skip certificate verification (true/false)",
-			Required:     false,
-			DefaultValue: "false",
-			Example:      "true",
+			Name:        "insecure",
+			Description: "Skip certificate verification (true/false)",
+			Type:        module.ParamBoolean,
+			Default:     false,
+			Example:     true,
 		},
 	}
 }
@@ -103,11 +103,11 @@ func tlsConnect(ctx context.Context, info module.ModuleInfo, target string, inse
 }
 
 func (n *netTLS) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	targetsStr := params.Get("targets", "example.com:443,github.com:443")
-	insecure := params.Get("insecure", "false") == "true"
+	targets := params.Strings("targets", []string{"example.com:443", "github.com:443"})
+	insecure := params.Bool("insecure", false)
 	info := n.Info()
 
-	for _, raw := range strings.Split(targetsStr, ",") {
+	for _, raw := range targets {
 		target := strings.TrimSpace(raw)
 		if target == "" {
 			continue
@@ -127,10 +127,10 @@ func (n *netTLS) Generate(ctx context.Context, params module.Params, emit module
 }
 
 func (n *netTLS) DryRun(params module.Params) []string {
-	targetsStr := params.Get("targets", "example.com:443,github.com:443")
-	insecure := params.Get("insecure", "false") == "true"
+	targets := params.Strings("targets", []string{"example.com:443", "github.com:443"})
+	insecure := params.Bool("insecure", false)
 	var steps []string
-	for _, raw := range strings.Split(targetsStr, ",") {
+	for _, raw := range targets {
 		target := strings.TrimSpace(raw)
 		if target == "" {
 			continue

--- a/modules/plist/create.go
+++ b/modules/plist/create.go
@@ -36,11 +36,11 @@ func (p *plistCreate) Info() module.ModuleInfo {
 
 func (p *plistCreate) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "output_path", Description: "Path for the created plist file", Required: false, DefaultValue: "/tmp/macnoise_test.plist", Example: "/tmp/test.plist"},
-		{Name: "bundle_id", Description: "Bundle ID value to embed in plist", Required: false, DefaultValue: "com.macnoise.test", Example: "com.example.app"},
-		{Name: "mode", Description: "Plist mode: 'bundle' (default) writes CFBundle keys; 'launchagent' writes LaunchAgent keys", Required: false, DefaultValue: "bundle", Example: "launchagent"},
-		{Name: "label", Description: "LaunchAgent Label key (used when mode=launchagent, defaults to bundle_id)", Required: false, DefaultValue: "", Example: "com.apple.coredata"},
-		{Name: "program", Description: "LaunchAgent ProgramArguments first element (used when mode=launchagent)", Required: false, DefaultValue: "/usr/bin/true", Example: "/Library/LaunchAgents/helper"},
+		{Name: "output_path", Description: "Path for the created plist file", Type: module.ParamPath, Default: "/tmp/macnoise_test.plist", Example: "/tmp/test.plist"},
+		{Name: "bundle_id", Description: "Bundle ID value to embed in plist", Type: module.ParamString, Default: "com.macnoise.test", Example: "com.example.app"},
+		{Name: "mode", Description: "Plist mode: 'bundle' (default) writes CFBundle keys; 'launchagent' writes LaunchAgent keys", Type: module.ParamString, Default: "bundle", Example: "launchagent", Choices: []string{"bundle", "launchagent"}},
+		{Name: "label", Description: "LaunchAgent Label key (used when mode=launchagent, defaults to bundle_id)", Type: module.ParamString, Example: "com.apple.coredata"},
+		{Name: "program", Description: "LaunchAgent ProgramArguments first element (used when mode=launchagent)", Type: module.ParamPath, Default: "/usr/bin/true", Example: "/Library/LaunchAgents/helper"},
 	}
 }
 
@@ -48,12 +48,12 @@ func (p *plistCreate) CheckPrereqs(ctx context.Context, params module.Params) er
 
 func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
-	outPath := module.TagPath(params.Get("output_path", "/tmp/macnoise_test.plist"), runID)
-	bundleID := params.Get("bundle_id", "com.macnoise.test")
+	outPath := module.TagPath(params.String("output_path", "/tmp/macnoise_test.plist"), runID)
+	bundleID := params.String("bundle_id", "com.macnoise.test")
 	if runID != "" {
 		bundleID += "." + runID
 	}
-	mode := params.Get("mode", "bundle")
+	mode := params.String("mode", "bundle")
 	info := p.Info()
 
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
@@ -64,8 +64,8 @@ func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit m
 	var evAction, evMsg string
 
 	if mode == "launchagent" {
-		label := params.Get("label", bundleID)
-		program := params.Get("program", "/usr/bin/true")
+		label := params.String("label", bundleID)
+		program := params.String("program", "/usr/bin/true")
 		plistData = map[string]any{
 			"Label":            label,
 			"ProgramArguments": []string{program},
@@ -104,8 +104,8 @@ func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit m
 	p.createdPath = outPath
 
 	if mode == "launchagent" {
-		label := params.Get("label", bundleID)
-		program := params.Get("program", "/usr/bin/true")
+		label := params.String("label", bundleID)
+		program := params.String("program", "/usr/bin/true")
 		ev.Success = true
 		ev.Message = fmt.Sprintf("created LaunchAgent plist at %s (label: %s, program: %s)", outPath, label, program)
 		ev = output.WithDetails(ev, map[string]any{"path": outPath, "label": label, "program": program, "run_at_load": true, "format": "xml"})
@@ -119,17 +119,17 @@ func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit m
 }
 
 func (p *plistCreate) DryRun(params module.Params) []string {
-	outPath := params.Get("output_path", "/tmp/macnoise_test.plist")
-	mode := params.Get("mode", "bundle")
+	outPath := params.String("output_path", "/tmp/macnoise_test.plist")
+	mode := params.String("mode", "bundle")
 	if mode == "launchagent" {
-		bundleID := params.Get("bundle_id", "com.macnoise.test")
-		label := params.Get("label", bundleID)
-		program := params.Get("program", "/usr/bin/true")
+		bundleID := params.String("bundle_id", "com.macnoise.test")
+		label := params.String("label", bundleID)
+		program := params.String("program", "/usr/bin/true")
 		return []string{
 			fmt.Sprintf("create LaunchAgent plist at %s with Label=%s ProgramArguments=[%s] RunAtLoad=true", outPath, label, program),
 		}
 	}
-	bundleID := params.Get("bundle_id", "com.macnoise.test")
+	bundleID := params.String("bundle_id", "com.macnoise.test")
 	return []string{
 		fmt.Sprintf("create XML plist at %s with CFBundleIdentifier=%s", outPath, bundleID),
 	}

--- a/modules/plist/modify.go
+++ b/modules/plist/modify.go
@@ -84,9 +84,9 @@ func (p *plistModify) Info() module.ModuleInfo {
 
 func (p *plistModify) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "domain", Description: "Defaults domain to write to", Required: false, DefaultValue: "com.macnoise.test", Example: "com.apple.finder"},
-		{Name: "key", Description: "Preference key to set", Required: false, DefaultValue: "MacnoiseTest", Example: "ShowHiddenFiles"},
-		{Name: "value", Description: "String value to set", Required: false, DefaultValue: "true", Example: "1"},
+		{Name: "domain", Description: "Defaults domain to write to", Type: module.ParamString, Default: "com.macnoise.test", Example: "com.apple.finder"},
+		{Name: "key", Description: "Preference key to set", Type: module.ParamString, Default: "MacnoiseTest", Example: "ShowHiddenFiles"},
+		{Name: "value", Description: "String value to set", Type: module.ParamString, Default: "true", Example: "1"},
 	}
 }
 
@@ -95,12 +95,12 @@ func (p *plistModify) CheckPrereqs(ctx context.Context, params module.Params) er
 }
 
 func (p *plistModify) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	domain := params.Get("domain", "com.macnoise.test")
+	domain := params.String("domain", "com.macnoise.test")
 	if runID := module.RunIDFromContext(ctx); runID != "" {
 		domain += "." + runID
 	}
-	key := params.Get("key", "MacnoiseTest")
-	value := params.Get("value", "true")
+	key := params.String("key", "MacnoiseTest")
+	value := params.String("value", "true")
 	info := p.Info()
 
 	readEv := output.NewEvent(info, "plist_read_prior", false, fmt.Sprintf("reading prior value of %s %s", domain, key))
@@ -141,9 +141,9 @@ func (p *plistModify) Generate(ctx context.Context, params module.Params, emit m
 }
 
 func (p *plistModify) DryRun(params module.Params) []string {
-	domain := params.Get("domain", "com.macnoise.test")
-	key := params.Get("key", "MacnoiseTest")
-	value := params.Get("value", "true")
+	domain := params.String("domain", "com.macnoise.test")
+	key := params.String("key", "MacnoiseTest")
+	value := params.String("value", "true")
 	return []string{
 		fmt.Sprintf("defaults read %s %s (capture prior value for cleanup)", domain, key),
 		fmt.Sprintf("defaults write %s %s -string %s", domain, key, value),

--- a/modules/process/discovery.go
+++ b/modules/process/discovery.go
@@ -72,11 +72,11 @@ func (p *procDiscovery) Info() module.ModuleInfo {
 func (p *procDiscovery) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "commands",
-			Description:  "Comma-separated list of discovery commands to run",
-			Required:     false,
-			DefaultValue: strings.Join(defaultDiscoveryCommands, ","),
-			Example:      "sw_vers,whoami",
+			Name:        "commands",
+			Description: "Discovery commands to run",
+			Type:        module.ParamStringList,
+			Default:     defaultDiscoveryCommands,
+			Example:     []string{"sw_vers", "whoami"},
 		},
 	}
 }
@@ -84,8 +84,7 @@ func (p *procDiscovery) ParamSpecs() []module.ParamSpec {
 func (p *procDiscovery) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (p *procDiscovery) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	commandsParam := params.Get("commands", strings.Join(defaultDiscoveryCommands, ","))
-	commands := strings.Split(commandsParam, ",")
+	commands := params.Strings("commands", defaultDiscoveryCommands)
 	info := p.Info()
 
 	for _, raw := range commands {
@@ -120,8 +119,7 @@ func (p *procDiscovery) Generate(ctx context.Context, params module.Params, emit
 }
 
 func (p *procDiscovery) DryRun(params module.Params) []string {
-	commandsParam := params.Get("commands", strings.Join(defaultDiscoveryCommands, ","))
-	commands := strings.Split(commandsParam, ",")
+	commands := params.Strings("commands", defaultDiscoveryCommands)
 	steps := make([]string, 0, len(commands))
 	for _, cmd := range commands {
 		cmd = strings.TrimSpace(cmd)

--- a/modules/process/gatekeeper.go
+++ b/modules/process/gatekeeper.go
@@ -34,11 +34,11 @@ func (p *procGatekeeper) Info() module.ModuleInfo {
 func (p *procGatekeeper) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "target_path",
-			Description:  "Path to the test file used for quarantine xattr operations",
-			Required:     false,
-			DefaultValue: "/tmp/macnoise_gatekeeper_test",
-			Example:      "/var/tmp/macnoise_gk",
+			Name:        "target_path",
+			Description: "Path to the test file used for quarantine xattr operations",
+			Type:        module.ParamPath,
+			Default:     "/tmp/macnoise_gatekeeper_test",
+			Example:     "/var/tmp/macnoise_gk",
 		},
 	}
 }
@@ -47,7 +47,7 @@ func (p *procGatekeeper) CheckPrereqs(ctx context.Context, params module.Params)
 
 func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
 	runID := module.RunIDFromContext(ctx)
-	targetPath := module.TagPath(params.Get("target_path", "/tmp/macnoise_gatekeeper_test"), runID)
+	targetPath := module.TagPath(params.String("target_path", "/tmp/macnoise_gatekeeper_test"), runID)
 	p.targetPath = targetPath
 	info := p.Info()
 
@@ -104,7 +104,7 @@ func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emi
 }
 
 func (p *procGatekeeper) DryRun(params module.Params) []string {
-	targetPath := params.Get("target_path", "/tmp/macnoise_gatekeeper_test")
+	targetPath := params.String("target_path", "/tmp/macnoise_gatekeeper_test")
 	return []string{
 		fmt.Sprintf("create test file at %s", targetPath),
 		fmt.Sprintf("xattr -w com.apple.quarantine 0081;00000000;macnoise; %s", targetPath),

--- a/modules/process/inject.go
+++ b/modules/process/inject.go
@@ -40,8 +40,8 @@ func (p *procInject) Info() module.ModuleInfo {
 
 func (p *procInject) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "dylib_path", Description: "Path to the dylib to insert; it need not exist, dyld's refusal to find it is itself the evidence", Required: false, DefaultValue: "/tmp/macnoise_inject.dylib", Example: "/tmp/evil.dylib"},
-		{Name: "target", Description: "Binary to spawn with the injection env (defaults to macnoise itself, which is injectable)", Required: false, DefaultValue: "", Example: "/tmp/my_unsigned_binary"},
+		{Name: "dylib_path", Description: "Path to the dylib to insert; it need not exist, dyld's refusal to find it is itself the evidence", Type: module.ParamPath, Default: "/tmp/macnoise_inject.dylib", Example: "/tmp/evil.dylib"},
+		{Name: "target", Description: "Binary to spawn with the injection env (defaults to macnoise itself, which is injectable)", Type: module.ParamPath, Example: "/tmp/my_unsigned_binary"},
 	}
 }
 
@@ -83,8 +83,8 @@ func classifyInjection(dylibExists bool, stderr string) injectOutcome {
 }
 
 func (p *procInject) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	dylibPath := module.TagPath(params.Get("dylib_path", "/tmp/macnoise_inject.dylib"), module.RunIDFromContext(ctx))
-	targetBin := params.Get("target", "")
+	dylibPath := module.TagPath(params.String("dylib_path", "/tmp/macnoise_inject.dylib"), module.RunIDFromContext(ctx))
+	targetBin := params.String("target", "")
 	if targetBin == "" {
 		var err error
 		if targetBin, err = defaultTarget(); err != nil {
@@ -133,8 +133,8 @@ func (p *procInject) Generate(ctx context.Context, params module.Params, emit mo
 }
 
 func (p *procInject) DryRun(params module.Params) []string {
-	dylib := params.Get("dylib_path", "/tmp/macnoise_inject.dylib")
-	target := params.Get("target", "")
+	dylib := params.String("dylib_path", "/tmp/macnoise_inject.dylib")
+	target := params.String("target", "")
 	if target == "" {
 		target, _ = defaultTarget()
 	}

--- a/modules/process/osascript.go
+++ b/modules/process/osascript.go
@@ -56,18 +56,19 @@ func (p *procOsascript) Info() module.ModuleInfo {
 func (p *procOsascript) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "script",
-			Description:  "AppleScript or JXA code to execute",
-			Required:     false,
-			DefaultValue: `display notification "macnoise telemetry" with title "MacNoise"`,
-			Example:      `do shell script "id"`,
+			Name:        "script",
+			Description: "AppleScript or JXA code to execute",
+			Type:        module.ParamString,
+			Default:     `display notification "macnoise telemetry" with title "MacNoise"`,
+			Example:     `do shell script "id"`,
 		},
 		{
-			Name:         "language",
-			Description:  "Script language: AppleScript or JavaScript",
-			Required:     false,
-			DefaultValue: "AppleScript",
-			Example:      "JavaScript",
+			Name:        "language",
+			Description: "Script language: AppleScript or JavaScript",
+			Type:        module.ParamString,
+			Default:     "AppleScript",
+			Example:     "JavaScript",
+			Choices:     []string{"AppleScript", "JavaScript"},
 		},
 	}
 }
@@ -96,8 +97,8 @@ func (p *procOsascript) Generate(ctx context.Context, params module.Params, emit
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	language := params.Get("language", "AppleScript")
-	script := stampScript(params.Get("script", `display notification "macnoise telemetry" with title "MacNoise"`), language, module.RunIDFromContext(ctx))
+	language := params.String("language", "AppleScript")
+	script := stampScript(params.String("script", `display notification "macnoise telemetry" with title "MacNoise"`), language, module.RunIDFromContext(ctx))
 	info := p.Info()
 
 	ev := output.NewEvent(info, "osascript_exec", false, fmt.Sprintf("executing %s via osascript", language))
@@ -120,8 +121,8 @@ func (p *procOsascript) Generate(ctx context.Context, params module.Params, emit
 }
 
 func (p *procOsascript) DryRun(params module.Params) []string {
-	script := params.Get("script", `display notification "macnoise telemetry" with title "MacNoise"`)
-	language := params.Get("language", "AppleScript")
+	script := params.String("script", `display notification "macnoise telemetry" with title "MacNoise"`)
+	language := params.String("language", "AppleScript")
 	return []string{fmt.Sprintf("osascript -l %s -e %q", language, script)}
 }
 

--- a/modules/process/signal.go
+++ b/modules/process/signal.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (p *procSignal) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	targetCmd := stampCommand(params.Get("target_command", "sleep 30"), module.RunIDFromContext(ctx))
+	targetCmd := stampCommand(params.String("target_command", "sleep 30"), module.RunIDFromContext(ctx))
 	info := p.Info()
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", targetCmd)

--- a/modules/process/signal_common.go
+++ b/modules/process/signal_common.go
@@ -28,7 +28,7 @@ func (p *procSignal) Info() module.ModuleInfo {
 
 func (p *procSignal) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "target_command", Description: "Command to spawn as signal target", Required: false, DefaultValue: "sleep 30", Example: "sleep 60"},
+		{Name: "target_command", Description: "Command to spawn as signal target", Type: module.ParamString, Default: "sleep 30", Example: "sleep 60"},
 	}
 }
 
@@ -40,7 +40,7 @@ func (p *procSignal) CheckPrereqs(ctx context.Context, params module.Params) err
 }
 
 func (p *procSignal) DryRun(params module.Params) []string {
-	targetCmd := params.Get("target_command", "sleep 30")
+	targetCmd := params.String("target_command", "sleep 30")
 	return []string{
 		fmt.Sprintf("fork: sh -c %q", targetCmd),
 		"send SIGSTOP, SIGCONT, SIGTERM to forked PID",

--- a/modules/process/spawn.go
+++ b/modules/process/spawn.go
@@ -32,7 +32,7 @@ func (p *procSpawn) Info() module.ModuleInfo {
 
 func (p *procSpawn) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "command", Description: "Shell command to execute via sh -c", Required: false, DefaultValue: "echo 'Telemetry Payload Executed'", Example: "id && whoami"},
+		{Name: "command", Description: "Shell command to execute via sh -c", Type: module.ParamString, Default: "echo 'Telemetry Payload Executed'", Example: "id && whoami"},
 	}
 }
 
@@ -49,7 +49,7 @@ func stampCommand(command, runID string) string {
 }
 
 func (p *procSpawn) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	command := stampCommand(params.Get("command", "echo 'Telemetry Payload Executed'"), module.RunIDFromContext(ctx))
+	command := stampCommand(params.String("command", "echo 'Telemetry Payload Executed'"), module.RunIDFromContext(ctx))
 	info := p.Info()
 
 	ev := output.NewEvent(info, "process_spawn", false, fmt.Sprintf("spawning: sh -c %q", command))
@@ -68,7 +68,7 @@ func (p *procSpawn) Generate(ctx context.Context, params module.Params, emit mod
 }
 
 func (p *procSpawn) DryRun(params module.Params) []string {
-	command := params.Get("command", "echo 'Telemetry Payload Executed'")
+	command := params.String("command", "echo 'Telemetry Payload Executed'")
 	return []string{fmt.Sprintf("exec: sh -c %q", command)}
 }
 

--- a/modules/service/cron.go
+++ b/modules/service/cron.go
@@ -32,8 +32,8 @@ func (s *svcCron) Info() module.ModuleInfo {
 
 func (s *svcCron) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "schedule", Description: "Cron schedule expression", Required: false, DefaultValue: "*/5 * * * *", Example: "@hourly"},
-		{Name: "command", Description: "Command for the cron job", Required: false, DefaultValue: "/usr/bin/true", Example: "/bin/sh -c 'echo test'"},
+		{Name: "schedule", Description: "Cron schedule expression", Type: module.ParamString, Default: "*/5 * * * *", Example: "@hourly"},
+		{Name: "command", Description: "Command for the cron job", Type: module.ParamString, Default: "/usr/bin/true", Example: "/bin/sh -c 'echo test'"},
 	}
 }
 
@@ -77,8 +77,8 @@ func cronMarker(runID string) string {
 }
 
 func (s *svcCron) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	schedule := params.Get("schedule", "*/5 * * * *")
-	command := params.Get("command", "/usr/bin/true")
+	schedule := params.String("schedule", "*/5 * * * *")
+	command := params.String("command", "/usr/bin/true")
 	info := s.Info()
 
 	marker := cronMarker(module.RunIDFromContext(ctx))
@@ -127,8 +127,8 @@ func (s *svcCron) Generate(ctx context.Context, params module.Params, emit modul
 }
 
 func (s *svcCron) DryRun(params module.Params) []string {
-	schedule := params.Get("schedule", "*/5 * * * *")
-	command := params.Get("command", "/usr/bin/true")
+	schedule := params.String("schedule", "*/5 * * * *")
+	command := params.String("command", "/usr/bin/true")
 	return []string{
 		"crontab -l",
 		fmt.Sprintf("crontab -: append \"%s %s # macnoise\"", schedule, command),

--- a/modules/service/launch_agent.go
+++ b/modules/service/launch_agent.go
@@ -39,8 +39,8 @@ func (s *svcLaunchAgent) Info() module.ModuleInfo {
 
 func (s *svcLaunchAgent) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "label", Description: "LaunchAgent label (bundle ID style)", Required: false, DefaultValue: "com.macnoise.testagent", Example: "com.corp.myagent"},
-		{Name: "program", Description: "Program path to run", Required: false, DefaultValue: "/usr/bin/true", Example: "/bin/sh"},
+		{Name: "label", Description: "LaunchAgent label (bundle ID style)", Type: module.ParamString, Default: "com.macnoise.testagent", Example: "com.corp.myagent"},
+		{Name: "program", Description: "Program path to run", Type: module.ParamPath, Default: "/usr/bin/true", Example: "/bin/sh"},
 	}
 }
 
@@ -59,8 +59,8 @@ func stampLabel(label, runID string) string {
 }
 
 func (s *svcLaunchAgent) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	label := stampLabel(params.Get("label", "com.macnoise.testagent"), module.RunIDFromContext(ctx))
-	program := params.Get("program", "/usr/bin/true")
+	label := stampLabel(params.String("label", "com.macnoise.testagent"), module.RunIDFromContext(ctx))
+	program := params.String("program", "/usr/bin/true")
 	info := s.Info()
 
 	home, err := os.UserHomeDir()
@@ -125,8 +125,8 @@ func (s *svcLaunchAgent) Generate(ctx context.Context, params module.Params, emi
 }
 
 func (s *svcLaunchAgent) DryRun(params module.Params) []string {
-	label := params.Get("label", "com.macnoise.testagent")
-	program := params.Get("program", "/usr/bin/true")
+	label := params.String("label", "com.macnoise.testagent")
+	program := params.String("program", "/usr/bin/true")
 	plistPath := fmt.Sprintf("~/Library/LaunchAgents/%s.plist", label)
 	return []string{
 		fmt.Sprintf("create %s with Program=%s", plistPath, program),

--- a/modules/service/launch_daemon.go
+++ b/modules/service/launch_daemon.go
@@ -37,8 +37,8 @@ func (s *svcLaunchDaemon) Info() module.ModuleInfo {
 
 func (s *svcLaunchDaemon) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "label", Description: "LaunchDaemon label", Required: false, DefaultValue: "com.macnoise.testdaemon", Example: "com.corp.mydaemon"},
-		{Name: "program", Description: "Program to run", Required: false, DefaultValue: "/usr/bin/true", Example: "/bin/sh"},
+		{Name: "label", Description: "LaunchDaemon label", Type: module.ParamString, Default: "com.macnoise.testdaemon", Example: "com.corp.mydaemon"},
+		{Name: "program", Description: "Program to run", Type: module.ParamPath, Default: "/usr/bin/true", Example: "/bin/sh"},
 	}
 }
 
@@ -47,8 +47,8 @@ func (s *svcLaunchDaemon) CheckPrereqs(ctx context.Context, params module.Params
 }
 
 func (s *svcLaunchDaemon) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	label := stampLabel(params.Get("label", "com.macnoise.testdaemon"), module.RunIDFromContext(ctx))
-	program := params.Get("program", "/usr/bin/true")
+	label := stampLabel(params.String("label", "com.macnoise.testdaemon"), module.RunIDFromContext(ctx))
+	program := params.String("program", "/usr/bin/true")
 	info := s.Info()
 
 	daemonDir := "/Library/LaunchDaemons"
@@ -104,8 +104,8 @@ func (s *svcLaunchDaemon) Generate(ctx context.Context, params module.Params, em
 }
 
 func (s *svcLaunchDaemon) DryRun(params module.Params) []string {
-	label := params.Get("label", "com.macnoise.testdaemon")
-	program := params.Get("program", "/usr/bin/true")
+	label := params.String("label", "com.macnoise.testdaemon")
+	program := params.String("program", "/usr/bin/true")
 	return []string{
 		fmt.Sprintf("create /Library/LaunchDaemons/%s.plist with Program=%s (requires root)", label, program),
 		launchctlCmdLine(bootstrapArgs(systemDomain, fmt.Sprintf("/Library/LaunchDaemons/%s.plist", label))),

--- a/modules/service/login_item.go
+++ b/modules/service/login_item.go
@@ -34,8 +34,8 @@ func (s *svcLoginItem) Info() module.ModuleInfo {
 
 func (s *svcLoginItem) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "name", Description: "Login item name", Required: false, DefaultValue: "MacNoiseLoginItem", Example: "com.corp.helper"},
-		{Name: "path", Description: "POSIX path the login item points at", Required: false, DefaultValue: "/usr/bin/true", Example: "/Applications/Evil.app"},
+		{Name: "name", Description: "Login item name", Type: module.ParamString, Default: "MacNoiseLoginItem", Example: "com.corp.helper"},
+		{Name: "path", Description: "POSIX path the login item points at", Type: module.ParamPath, Default: "/usr/bin/true", Example: "/Applications/Evil.app"},
 	}
 }
 
@@ -117,11 +117,11 @@ func parseLoginItemNames(out string) []string {
 }
 
 func (s *svcLoginItem) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	name := params.Get("name", "MacNoiseLoginItem")
+	name := params.String("name", "MacNoiseLoginItem")
 	if runID := module.RunIDFromContext(ctx); runID != "" {
 		name += "_" + runID
 	}
-	targetPath := params.Get("path", "/usr/bin/true")
+	targetPath := params.String("path", "/usr/bin/true")
 	info := s.Info()
 	s.name = name
 
@@ -174,8 +174,8 @@ func runOsascript(ctx context.Context, script string) (string, error) {
 }
 
 func (s *svcLoginItem) DryRun(params module.Params) []string {
-	name := params.Get("name", "MacNoiseLoginItem")
-	targetPath := params.Get("path", "/usr/bin/true")
+	name := params.String("name", "MacNoiseLoginItem")
+	targetPath := params.String("path", "/usr/bin/true")
 	return []string{
 		fmt.Sprintf("osascript -e '%s' -> ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD", makeLoginItemScript(name, targetPath)),
 		fmt.Sprintf("osascript -e '%s'", deleteLoginItemScript(name)),

--- a/modules/service/shell_profile.go
+++ b/modules/service/shell_profile.go
@@ -38,16 +38,16 @@ func (s *svcShellProfile) Info() module.ModuleInfo {
 
 func (s *svcShellProfile) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "target", Description: "Shell profile file to modify", Required: false, DefaultValue: "~/.zshrc", Example: "~/.bash_profile"},
-		{Name: "payload", Description: "Shell expression to inject between markers", Required: false, DefaultValue: "export MACNOISE_PERSIST=1", Example: "alias ls='ls -la'"},
+		{Name: "target", Description: "Shell profile file to modify", Type: module.ParamPath, Default: "~/.zshrc", Example: "~/.bash_profile"},
+		{Name: "payload", Description: "Shell expression to inject between markers", Type: module.ParamString, Default: "export MACNOISE_PERSIST=1", Example: "alias ls='ls -la'"},
 	}
 }
 
 func (s *svcShellProfile) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (s *svcShellProfile) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	target := params.Get("target", "~/.zshrc")
-	payload := params.Get("payload", "export MACNOISE_PERSIST=1")
+	target := params.String("target", "~/.zshrc")
+	payload := params.String("payload", "export MACNOISE_PERSIST=1")
 	info := s.Info()
 
 	if strings.HasPrefix(target, "~/") {
@@ -94,8 +94,8 @@ func (s *svcShellProfile) Generate(ctx context.Context, params module.Params, em
 }
 
 func (s *svcShellProfile) DryRun(params module.Params) []string {
-	target := params.Get("target", "~/.zshrc")
-	payload := params.Get("payload", "export MACNOISE_PERSIST=1")
+	target := params.String("target", "~/.zshrc")
+	payload := params.String("payload", "export MACNOISE_PERSIST=1")
 	return []string{
 		fmt.Sprintf("append %s/%s/%s block to %s", shellProfileMarkerStart, payload, shellProfileMarkerEnd, target),
 	}

--- a/modules/tcc/contacts.go
+++ b/modules/tcc/contacts.go
@@ -31,11 +31,10 @@ func (t *tccContacts) Info() module.ModuleInfo {
 func (t *tccContacts) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "addressbook_path",
-			Description:  "Path to AddressBook directory",
-			Required:     false,
-			DefaultValue: "",
-			Example:      "~/Library/Application Support/AddressBook",
+			Name:        "addressbook_path",
+			Description: "Path to AddressBook directory",
+			Type:        module.ParamPath,
+			Example:     "~/Library/Application Support/AddressBook",
 		},
 	}
 }
@@ -43,7 +42,7 @@ func (t *tccContacts) ParamSpecs() []module.ParamSpec {
 func (t *tccContacts) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (t *tccContacts) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	abPath := params.Get("addressbook_path", "")
+	abPath := params.String("addressbook_path", "")
 	if abPath == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/modules/tcc/fda.go
+++ b/modules/tcc/fda.go
@@ -35,11 +35,11 @@ func (t *tccFDA) Info() module.ModuleInfo {
 func (t *tccFDA) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "tcc_path",
-			Description:  "Path to the TCC-gated file to probe (defaults to the per-user TCC.db)",
-			Required:     false,
-			DefaultValue: "~/Library/Application Support/com.apple.TCC/TCC.db",
-			Example:      "/Library/Application Support/com.apple.TCC/TCC.db",
+			Name:        "tcc_path",
+			Description: "Path to the TCC-gated file to probe (defaults to the per-user TCC.db)",
+			Type:        module.ParamPath,
+			Default:     "",
+			Example:     "/Library/Application Support/com.apple.TCC/TCC.db",
 		},
 	}
 }
@@ -62,7 +62,7 @@ func defaultFDAPath() (string, error) {
 }
 
 func (t *tccFDA) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	tccPath := params.Get("tcc_path", "")
+	tccPath := params.String("tcc_path", "")
 	if tccPath == "" {
 		var err error
 		if tccPath, err = defaultFDAPath(); err != nil {
@@ -100,7 +100,7 @@ func (t *tccFDA) Generate(ctx context.Context, params module.Params, emit module
 }
 
 func (t *tccFDA) DryRun(params module.Params) []string {
-	path := params.Get("tcc_path", "")
+	path := params.String("tcc_path", "")
 	if path == "" {
 		path, _ = defaultFDAPath()
 	}

--- a/modules/tcc/keychain.go
+++ b/modules/tcc/keychain.go
@@ -32,18 +32,17 @@ func (t *tccKeychain) Info() module.ModuleInfo {
 func (t *tccKeychain) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
 		{
-			Name:         "keychain_path",
-			Description:  "Path to the target keychain file (default: ~/Library/Keychains/login.keychain-db)",
-			Required:     false,
-			DefaultValue: "",
-			Example:      "/Users/victim/Library/Keychains/login.keychain-db",
+			Name:        "keychain_path",
+			Description: "Path to the target keychain file (default: ~/Library/Keychains/login.keychain-db)",
+			Type:        module.ParamPath,
+			Example:     "/Users/victim/Library/Keychains/login.keychain-db",
 		},
 		{
-			Name:         "password",
-			Description:  "Password for unlock attempt (empty causes expected failure telemetry)",
-			Required:     false,
-			DefaultValue: "",
-			Example:      "hunter2",
+			Name:        "password",
+			Description: "Password for unlock attempt (empty causes expected failure telemetry)",
+			Type:        module.ParamString,
+			Default:     "",
+			Example:     "hunter2",
 		},
 	}
 }
@@ -51,8 +50,8 @@ func (t *tccKeychain) ParamSpecs() []module.ParamSpec {
 func (t *tccKeychain) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
 
 func (t *tccKeychain) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	keychainPath := params.Get("keychain_path", "")
-	password := params.Get("password", "")
+	keychainPath := params.String("keychain_path", "")
+	password := params.String("password", "")
 	info := t.Info()
 
 	if keychainPath == "" {
@@ -112,7 +111,7 @@ func (t *tccKeychain) Generate(ctx context.Context, params module.Params, emit m
 }
 
 func (t *tccKeychain) DryRun(params module.Params) []string {
-	keychainPath := params.Get("keychain_path", "~/Library/Keychains/login.keychain-db")
+	keychainPath := params.String("keychain_path", "~/Library/Keychains/login.keychain-db")
 	return []string{
 		"security list-keychains",
 		fmt.Sprintf("security unlock-keychain -p '' %s", keychainPath),

--- a/modules/xpc/enumerate.go
+++ b/modules/xpc/enumerate.go
@@ -35,8 +35,8 @@ func (x *xpcEnumerate) Info() module.ModuleInfo {
 
 func (x *xpcEnumerate) ParamSpecs() []module.ParamSpec {
 	return []module.ParamSpec{
-		{Name: "filter", Description: "Filter string for service name (empty = all)", Required: false, DefaultValue: "com.apple", Example: "com.apple.security"},
-		{Name: "max_results", Description: "Maximum services to enumerate", Required: false, DefaultValue: "10", Example: "20"},
+		{Name: "filter", Description: "Filter string for service name (empty = all)", Type: module.ParamString, Default: "com.apple", Example: "com.apple.security"},
+		{Name: "max_results", Description: "Maximum services to enumerate", Type: module.ParamInteger, Default: 10, Example: 20, Range: &module.IntegerRange{Min: 1}},
 	}
 }
 
@@ -115,10 +115,8 @@ func (x *xpcEnumerate) enumerateDomain(ctx context.Context, domain, filter strin
 }
 
 func (x *xpcEnumerate) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
-	filter := params.Get("filter", "com.apple")
-	maxStr := params.Get("max_results", "10")
-	max := 10
-	fmt.Sscanf(maxStr, "%d", &max) //nolint:errcheck
+	filter := params.String("filter", "com.apple")
+	max := params.Int("max_results", 10)
 
 	// Both domains are attempted unprivileged. `launchctl print system` was
 	// verified to succeed as a non-root user on macOS 26 (412 services read
@@ -136,7 +134,7 @@ func guiDomain() string {
 }
 
 func (x *xpcEnumerate) DryRun(params module.Params) []string {
-	filter := params.Get("filter", "com.apple")
+	filter := params.String("filter", "com.apple")
 	return []string{
 		fmt.Sprintf("launchctl print %s", guiDomain()),
 		"launchctl print system",

--- a/pkg/module/catalog.go
+++ b/pkg/module/catalog.go
@@ -30,11 +30,14 @@ type CatalogMITRE struct {
 
 // CatalogParam is one parameter in a CatalogEntry.
 type CatalogParam struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Required    bool   `json:"required"`
-	Default     string `json:"default,omitempty"`
-	Example     string `json:"example,omitempty"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Type        ParamType     `json:"type"`
+	Required    bool          `json:"required"`
+	Default     any           `json:"default,omitempty"`
+	Example     any           `json:"example,omitempty"`
+	Range       *IntegerRange `json:"range,omitempty"`
+	Choices     []string      `json:"choices,omitempty"`
 }
 
 // NewCatalogEntry builds the catalog view of a module from its Info and
@@ -54,13 +57,7 @@ func NewCatalogEntry(g Generator) CatalogEntry {
 	specs := g.ParamSpecs()
 	params := make([]CatalogParam, 0, len(specs))
 	for _, s := range specs {
-		params = append(params, CatalogParam{
-			Name:        s.Name,
-			Description: s.Description,
-			Required:    s.Required,
-			Default:     s.DefaultValue,
-			Example:     s.Example,
-		})
+		params = append(params, CatalogParam(s))
 	}
 
 	return CatalogEntry{

--- a/pkg/module/catalog_test.go
+++ b/pkg/module/catalog_test.go
@@ -23,7 +23,7 @@ func (catalogTestGen) Info() ModuleInfo {
 }
 func (catalogTestGen) ParamSpecs() []ParamSpec {
 	return []ParamSpec{
-		{Name: "target", Description: "the target", Required: true, DefaultValue: "1.2.3.4", Example: "10.0.0.1"},
+		{Name: "target", Description: "the target", Type: ParamString, Required: true, Default: "1.2.3.4", Example: "10.0.0.1"},
 	}
 }
 func (catalogTestGen) CheckPrereqs(ctx context.Context, params Params) error { return nil }
@@ -48,7 +48,7 @@ func TestNewCatalogEntry(t *testing.T) {
 	if e.MITRE[1].SubTechnique != "" {
 		t.Errorf("sub_technique should be empty for technique-only mapping, got %q", e.MITRE[1].SubTechnique)
 	}
-	if len(e.Params) != 1 || e.Params[0].Name != "target" || !e.Params[0].Required || e.Params[0].Default != "1.2.3.4" {
+	if len(e.Params) != 1 || e.Params[0].Name != "target" || e.Params[0].Type != ParamString || !e.Params[0].Required || e.Params[0].Default != "1.2.3.4" {
 		t.Errorf("params mapped wrong: %+v", e.Params)
 	}
 }

--- a/pkg/module/interface.go
+++ b/pkg/module/interface.go
@@ -45,23 +45,38 @@ type ModuleInfo struct { //nolint:revive // stutter is intentional: ModuleInfo i
 
 // ParamSpec describes a single named parameter accepted by a module.
 type ParamSpec struct {
-	Name         string
-	Description  string
-	Required     bool
-	DefaultValue string
-	Example      string
+	Name        string
+	Description string
+	Type        ParamType
+	Required    bool
+	Default     any
+	Example     any
+	Range       *IntegerRange
+	Choices     []string
 }
 
-// Params is the key-value map of runtime parameters passed to a module.
-type Params map[string]string
-
-// Get returns the value for key, or defaultVal if key is absent or empty.
-func (p Params) Get(key, defaultVal string) string {
-	if v, ok := p[key]; ok && v != "" {
-		return v
-	}
-	return defaultVal
+// IntegerRange defines inclusive bounds. A zero Max means no upper bound.
+type IntegerRange struct {
+	Min int `json:"min"`
+	Max int `json:"max,omitempty"`
 }
+
+// ParamType identifies the runtime type produced by parameter normalization.
+type ParamType string
+
+// Supported parameter types.
+const (
+	ParamString     ParamType = "string"
+	ParamInteger    ParamType = "integer"
+	ParamBoolean    ParamType = "boolean"
+	ParamPath       ParamType = "path"
+	ParamStringList ParamType = "string_list"
+	ParamPathList   ParamType = "path_list"
+)
+
+// Params holds raw or normalized runtime parameters. NormalizeParams converts
+// input values to the types declared by a module's ParamSpecs.
+type Params map[string]any
 
 // ProcessContext captures identifying information about the MacNoise process itself.
 type ProcessContext struct {

--- a/pkg/module/params.go
+++ b/pkg/module/params.go
@@ -1,0 +1,334 @@
+package module
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// NormalizeParams validates input against specs, applies defaults only to
+// omitted values, and returns values using the declared runtime types.
+func NormalizeParams(specs []ParamSpec, input Params) (Params, error) {
+	if err := ValidateParamSpecs(specs); err != nil {
+		return nil, err
+	}
+	byName := make(map[string]ParamSpec, len(specs))
+	for _, spec := range specs {
+		byName[spec.Name] = spec
+	}
+
+	unknown := make([]string, 0)
+	for name := range input {
+		if _, ok := byName[name]; !ok {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return nil, fmt.Errorf("unknown parameter %q", unknown[0])
+	}
+
+	normalized := make(Params, len(specs))
+	for _, spec := range specs {
+		value, provided := input[spec.Name]
+		if !provided {
+			if spec.Default == nil {
+				if spec.Required {
+					return nil, fmt.Errorf("required parameter %q is missing", spec.Name)
+				}
+				continue
+			}
+			value = spec.Default
+		}
+
+		value, err := normalizeParamValue(spec, value)
+		if err != nil {
+			return nil, err
+		}
+		if spec.Required && emptyParamValue(value) {
+			return nil, fmt.Errorf("required parameter %q is empty", spec.Name)
+		}
+		normalized[spec.Name] = value
+	}
+	return normalized, nil
+}
+
+// ValidateParamSpecs checks that parameter definitions are complete and that
+// their defaults match their declared types.
+func ValidateParamSpecs(specs []ParamSpec) error {
+	seen := make(map[string]struct{}, len(specs))
+	for _, spec := range specs {
+		if spec.Name == "" {
+			return fmt.Errorf("parameter spec has an empty name")
+		}
+		if _, exists := seen[spec.Name]; exists {
+			return fmt.Errorf("duplicate parameter spec %q", spec.Name)
+		}
+		seen[spec.Name] = struct{}{}
+		if !validParamType(spec.Type) {
+			return fmt.Errorf("parameter %q has invalid type %q", spec.Name, spec.Type)
+		}
+		if spec.Range != nil && spec.Type != ParamInteger {
+			return fmt.Errorf("parameter %q has integer bounds for type %q", spec.Name, spec.Type)
+		}
+		if spec.Range != nil && spec.Range.Max != 0 && spec.Range.Max < spec.Range.Min {
+			return fmt.Errorf("parameter %q has invalid integer bounds", spec.Name)
+		}
+		if len(spec.Choices) > 0 && spec.Type != ParamString && spec.Type != ParamStringList {
+			return fmt.Errorf("parameter %q has choices for type %q", spec.Name, spec.Type)
+		}
+		if spec.Default != nil {
+			if _, err := normalizeParamValue(spec, spec.Default); err != nil {
+				return fmt.Errorf("default: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func validParamType(paramType ParamType) bool {
+	switch paramType {
+	case ParamString, ParamInteger, ParamBoolean, ParamPath, ParamStringList, ParamPathList:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeParamValue(spec ParamSpec, value any) (any, error) {
+	switch spec.Type {
+	case ParamString, ParamPath:
+		value, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("parameter %q must be %s", spec.Name, articleFor(spec.Type))
+		}
+		if err := validateChoice(spec, value); err != nil {
+			return nil, err
+		}
+		return value, nil
+
+	case ParamInteger:
+		var parsed int
+		switch value := value.(type) {
+		case int:
+			parsed = value
+		case int8:
+			parsed = int(value)
+		case int16:
+			parsed = int(value)
+		case int32:
+			parsed = int(value)
+		case int64:
+			parsed = int(value)
+		case uint:
+			parsed = int(value)
+		case uint8:
+			parsed = int(value)
+		case uint16:
+			parsed = int(value)
+		case uint32:
+			parsed = int(value)
+		case string:
+			var err error
+			parsed, err = strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("parameter %q must be an integer", spec.Name)
+			}
+		default:
+			return nil, fmt.Errorf("parameter %q must be an integer", spec.Name)
+		}
+		if spec.Range != nil {
+			if parsed < spec.Range.Min {
+				return nil, fmt.Errorf("parameter %q must be at least %d", spec.Name, spec.Range.Min)
+			}
+			if spec.Range.Max != 0 && parsed > spec.Range.Max {
+				return nil, fmt.Errorf("parameter %q must be at most %d", spec.Name, spec.Range.Max)
+			}
+		}
+		return parsed, nil
+
+	case ParamBoolean:
+		switch value := value.(type) {
+		case bool:
+			return value, nil
+		case string:
+			switch strings.ToLower(value) {
+			case "true":
+				return true, nil
+			case "false":
+				return false, nil
+			}
+		}
+		return nil, fmt.Errorf("parameter %q must be a boolean", spec.Name)
+
+	case ParamStringList, ParamPathList:
+		itemType := "string"
+		if spec.Type == ParamPathList {
+			itemType = "path"
+		}
+		var values []string
+		if raw, ok := value.([]any); ok {
+			values = make([]string, 0, len(raw))
+			for i, item := range raw {
+				text, ok := item.(string)
+				if !ok || text == "" {
+					return nil, fmt.Errorf("parameter %q item %d must be a %s", spec.Name, i+1, itemType)
+				}
+				values = append(values, text)
+			}
+		} else {
+			var ok bool
+			values, ok = stringList(value)
+			if !ok {
+				return nil, fmt.Errorf("parameter %q must be a %s", spec.Name, spec.Type)
+			}
+		}
+		for i, value := range values {
+			if value == "" {
+				return nil, fmt.Errorf("parameter %q item %d must be a %s", spec.Name, i+1, itemType)
+			}
+			if err := validateChoice(spec, value); err != nil {
+				return nil, fmt.Errorf("parameter %q item %d must be one of %s", spec.Name, i+1, quotedChoices(spec.Choices))
+			}
+		}
+		return values, nil
+	}
+	return nil, fmt.Errorf("parameter %q has invalid type %q", spec.Name, spec.Type)
+}
+
+func validateChoice(spec ParamSpec, value string) error {
+	if len(spec.Choices) == 0 {
+		return nil
+	}
+	for _, choice := range spec.Choices {
+		if value == choice {
+			return nil
+		}
+	}
+	return fmt.Errorf("parameter %q must be one of %s", spec.Name, quotedChoices(spec.Choices))
+}
+
+func quotedChoices(choices []string) string {
+	quoted := make([]string, len(choices))
+	for i, choice := range choices {
+		quoted[i] = strconv.Quote(choice)
+	}
+	return strings.Join(quoted, ", ")
+}
+
+func articleFor(paramType ParamType) string {
+	if paramType == ParamPath {
+		return "a path"
+	}
+	return "a string"
+}
+
+func stringList(value any) ([]string, bool) {
+	switch value := value.(type) {
+	case []string:
+		return append([]string(nil), value...), true
+	case []any:
+		values := make([]string, 0, len(value))
+		for _, item := range value {
+			text, ok := item.(string)
+			if !ok {
+				return nil, false
+			}
+			values = append(values, text)
+		}
+		return values, true
+	case string:
+		if value == "" {
+			return []string{}, true
+		}
+		parts := strings.Split(value, ",")
+		values := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if part = strings.TrimSpace(part); part != "" {
+				values = append(values, part)
+			}
+		}
+		return values, true
+	default:
+		return nil, false
+	}
+}
+
+func emptyParamValue(value any) bool {
+	switch value := value.(type) {
+	case string:
+		return value == ""
+	case []string:
+		return len(value) == 0
+	default:
+		return false
+	}
+}
+
+// String returns a string parameter, or fallback when key is omitted.
+func (p Params) String(key, fallback string) string {
+	value, ok := p[key]
+	if !ok {
+		return fallback
+	}
+	text, ok := value.(string)
+	if !ok {
+		return fallback
+	}
+	return text
+}
+
+// Int returns an integer parameter, or fallback when key is omitted or invalid.
+func (p Params) Int(key string, fallback int) int {
+	value, ok := p[key]
+	if !ok {
+		return fallback
+	}
+	switch value := value.(type) {
+	case int:
+		return value
+	case string:
+		parsed, err := strconv.Atoi(value)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+// Bool returns a boolean parameter, or fallback when key is omitted or invalid.
+func (p Params) Bool(key string, fallback bool) bool {
+	value, ok := p[key]
+	if !ok {
+		return fallback
+	}
+	switch value := value.(type) {
+	case bool:
+		return value
+	case string:
+		parsed, err := strconv.ParseBool(value)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+// Strings returns a string-list parameter, or fallback when key is omitted.
+func (p Params) Strings(key string, fallback []string) []string {
+	value, ok := p[key]
+	if !ok {
+		return append([]string(nil), fallback...)
+	}
+	values, ok := stringList(value)
+	if !ok {
+		return append([]string(nil), fallback...)
+	}
+	return values
+}
+
+// Paths returns a path-list parameter, or fallback when key is omitted.
+func (p Params) Paths(key string, fallback []string) []string {
+	return p.Strings(key, fallback)
+}

--- a/pkg/module/params_test.go
+++ b/pkg/module/params_test.go
@@ -1,0 +1,90 @@
+package module
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeParamsAppliesTypedDefaults(t *testing.T) {
+	specs := []ParamSpec{
+		{Name: "name", Type: ParamString, Default: "example"},
+		{Name: "count", Type: ParamInteger, Default: 3, Range: &IntegerRange{Min: 1}},
+		{Name: "enabled", Type: ParamBoolean, Default: false},
+		{Name: "commands", Type: ParamStringList, Default: []string{"whoami", "uname -a"}},
+		{Name: "paths", Type: ParamPathList},
+		{Name: "mode", Type: ParamString, Choices: []string{"safe", "loud"}},
+	}
+
+	params, err := NormalizeParams(specs, Params{
+		"count":   "5",
+		"enabled": "true",
+		"commands": []any{
+			`printf "a,b"`,
+			"id",
+		},
+		"paths": []any{"/tmp/one", "/tmp/two"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := params.String("name", "wrong"); got != "example" {
+		t.Errorf("name = %q, want default", got)
+	}
+	if got := params.Int("count", 0); got != 5 {
+		t.Errorf("count = %d, want 5", got)
+	}
+	if got := params.Bool("enabled", false); !got {
+		t.Error("enabled = false, want true")
+	}
+	if got := params.Strings("commands", nil); !reflect.DeepEqual(got, []string{`printf "a,b"`, "id"}) {
+		t.Errorf("commands = %#v", got)
+	}
+	if got := params.Paths("paths", nil); !reflect.DeepEqual(got, []string{"/tmp/one", "/tmp/two"}) {
+		t.Errorf("paths = %#v", got)
+	}
+}
+
+func TestNormalizeParamsPreservesExplicitEmptyValue(t *testing.T) {
+	specs := []ParamSpec{{Name: "filter", Type: ParamString, Default: "com.apple"}}
+
+	params, err := NormalizeParams(specs, Params{"filter": ""})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := params.String("filter", "wrong"); got != "" {
+		t.Errorf("filter = %q, want explicit empty value", got)
+	}
+}
+
+func TestNormalizeParamsRejectsInvalidInputs(t *testing.T) {
+	specs := []ParamSpec{
+		{Name: "count", Type: ParamInteger, Range: &IntegerRange{Min: 0}},
+		{Name: "enabled", Type: ParamBoolean},
+		{Name: "paths", Type: ParamPathList},
+		{Name: "mode", Type: ParamString, Choices: []string{"safe", "loud"}},
+	}
+
+	tests := []struct {
+		name   string
+		input  Params
+		needle string
+	}{
+		{name: "unknown", input: Params{"other": "value"}, needle: `unknown parameter "other"`},
+		{name: "integer", input: Params{"count": "many"}, needle: `parameter "count" must be an integer`},
+		{name: "integer range", input: Params{"count": "-1"}, needle: `parameter "count" must be at least 0`},
+		{name: "boolean", input: Params{"enabled": "sometimes"}, needle: `parameter "enabled" must be a boolean`},
+		{name: "list element", input: Params{"paths": []any{"/tmp/ok", 7}}, needle: `parameter "paths" item 2 must be a path`},
+		{name: "choice", input: Params{"mode": "quiet"}, needle: `parameter "mode" must be one of "safe", "loud"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NormalizeParams(specs, tt.input)
+			if err == nil || !strings.Contains(err.Error(), tt.needle) {
+				t.Fatalf("NormalizeParams error = %v, want %q", err, tt.needle)
+			}
+		})
+	}
+}

--- a/pkg/module/registry.go
+++ b/pkg/module/registry.go
@@ -23,7 +23,11 @@ func Register(newGenerator Factory) { DefaultRegistry.Register(newGenerator) }
 
 // Register adds a constructor, panicking on duplicate or empty names.
 func (r *Registry) Register(newGenerator Factory) {
-	name := newGenerator().Info().Name
+	gen := newGenerator()
+	name := gen.Info().Name
+	if err := ValidateParamSpecs(gen.ParamSpecs()); err != nil {
+		panic(fmt.Sprintf("module: invalid parameters for %q: %v", name, err))
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if name == "" {


### PR DESCRIPTION
Module inputs now normalize through typed specs before preview or execution, rejecting unknown, malformed, and out-of-range values while preserving YAML and repeated CLI lists. This prevents invalid values such as negative payload sizes from reaching module code.

Validation: Go 1.26.8 tests, vet, lint, govulncheck, Darwin builds, and macOS integration tests with race detection.
