### PR TITLE
ci: build with Go 1.27

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true
       - name: Run unit tests
         run: make test
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true
       - name: Run integration tests
         run: go test -tags integration -race -count=1 ./...
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true
       - name: Build darwin/${{ matrix.goarch }}
         run: make build-${{ matrix.goarch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
-          install-mode: goinstall
+          version: v2.13.2
       - name: govulncheck
         run: GOTOOLCHAIN=auto go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
+          install-mode: goinstall
       - name: govulncheck
         run: GOTOOLCHAIN=auto go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version: '1.27'
           check-latest: true
       - name: Build darwin/amd64
         run: make build-amd64


### PR DESCRIPTION
CI and release builds now use Go 1.27, keeping lint, tests, macOS integration, and published binaries on the same current toolchain. golangci-lint moves to 2.13.2, the current stable release with Go 1.27 support.

Validation: Go 1.27.1 tests, vet, golangci-lint 2.13.2, govulncheck, Darwin amd64 and arm64 builds, and integration-tag compilation.