### PR TITLE
refactor: add typed scenario runtime

### DIFF
--- a/AI-GUIDANCE.md
+++ b/AI-GUIDANCE.md
@@ -133,6 +133,16 @@ type Generator interface {
 }
 ```
 
+Modules that produce values for later scenario steps also implement
+`module.OutputProvider`. Declare each value with `OutputSpecs()` and publish it
+from `Generate` with `module.PublishOutput(ctx, name, value)`. A scenario run
+provides its private directory through `module.WorkspaceFromContext(ctx)`.
+
+Scenario YAML is versioned with `version: 1`. Dataflow references are explicit
+mapping values (`input: name` or `output: step.output`); do not add template,
+environment, or glob expansion. The runner preflights the full local include
+graph before mutation and owns reverse cleanup and workspace lifetime.
+
 **Registration** — every module file has an `init()` function:
 ```go
 func init() {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,12 @@ fmt.Println("something happened")
 
 Every event requires exactly one typed subject. Use `module.File`, `module.Process`, `module.Network`, `module.Service`, or `module.Resource`. Mark secret-bearing parameter specs with `Sensitive: true` so managed audit output redacts their values.
 
+If later scenario steps need a value produced by the module, implement
+`module.OutputProvider`, declare it in `OutputSpecs()`, and call
+`module.PublishOutput(ctx, name, value)` from `Generate`. Mark secret-bearing
+outputs sensitive as well. Use `module.WorkspaceFromContext(ctx)` for temporary
+scenario artifacts that must remain available until reverse cleanup.
+
 ## Audit Logging (OCSF)
 
 MacNoise writes a second output stream alongside telemetry events: structured audit records in [OCSF 1.7.0](https://schema.ocsf.io/) JSONL format via `internal/audit/`. These records capture what MacNoise itself did - which modules ran, prereq and cleanup outcomes, timing, and MITRE mappings - rather than the telemetry events that modules produce for EDR consumption.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ macnoise run --category <cat>                 Run all modules in a category
 macnoise run --all                            Run all modules
 macnoise list [--category <cat>]              List modules
 macnoise info <module>                        Show module details, params, MITRE
-macnoise scenario <file.yaml>                 Run a YAML scenario
+macnoise scenario <file.yaml> [--input key=val] [--report report.json]
+                                                Run a YAML scenario
 macnoise categories                           List categories with counts
 macnoise version                              Print version
 ```
@@ -77,6 +78,45 @@ macnoise version                              Print version
 | `--timeout` | `30` | Per-module timeout in seconds |
 | `--audit-log` | (none) | Write OCSF 1.7.0 audit records to a JSONL file |
 | `--config` | (none) | Load defaults from a YAML config file |
+
+### Scenario dataflow
+
+Scenario files use `version: 1`. Inputs and module outputs are typed, and a
+later step references them with explicit mappings rather than string
+interpolation:
+
+```yaml
+version: 1
+name: Archive one generated artifact
+on_error: stop
+inputs:
+  content:
+    type: string
+    required: true
+steps:
+  # Custom modules declare these outputs through OutputSpecs.
+  - id: create
+    module: custom_create
+    params:
+      content:
+        input: content
+  - id: archive
+    module: custom_archive
+    params:
+      source:
+        output: create.path
+outputs:
+  archive:
+    output: archive.path
+```
+
+Only outputs declared by a module can be referenced. Local scenarios can be
+reused with an `include` step; includes are relative, cannot traverse above
+the root scenario directory, are cycle-checked, and are limited to eight levels.
+MacNoise validates the complete graph before execution, gives the run one
+private workspace, and cleans invoked modules in reverse order. Use
+`--input content=value` to supply inputs and `--report report.json` for the
+versioned execution report.
 
 ## Leaving Artifacts In Place
 

--- a/cmd/macnoise/docs_test.go
+++ b/cmd/macnoise/docs_test.go
@@ -71,36 +71,8 @@ func TestStockScenariosHaveValidInputs(t *testing.T) {
 			continue
 		}
 		path := filepath.Join(dir, e.Name())
-		scenario, err := runner.LoadScenario(path)
-		if err != nil {
+		if err := runner.ValidateScenario(path, nil, &module.DefaultRegistry); err != nil {
 			t.Errorf("%s: %v", e.Name(), err)
-			continue
-		}
-		for i, step := range scenario.Steps {
-			var generators []module.Generator
-			switch {
-			case step.Module != "":
-				gen, found := module.Get(step.Module)
-				if !found {
-					t.Errorf("%s step %d references unregistered module %q", e.Name(), i+1, step.Module)
-					continue
-				}
-				generators = []module.Generator{gen}
-			case step.Category != "":
-				generators = module.ByCategory(module.Category(step.Category))
-				if len(generators) == 0 {
-					t.Errorf("%s step %d references empty category %q", e.Name(), i+1, step.Category)
-					continue
-				}
-			default:
-				t.Errorf("%s step %d has neither module nor category", e.Name(), i+1)
-				continue
-			}
-			for _, gen := range generators {
-				if _, err := module.NormalizeParams(gen.ParamSpecs(), step.Params); err != nil {
-					t.Errorf("%s step %d (%s): %v", e.Name(), i+1, gen.Info().Name, err)
-				}
-			}
 		}
 	}
 }

--- a/cmd/macnoise/main.go
+++ b/cmd/macnoise/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -366,17 +367,34 @@ func buildInfo() *cobra.Command {
 					}
 				}
 			}
+			if provider, ok := gen.(module.OutputProvider); ok && len(provider.OutputSpecs()) > 0 {
+				fmt.Println("\nOutputs:")
+				for _, spec := range provider.OutputSpecs() {
+					fmt.Printf("  %-20s %s\n", spec.Name+" ("+string(spec.Type)+")", spec.Description)
+				}
+			}
 			return nil
 		},
 	}
 }
 
 func buildScenario() *cobra.Command {
-	return &cobra.Command{
+	var (
+		inputFlags []string
+		reportPath string
+	)
+	cmd := &cobra.Command{
 		Use:   "scenario <file.yaml>",
 		Short: "Run a YAML scenario file",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			inputs, err := parseParams(inputFlags)
+			if err != nil {
+				return fmt.Errorf("scenario input: %w", err)
+			}
+			if err := runner.ValidateScenario(args[0], inputs, nil); err != nil {
+				return err
+			}
 			em, closeEM, err := buildEmitter()
 			if err != nil {
 				return err
@@ -398,12 +416,28 @@ func buildScenario() *cobra.Command {
 			fmt.Fprintf(os.Stderr, "run_id=%s\n", runID)
 
 			opts := buildRunOpts(auditLogger, runID)
+			opts.ScenarioInputs = inputs
 			ctx, stop := signalContext()
 			defer stop()
 
-			return runner.RunScenario(ctx, args[0], em.EmitFunc(), opts)
+			report, runErr := runner.RunScenario(ctx, args[0], em.EmitFunc(), opts)
+			if reportPath != "" {
+				data, err := json.MarshalIndent(report, "", "  ")
+				if err == nil {
+					data = append(data, '\n')
+					err = os.WriteFile(reportPath, data, 0o600)
+				}
+				if err != nil {
+					runErr = errors.Join(runErr, fmt.Errorf("write scenario report: %w", err))
+				}
+			}
+			fmt.Fprintf(os.Stderr, "scenario_status=%s\n", report.Status)
+			return runErr
 		},
 	}
+	cmd.Flags().StringArrayVar(&inputFlags, "input", nil, "Scenario input as key=value (repeatable)")
+	cmd.Flags().StringVar(&reportPath, "report", "", "Write the scenario execution report as JSON")
+	return cmd
 }
 
 func buildCategories() *cobra.Command {

--- a/cmd/macnoise/scenario_test.go
+++ b/cmd/macnoise/scenario_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScenarioPreflightDoesNotCreateOutputFiles(t *testing.T) {
+	dir := t.TempDir()
+	scenarioPath := filepath.Join(dir, "invalid.yaml")
+	if err := os.WriteFile(scenarioPath, []byte("version: 1\nname: invalid\nsteps:\n  - module: missing_module\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(dir, "events.jsonl")
+	auditPath := filepath.Join(dir, "audit.jsonl")
+	reportPath := filepath.Join(dir, "report.json")
+	globalOutput = outputPath
+	globalAuditLog = auditPath
+	t.Cleanup(func() {
+		globalOutput = ""
+		globalAuditLog = ""
+	})
+
+	cmd := buildScenario()
+	if err := cmd.Flags().Set("report", reportPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.RunE(cmd, []string{scenarioPath}); err == nil {
+		t.Fatal("invalid scenario passed preflight")
+	}
+	for _, path := range []string{outputPath, auditPath, reportPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("preflight failure created %s", path)
+		}
+	}
+}

--- a/configs/scenarios/amos_atomic_stealer.yaml
+++ b/configs/scenarios/amos_atomic_stealer.yaml
@@ -1,3 +1,5 @@
+version: 1
+on_error: stop
 name: AMOS / Atomic macOS Stealer — Comprehensive Emulation
 description: |
   Full kill-chain emulation of Atomic macOS Stealer (AMOS), a crimeware-as-a-service

--- a/configs/scenarios/clickfix.yaml
+++ b/configs/scenarios/clickfix.yaml
@@ -1,3 +1,5 @@
+version: 1
+on_error: stop
 name: ClickFix / Malicious Copy-Paste Delivery
 description: |
   Emulates the ClickFix delivery pattern (T1204.004 User Execution: Malicious

--- a/configs/scenarios/edr_validation.yaml
+++ b/configs/scenarios/edr_validation.yaml
@@ -1,3 +1,5 @@
+version: 1
+on_error: stop
 name: EDR Validation Suite
 description: Modules most relevant to EDR detection validation — covers process, network, file, persistence, and TCC telemetry
 

--- a/configs/scenarios/full_sweep.yaml
+++ b/configs/scenarios/full_sweep.yaml
@@ -1,3 +1,5 @@
+version: 1
+on_error: stop
 name: Full Telemetry Sweep
 description: Runs all modules across every category (excludes root-only modules)
 

--- a/configs/scenarios/lazarus_group.yaml
+++ b/configs/scenarios/lazarus_group.yaml
@@ -1,3 +1,5 @@
+version: 1
+on_error: stop
 name: Lazarus Group Emulation
 description: |
   Emulates a representative Lazarus Group (G0032) intrusion sequence on macOS.

--- a/configs/scenarios/network_only.yaml
+++ b/configs/scenarios/network_only.yaml
@@ -1,3 +1,5 @@
+version: 1
+on_error: stop
 name: Network Telemetry Sweep
 description: Runs selected network modules to generate connection, listener, DNS, and beacon telemetry
 

--- a/configs/scenarios/ransomware.yaml
+++ b/configs/scenarios/ransomware.yaml
@@ -1,3 +1,5 @@
+version: 1
+on_error: stop
 name: Ransomware Impact Simulation
 description: |
   Stages plaintext decoy files with randomized common extensions, encrypts them

--- a/internal/runner/outputs.go
+++ b/internal/runner/outputs.go
@@ -1,0 +1,82 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+type outputCollector struct {
+	mu     sync.Mutex
+	specs  map[string]module.OutputSpec
+	items  module.Params
+	errors []error
+}
+
+func newOutputCollector(gen module.Generator) *outputCollector {
+	specs := make(map[string]module.OutputSpec)
+	if provider, ok := gen.(module.OutputProvider); ok {
+		for _, spec := range provider.OutputSpecs() {
+			specs[spec.Name] = spec
+		}
+	}
+	return &outputCollector{specs: specs, items: make(module.Params)}
+}
+
+func (c *outputCollector) publish(name string, value any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	spec, ok := c.specs[name]
+	if !ok {
+		err := fmt.Errorf("undeclared module output %q", name)
+		c.errors = append(c.errors, err)
+		return err
+	}
+	if _, duplicate := c.items[name]; duplicate {
+		err := fmt.Errorf("module output %q was published more than once", name)
+		c.errors = append(c.errors, err)
+		return err
+	}
+	normalized, err := module.NormalizeOutput(spec, value)
+	if err != nil {
+		c.errors = append(c.errors, err)
+		return err
+	}
+	c.items[name] = normalized
+	return nil
+}
+
+func (c *outputCollector) err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return errors.Join(c.errors...)
+}
+
+func (c *outputCollector) requireAll() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	missing := make([]string, 0)
+	for name := range c.specs {
+		if _, ok := c.items[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	return fmt.Errorf("module did not publish declared output %q", missing[0])
+}
+
+func (c *outputCollector) values() module.Params {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	values := make(module.Params, len(c.items))
+	for name, value := range c.items {
+		values[name] = value
+	}
+	return values
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -33,6 +33,14 @@ type Options struct {
 	// retrieve it via module.RunIDFromContext so they can fold it into
 	// artifact names, DNS labels, and command arguments.
 	RunID string
+	// ScenarioInputs supplies typed values declared by a scenario. It is
+	// ignored by RunSingle and RunMany.
+	ScenarioInputs module.Params
+
+	workspace        string
+	deferCleanup     func(func() error)
+	cleanupResult    func(string, string)
+	invocationOutput *module.Params
 }
 
 // RunSingle executes one module through its full lifecycle (prereqs → generate → cleanup).
@@ -52,6 +60,9 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 	}
 
 	runCtx := module.ContextWithRunID(ctx, opts.RunID)
+	if opts.workspace != "" {
+		runCtx = module.ContextWithWorkspace(runCtx, opts.workspace)
+	}
 	if opts.Timeout > 0 {
 		var cancel context.CancelFunc
 		runCtx, cancel = context.WithTimeout(runCtx, opts.Timeout)
@@ -76,7 +87,7 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 
 	if opts.DryRun {
 		for _, action := range gen.DryRun(params) {
-			fmt.Printf("[dry-run] [%s] %s\n", info.Name, action)
+			fmt.Fprintf(os.Stderr, "[dry-run] [%s] %s\n", info.Name, action)
 		}
 		if opts.AuditLog != nil {
 			lifecycle.EndTime = time.Now()
@@ -107,42 +118,64 @@ func RunSingle(ctx context.Context, gen module.Generator, params module.Params, 
 		return err
 	}
 
+	collector := newOutputCollector(gen)
+	runCtx = module.ContextWithOutputSink(runCtx, collector.publish)
+
 	var generateErr error
 	defer func() {
-		cleanupResult := "ok"
-		cleanupErrStr := ""
-		switch {
-		case opts.NoCleanup:
-			// Always announced, not gated behind --verbose: leaving real
-			// persistence installed is the kind of thing an operator must not
-			// discover later by accident.
-			cleanupResult = "skipped"
-			fmt.Printf("[%s] cleanup skipped (--no-cleanup); artifacts left in place, see 'macnoise info %s'\n", info.Name, info.Name)
-		default:
-			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(runCtx), 10*time.Second)
-			defer cancel()
-			if err := gen.Cleanup(cleanupCtx); err != nil {
-				cleanupResult = "error"
-				cleanupErrStr = err.Error()
-				resultErr = errors.Join(resultErr, fmt.Errorf("[%s] cleanup: %w", info.Name, err))
-				fmt.Fprintf(os.Stderr, "[%s] cleanup error: %v\n", info.Name, err)
+		finish := func() error {
+			cleanupResult := "ok"
+			cleanupErrStr := ""
+			var finishErr error
+			switch {
+			case opts.NoCleanup:
+				// Always announced, not gated behind --verbose: leaving real
+				// persistence installed is the kind of thing an operator must not
+				// discover later by accident.
+				cleanupResult = "skipped"
+				fmt.Fprintf(os.Stderr, "[%s] cleanup skipped (--no-cleanup); artifacts left in place, see 'macnoise info %s'\n", info.Name, info.Name)
+			default:
+				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(runCtx), 10*time.Second)
+				defer cancel()
+				if err := gen.Cleanup(cleanupCtx); err != nil {
+					cleanupResult = "error"
+					cleanupErrStr = err.Error()
+					finishErr = fmt.Errorf("[%s] cleanup: %w", info.Name, err)
+					fmt.Fprintf(os.Stderr, "[%s] cleanup error: %v\n", info.Name, err)
+				}
 			}
+			if opts.cleanupResult != nil {
+				opts.cleanupResult(cleanupResult, cleanupErrStr)
+			}
+			if opts.AuditLog != nil {
+				lifecycle.EndTime = time.Now()
+				lifecycle.EventsEmitted = eventsEmitted
+				lifecycle.CleanupResult = cleanupResult
+				lifecycle.CleanupError = cleanupErrStr
+				if generateErr != nil {
+					lifecycle.GenerateError = generateErr.Error()
+				}
+				finishErr = errors.Join(finishErr, opts.AuditLog.LogLifecycle("module_run", info, auditParams, lifecycle))
+			}
+			return finishErr
 		}
-		if opts.AuditLog != nil {
-			lifecycle.EndTime = time.Now()
-			lifecycle.EventsEmitted = eventsEmitted
-			lifecycle.CleanupResult = cleanupResult
-			lifecycle.CleanupError = cleanupErrStr
-			if generateErr != nil {
-				lifecycle.GenerateError = generateErr.Error()
-			}
-			if err := opts.AuditLog.LogLifecycle("module_run", info, auditParams, lifecycle); err != nil {
-				resultErr = errors.Join(resultErr, err)
-			}
+		if opts.deferCleanup != nil {
+			opts.deferCleanup(finish)
+			return
 		}
+		resultErr = errors.Join(resultErr, finish())
 	}()
 
 	generateErr = gen.Generate(runCtx, params, normalizedEmit)
+	if outputErr := collector.err(); outputErr != nil && !errors.Is(generateErr, outputErr) {
+		generateErr = errors.Join(generateErr, outputErr)
+	}
+	if generateErr == nil {
+		generateErr = collector.requireAll()
+	}
+	if opts.invocationOutput != nil {
+		*opts.invocationOutput = collector.values()
+	}
 	emitMu.Lock()
 	if emitErr != nil && !errors.Is(generateErr, emitErr) {
 		generateErr = errors.Join(generateErr, emitErr)
@@ -169,120 +202,6 @@ func RunMany(ctx context.Context, gens []module.Generator, params module.Params,
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%d module(s) failed: %v", len(errs), errs)
-	}
-	return nil
-}
-
-// RunScenario loads the YAML scenario at path and executes its steps in order.
-func RunScenario(ctx context.Context, path string, emit module.EventEmitter, opts Options) error {
-	registry := opts.Registry
-	if registry == nil {
-		registry = &module.DefaultRegistry
-	}
-	sc, err := LoadScenario(path)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Running scenario: %s\n", sc.Name)
-	if sc.Description != "" {
-		fmt.Printf("  %s\n", sc.Description)
-	}
-
-	scenarioStart := time.Now()
-	stepsPassed := 0
-	stepsFailed := 0
-
-	var interruptErr error
-
-stepLoop:
-	for i, step := range sc.Steps {
-		// Stop on cancellation rather than fast-failing every remaining step.
-		// An interrupted scenario should end at the step it reached, and still
-		// record a scenario audit entry describing how far it got.
-		select {
-		case <-ctx.Done():
-			interruptErr = fmt.Errorf("scenario %q: interrupted after %d of %d step(s): %w",
-				sc.Name, i, len(sc.Steps), ctx.Err())
-			break stepLoop
-		default:
-		}
-
-		params := step.Params
-		if params == nil {
-			params = module.Params{}
-		}
-
-		var stepErr error
-		switch {
-		case step.Module != "":
-			gen, ok := registry.Get(step.Module)
-			if !ok {
-				stepErr = fmt.Errorf("scenario step %d: module %q not found", i+1, step.Module)
-			} else {
-				stepErr = RunSingle(ctx, gen, params, emit, opts)
-			}
-
-		case step.Category != "":
-			cat := module.Category(step.Category)
-			gens := registry.ByCategory(cat)
-			if len(gens) == 0 {
-				stepErr = fmt.Errorf("scenario step %d: no modules found for category %q", i+1, step.Category)
-			} else if sc.OnError == "continue" {
-				stepErr = RunMany(ctx, gens, params, emit, opts)
-			} else {
-				for _, gen := range gens {
-					if stepErr = RunSingle(ctx, gen, params, emit, opts); stepErr != nil {
-						break
-					}
-				}
-			}
-
-		default:
-			stepErr = fmt.Errorf("scenario step %d: must specify either 'module' or 'category'", i+1)
-		}
-
-		if err := ctx.Err(); err != nil {
-			interruptErr = fmt.Errorf("scenario %q: interrupted during step %d of %d: %w",
-				sc.Name, i+1, len(sc.Steps), err)
-			break stepLoop
-		}
-
-		if stepErr != nil {
-			stepsFailed++
-			fmt.Fprintf(os.Stderr, "step %d error: %v\n", i+1, stepErr)
-			if sc.OnError != "continue" {
-				break stepLoop
-			}
-		} else {
-			stepsPassed++
-		}
-	}
-
-	if opts.AuditLog != nil {
-		ld := audit.LifecycleData{
-			StartTime:   scenarioStart,
-			EndTime:     time.Now(),
-			StepsPassed: stepsPassed,
-			StepsFailed: stepsFailed,
-			TotalSteps:  len(sc.Steps),
-		}
-		switch {
-		case interruptErr != nil:
-			ld.GenerateError = interruptErr.Error()
-		case stepsFailed > 0:
-			ld.GenerateError = fmt.Sprintf("%d step(s) failed", stepsFailed)
-		}
-		if err := opts.AuditLog.LogScenario(sc.Name, path, ld); err != nil {
-			interruptErr = errors.Join(interruptErr, err)
-		}
-	}
-
-	if interruptErr != nil {
-		return interruptErr
-	}
-	if stepsFailed > 0 {
-		return fmt.Errorf("scenario %q: %d of %d step(s) failed", sc.Name, stepsFailed, len(sc.Steps))
 	}
 	return nil
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -238,7 +238,7 @@ func TestRunScenarioAuditDoesNotChangeFailurePolicy(t *testing.T) {
 			}
 			path := writeScenario(t, name, 2, "")
 			calls := 0
-			err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) error {
+			_, err := runner.RunScenario(context.Background(), path, func(module.TelemetryEvent) error {
 				calls++
 				return nil
 			}, runner.Options{
@@ -376,7 +376,7 @@ func (c *countingGen) Cleanup(ctx context.Context) error { return nil }
 func writeScenario(t *testing.T, moduleName string, stepCount int, onError string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "scenario.yaml")
-	body := "name: cancel test\n"
+	body := "version: 1\nname: cancel test\n"
 	if onError != "" {
 		body += "on_error: " + onError + "\n"
 	}
@@ -413,7 +413,7 @@ func TestRunScenarioStopsOnCancel(t *testing.T) {
 			})
 
 			path := writeScenario(t, name, 4, tc.onError)
-			err := runner.RunScenario(ctx, path, discardEvent, runner.Options{Registry: &registry})
+			_, err := runner.RunScenario(ctx, path, discardEvent, runner.Options{Registry: &registry})
 			if !errors.Is(err, context.Canceled) {
 				t.Errorf("expected context.Canceled, got %v", err)
 			}
@@ -443,7 +443,7 @@ func TestRunScenarioAuditsInterrupt(t *testing.T) {
 	}
 
 	path := writeScenario(t, name, 5, "")
-	runErr := runner.RunScenario(ctx, path, discardEvent, runner.Options{
+	_, runErr := runner.RunScenario(ctx, path, discardEvent, runner.Options{
 		Registry: &registry,
 		AuditLog: logger,
 	})
@@ -556,7 +556,7 @@ func TestRunScenarioCategoryHonorsOnErrorPerInvocation(t *testing.T) {
 			})
 
 			path := filepath.Join(t.TempDir(), "scenario.yaml")
-			body := "name: category policy\n"
+			body := "version: 1\nname: category policy\n"
 			if tt.onError != "" {
 				body += "on_error: " + tt.onError + "\n"
 			}
@@ -565,7 +565,7 @@ func TestRunScenarioCategoryHonorsOnErrorPerInvocation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: &registry})
+			_, err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: &registry})
 			if err == nil {
 				t.Fatal("expected scenario failure")
 			}
@@ -578,7 +578,7 @@ func TestRunScenarioCategoryHonorsOnErrorPerInvocation(t *testing.T) {
 
 func TestLoadScenarioRejectsInvalidOnError(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "scenario.yaml")
-	if err := os.WriteFile(path, []byte("name: invalid\non_error: retry\nsteps:\n  - module: example\n"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte("version: 1\nname: invalid\non_error: retry\nsteps:\n  - module: example\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := runner.LoadScenario(path); err == nil || !strings.Contains(err.Error(), "invalid on_error") {
@@ -588,7 +588,7 @@ func TestLoadScenarioRejectsInvalidOnError(t *testing.T) {
 
 func TestLoadScenarioRejectsUnknownField(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "scenario.yaml")
-	if err := os.WriteFile(path, []byte("name: invalid\ndescripton: typo\nsteps:\n  - module: example\n"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte("version: 1\nname: invalid\ndescripton: typo\nsteps:\n  - module: example\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := runner.LoadScenario(path); err == nil || !strings.Contains(err.Error(), "field descripton not found") {
@@ -609,12 +609,12 @@ func TestRunScenarioNormalizesPathList(t *testing.T) {
 	})
 
 	path := filepath.Join(t.TempDir(), "scenario.yaml")
-	body := "name: typed list\nsteps:\n  - module: " + name + "\n    params:\n      paths:\n        - /tmp/one\n        - /tmp/two\n"
+	body := "version: 1\nname: typed list\nsteps:\n  - module: " + name + "\n    params:\n      paths:\n        - /tmp/one\n        - /tmp/two\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: &registry}); err != nil {
+	if _, err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: &registry}); err != nil {
 		t.Fatal(err)
 	}
 	if got := invocation.params.Paths("paths", nil); !reflect.DeepEqual(got, []string{"/tmp/one", "/tmp/two"}) {
@@ -635,12 +635,12 @@ func TestRunScenarioRejectsUnknownParamBeforeExecution(t *testing.T) {
 	})
 
 	path := filepath.Join(t.TempDir(), "scenario.yaml")
-	body := "name: strict params\nsteps:\n  - module: " + name + "\n    params:\n      paht: /tmp/typo\n"
+	body := "version: 1\nname: strict params\nsteps:\n  - module: " + name + "\n    params:\n      paht: /tmp/typo\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: &registry})
+	_, err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: &registry})
 	if err == nil || invocation.generateCalls != 0 || invocation.cleanedUp {
 		t.Fatalf("RunScenario error = %v, invocation = %+v", err, invocation)
 	}

--- a/internal/runner/scenario.go
+++ b/internal/runner/scenario.go
@@ -10,23 +10,73 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ScenarioStep defines a single module invocation within a scenario.
+const scenarioVersion = 1
+
+// ScenarioValue is either a literal value or an explicit reference. Mapping
+// values are reserved for references so scenarios cannot grow an implicit
+// template language.
+type ScenarioValue struct {
+	Literal any
+	Input   string
+	Output  string
+}
+
+// UnmarshalYAML distinguishes explicit input/output references from literals.
+func (v *ScenarioValue) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.MappingNode {
+		var ref struct {
+			Input  string `yaml:"input,omitempty"`
+			Output string `yaml:"output,omitempty"`
+		}
+		if err := node.Decode(&ref); err != nil {
+			return err
+		}
+		if (ref.Input == "") == (ref.Output == "") {
+			return fmt.Errorf("value mapping must contain exactly one of input or output")
+		}
+		if len(node.Content) != 2 {
+			return fmt.Errorf("value reference contains unknown fields")
+		}
+		v.Input = ref.Input
+		v.Output = ref.Output
+		return nil
+	}
+	return node.Decode(&v.Literal)
+}
+
+// ScenarioInput declares one typed value supplied to a scenario.
+type ScenarioInput struct {
+	Type      module.ParamType `yaml:"type"`
+	Required  bool             `yaml:"required,omitempty"`
+	Sensitive bool             `yaml:"sensitive,omitempty"`
+	Default   any              `yaml:"default,omitempty"`
+}
+
+// ScenarioStep defines one module, category, or local scenario inclusion.
 type ScenarioStep struct {
-	Module   string        `yaml:"module"`
-	Category string        `yaml:"category"`
-	Params   module.Params `yaml:"params"`
+	ID       string                   `yaml:"id,omitempty"`
+	Module   string                   `yaml:"module,omitempty"`
+	Category string                   `yaml:"category,omitempty"`
+	Include  string                   `yaml:"include,omitempty"`
+	OnError  string                   `yaml:"on_error,omitempty"`
+	Params   map[string]ScenarioValue `yaml:"params,omitempty"`
+	Inputs   map[string]ScenarioValue `yaml:"inputs,omitempty"`
 }
 
-// Scenario is the top-level structure parsed from a scenario YAML file.
+// Scenario is the versioned top-level scenario document.
 type Scenario struct {
-	OnError     string         `yaml:"on_error,omitempty"`
-	Name        string         `yaml:"name"`
-	Description string         `yaml:"description"`
-	AuditLog    string         `yaml:"audit_log,omitempty"`
-	Steps       []ScenarioStep `yaml:"steps"`
+	Version     int                      `yaml:"version"`
+	OnError     string                   `yaml:"on_error,omitempty"`
+	Name        string                   `yaml:"name"`
+	Description string                   `yaml:"description,omitempty"`
+	AuditLog    string                   `yaml:"audit_log,omitempty"`
+	Inputs      map[string]ScenarioInput `yaml:"inputs,omitempty"`
+	Outputs     map[string]ScenarioValue `yaml:"outputs,omitempty"`
+	Steps       []ScenarioStep           `yaml:"steps"`
 }
 
-// LoadScenario reads and parses a YAML scenario file, returning an error if the file has no steps.
+// LoadScenario strictly parses one scenario document. Registry-dependent and
+// recursive checks happen during preflight in RunScenario.
 func LoadScenario(path string) (Scenario, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -45,11 +95,24 @@ func LoadScenario(path string) (Scenario, error) {
 		}
 		return Scenario{}, fmt.Errorf("scenario: parse %s: %w", path, err)
 	}
+	if sc.Version != scenarioVersion {
+		return Scenario{}, fmt.Errorf("scenario: %s has unsupported version %d (want %d)", path, sc.Version, scenarioVersion)
+	}
+	if sc.Name == "" {
+		return Scenario{}, fmt.Errorf("scenario: %s has no name", path)
+	}
 	if len(sc.Steps) == 0 {
 		return Scenario{}, fmt.Errorf("scenario: %s contains no steps", path)
 	}
-	if sc.OnError != "" && sc.OnError != "stop" && sc.OnError != "continue" {
-		return Scenario{}, fmt.Errorf("scenario: invalid on_error %q", sc.OnError)
+	if err := validateFailurePolicy(sc.OnError); err != nil {
+		return Scenario{}, fmt.Errorf("scenario: %w", err)
 	}
 	return sc, nil
+}
+
+func validateFailurePolicy(policy string) error {
+	if policy != "" && policy != "stop" && policy != "continue" {
+		return fmt.Errorf("invalid on_error %q", policy)
+	}
+	return nil
 }

--- a/internal/runner/scenario_plan.go
+++ b/internal/runner/scenario_plan.go
@@ -1,0 +1,451 @@
+package runner
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+const (
+	maxIncludeDepth        = 8
+	maxScenarioInvocations = 1000
+)
+
+type outputReference struct {
+	step string
+	name string
+}
+
+type valueBinding struct {
+	literal   any
+	input     string
+	ref       *outputReference
+	typeName  module.ParamType
+	sensitive bool
+	label     string
+}
+
+type scenarioPlan struct {
+	scenario Scenario
+	path     string
+	inputs   map[string]valueBinding
+	steps    []plannedStep
+	outputs  map[string]valueBinding
+}
+
+type plannedStep struct {
+	id          string
+	module      string
+	includePath string
+	policy      string
+	params      map[string]valueBinding
+	outputs     map[string]module.OutputSpec
+	include     *scenarioPlan
+}
+
+type preflightState struct {
+	registry *module.Registry
+	rootDir  string
+	stack    map[string]bool
+	count    int
+}
+
+func preflightScenario(path string, rawInputs module.Params, registry *module.Registry) (*scenarioPlan, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("scenario: resolve %s: %w", path, err)
+	}
+	rootInputs := make(map[string]valueBinding, len(rawInputs))
+	for name, value := range rawInputs {
+		rootInputs[name] = valueBinding{literal: value}
+	}
+	state := &preflightState{
+		registry: registry,
+		rootDir:  filepath.Dir(absPath),
+		stack:    make(map[string]bool),
+	}
+	return state.load(absPath, rootInputs, 0)
+}
+
+// ValidateScenario performs the same recursive preflight used by execution
+// without creating a workspace or invoking a module.
+func ValidateScenario(path string, inputs module.Params, registry *module.Registry) error {
+	if registry == nil {
+		registry = &module.DefaultRegistry
+	}
+	_, err := preflightScenario(path, inputs, registry)
+	return err
+}
+
+func (s *preflightState) load(path string, supplied map[string]valueBinding, depth int) (*scenarioPlan, error) {
+	if depth > maxIncludeDepth {
+		return nil, fmt.Errorf("scenario: include depth exceeds %d", maxIncludeDepth)
+	}
+	path = filepath.Clean(path)
+	if s.stack[path] {
+		return nil, fmt.Errorf("scenario: include cycle at %s", path)
+	}
+	s.stack[path] = true
+	defer delete(s.stack, path)
+
+	sc, err := LoadScenario(path)
+	if err != nil {
+		return nil, err
+	}
+	inputs, err := bindScenarioInputs(sc.Inputs, supplied)
+	if err != nil {
+		return nil, fmt.Errorf("scenario %q inputs: %w", sc.Name, err)
+	}
+
+	plan := &scenarioPlan{scenario: sc, path: path, inputs: inputs}
+	priorOutputs := make(map[string]map[string]module.OutputSpec)
+	seenIDs := make(map[string]bool)
+
+	for index, rawStep := range sc.Steps {
+		if err := validateFailurePolicy(rawStep.OnError); err != nil {
+			return nil, fmt.Errorf("scenario %q step %d: %w", sc.Name, index+1, err)
+		}
+		policy := rawStep.OnError
+		if policy == "" {
+			policy = sc.OnError
+		}
+		if policy == "" {
+			policy = "stop"
+		}
+		id := rawStep.ID
+		if id == "" {
+			id = fmt.Sprintf("step_%d", index+1)
+		}
+		if !validScenarioIdentifier(id) {
+			return nil, fmt.Errorf("scenario %q step %d: invalid id %q", sc.Name, index+1, id)
+		}
+		if seenIDs[id] {
+			return nil, fmt.Errorf("scenario %q: duplicate step id %q", sc.Name, id)
+		}
+		seenIDs[id] = true
+
+		selectors := 0
+		if rawStep.Module != "" {
+			selectors++
+		}
+		if rawStep.Category != "" {
+			selectors++
+		}
+		if rawStep.Include != "" {
+			selectors++
+		}
+		if selectors != 1 {
+			return nil, fmt.Errorf("scenario %q step %d: specify exactly one of module, category, or include", sc.Name, index+1)
+		}
+
+		switch {
+		case rawStep.Module != "":
+			if len(rawStep.Inputs) != 0 {
+				return nil, fmt.Errorf("scenario %q step %d: inputs are only valid for includes", sc.Name, index+1)
+			}
+			step, err := s.moduleStep(id, rawStep.Module, policy, rawStep.Params, inputs, priorOutputs)
+			if err != nil {
+				return nil, fmt.Errorf("scenario %q step %d: %w", sc.Name, index+1, err)
+			}
+			plan.steps = append(plan.steps, step)
+			priorOutputs[id] = step.outputs
+
+		case rawStep.Category != "":
+			if len(rawStep.Inputs) != 0 {
+				return nil, fmt.Errorf("scenario %q step %d: inputs are only valid for includes", sc.Name, index+1)
+			}
+			gens := s.registry.ByCategory(module.Category(rawStep.Category))
+			if len(gens) == 0 {
+				return nil, fmt.Errorf("scenario %q step %d: no modules found for category %q", sc.Name, index+1, rawStep.Category)
+			}
+			for _, gen := range gens {
+				step, err := s.moduleStep(id+"."+gen.Info().Name, gen.Info().Name, policy, rawStep.Params, inputs, priorOutputs)
+				if err != nil {
+					return nil, fmt.Errorf("scenario %q step %d module %q: %w", sc.Name, index+1, gen.Info().Name, err)
+				}
+				plan.steps = append(plan.steps, step)
+			}
+
+		case rawStep.Include != "":
+			if len(rawStep.Params) != 0 {
+				return nil, fmt.Errorf("scenario %q step %d: params are not valid for includes", sc.Name, index+1)
+			}
+			includePath, err := s.resolveInclude(path, rawStep.Include)
+			if err != nil {
+				return nil, fmt.Errorf("scenario %q step %d: %w", sc.Name, index+1, err)
+			}
+			bindings, err := compileBindings(rawStep.Inputs, inputs, priorOutputs, nil)
+			if err != nil {
+				return nil, fmt.Errorf("scenario %q step %d inputs: %w", sc.Name, index+1, err)
+			}
+			child, err := s.load(includePath, bindings, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			outputs := make(map[string]module.OutputSpec, len(child.outputs))
+			for name, binding := range child.outputs {
+				outputs[name] = module.OutputSpec{Name: name, Type: binding.typeName, Sensitive: binding.sensitive}
+			}
+			plan.steps = append(plan.steps, plannedStep{
+				id:          id,
+				includePath: includePath,
+				policy:      policy,
+				outputs:     outputs,
+				include:     child,
+			})
+			priorOutputs[id] = outputs
+		}
+	}
+
+	plan.outputs = make(map[string]valueBinding, len(sc.Outputs))
+	for name, value := range sc.Outputs {
+		if !validScenarioIdentifier(name) {
+			return nil, fmt.Errorf("scenario %q has invalid output name %q", sc.Name, name)
+		}
+		if value.Output == "" || value.Input != "" || value.Literal != nil {
+			return nil, fmt.Errorf("scenario %q output %q must reference a preceding step output", sc.Name, name)
+		}
+		binding, err := compileReference(value, inputs, priorOutputs, nil)
+		if err != nil {
+			return nil, fmt.Errorf("scenario %q output %q: %w", sc.Name, name, err)
+		}
+		plan.outputs[name] = binding
+	}
+	return plan, nil
+}
+
+func (s *preflightState) moduleStep(id, name, policy string, raw map[string]ScenarioValue, inputs map[string]valueBinding, prior map[string]map[string]module.OutputSpec) (plannedStep, error) {
+	gen, ok := s.registry.Get(name)
+	if !ok {
+		return plannedStep{}, fmt.Errorf("module %q not found", name)
+	}
+	s.count++
+	if s.count > maxScenarioInvocations {
+		return plannedStep{}, fmt.Errorf("expanded scenario exceeds %d module invocations", maxScenarioInvocations)
+	}
+	params, err := compileBindings(raw, inputs, prior, gen.ParamSpecs())
+	if err != nil {
+		return plannedStep{}, err
+	}
+	if _, err := module.NormalizeParams(gen.ParamSpecs(), representativeParams(params, gen.ParamSpecs())); err != nil {
+		return plannedStep{}, fmt.Errorf("module %q params: %w", name, err)
+	}
+	outputs := make(map[string]module.OutputSpec)
+	if provider, ok := gen.(module.OutputProvider); ok {
+		for _, spec := range provider.OutputSpecs() {
+			outputs[spec.Name] = spec
+		}
+	}
+	return plannedStep{id: id, module: name, policy: policy, params: params, outputs: outputs}, nil
+}
+
+func (s *preflightState) resolveInclude(parent, include string) (string, error) {
+	if filepath.IsAbs(include) {
+		return "", fmt.Errorf("include %q must be relative", include)
+	}
+	resolved, err := filepath.Abs(filepath.Join(filepath.Dir(parent), include))
+	if err != nil {
+		return "", fmt.Errorf("resolve include %q: %w", include, err)
+	}
+	rel, err := filepath.Rel(s.rootDir, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("include %q escapes scenario root %s", include, s.rootDir)
+	}
+	return resolved, nil
+}
+
+func bindScenarioInputs(declared map[string]ScenarioInput, supplied map[string]valueBinding) (map[string]valueBinding, error) {
+	for name := range supplied {
+		if _, ok := declared[name]; !ok {
+			return nil, fmt.Errorf("unknown input %q", name)
+		}
+	}
+	names := sortedKeys(declared)
+	specs := make([]module.ParamSpec, 0, len(names))
+	for _, name := range names {
+		if !validScenarioIdentifier(name) {
+			return nil, fmt.Errorf("invalid input name %q", name)
+		}
+		decl := declared[name]
+		specs = append(specs, module.ParamSpec{Name: name, Type: decl.Type, Required: decl.Required, Sensitive: decl.Sensitive, Default: decl.Default})
+	}
+	if err := module.ValidateParamSpecs(specs); err != nil {
+		return nil, err
+	}
+
+	bound := make(map[string]valueBinding, len(declared))
+	for _, spec := range specs {
+		value, ok := supplied[spec.Name]
+		if !ok {
+			if spec.Default == nil {
+				if spec.Required {
+					return nil, fmt.Errorf("required input %q is missing", spec.Name)
+				}
+				continue
+			}
+			value = valueBinding{literal: spec.Default}
+		}
+		value.sensitive = value.sensitive || spec.Sensitive
+		if value.typeName != "" {
+			if value.typeName != spec.Type {
+				return nil, fmt.Errorf("input %q requires %s, got %s", spec.Name, spec.Type, value.typeName)
+			}
+		} else {
+			normalized, err := module.NormalizeParams([]module.ParamSpec{spec}, module.Params{spec.Name: value.literal})
+			if err != nil {
+				return nil, err
+			}
+			value.literal = normalized[spec.Name]
+			value.typeName = spec.Type
+		}
+		bound[spec.Name] = value
+	}
+	return bound, nil
+}
+
+func compileBindings(raw map[string]ScenarioValue, inputs map[string]valueBinding, prior map[string]map[string]module.OutputSpec, specs []module.ParamSpec) (map[string]valueBinding, error) {
+	byName := make(map[string]module.ParamSpec, len(specs))
+	for _, spec := range specs {
+		byName[spec.Name] = spec
+	}
+	bound := make(map[string]valueBinding, len(raw))
+	for name, value := range raw {
+		var target *module.ParamSpec
+		if specs != nil {
+			spec, ok := byName[name]
+			if !ok {
+				return nil, fmt.Errorf("unknown parameter %q", name)
+			}
+			target = &spec
+		}
+		binding, err := compileReference(value, inputs, prior, target)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		bound[name] = binding
+	}
+	return bound, nil
+}
+
+func compileReference(value ScenarioValue, inputs map[string]valueBinding, prior map[string]map[string]module.OutputSpec, target *module.ParamSpec) (valueBinding, error) {
+	var binding valueBinding
+	switch {
+	case value.Input != "":
+		found, ok := inputs[value.Input]
+		if !ok {
+			return binding, fmt.Errorf("unknown input %q", value.Input)
+		}
+		binding = valueBinding{
+			input:     value.Input,
+			typeName:  found.typeName,
+			sensitive: found.sensitive,
+			label:     "input:" + value.Input,
+		}
+	case value.Output != "":
+		ref, err := parseOutputReference(value.Output)
+		if err != nil {
+			return binding, err
+		}
+		outputs, ok := prior[ref.step]
+		if !ok {
+			return binding, fmt.Errorf("output reference %q does not name a preceding step", value.Output)
+		}
+		spec, ok := outputs[ref.name]
+		if !ok {
+			return binding, fmt.Errorf("step %q has no output %q", ref.step, ref.name)
+		}
+		binding = valueBinding{ref: &ref, typeName: spec.Type, sensitive: spec.Sensitive, label: "output:" + value.Output}
+	default:
+		binding.literal = value.Literal
+	}
+
+	if target != nil {
+		if binding.typeName != "" {
+			if binding.typeName != target.Type {
+				return valueBinding{}, fmt.Errorf("requires %s, got %s", target.Type, binding.typeName)
+			}
+			binding.sensitive = binding.sensitive || target.Sensitive
+			return binding, nil
+		}
+		normalized, err := module.NormalizeParams([]module.ParamSpec{*target}, module.Params{target.Name: binding.literal})
+		if err != nil {
+			return valueBinding{}, err
+		}
+		binding.literal = normalized[target.Name]
+		binding.typeName = target.Type
+		binding.sensitive = target.Sensitive
+	}
+	return binding, nil
+}
+
+func parseOutputReference(raw string) (outputReference, error) {
+	parts := strings.Split(raw, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return outputReference{}, fmt.Errorf("invalid output reference %q (want step.output)", raw)
+	}
+	return outputReference{step: parts[0], name: parts[1]}, nil
+}
+
+func representativeParams(bindings map[string]valueBinding, specs []module.ParamSpec) module.Params {
+	params := make(module.Params, len(bindings))
+	byName := make(map[string]module.ParamSpec, len(specs))
+	for _, spec := range specs {
+		byName[spec.Name] = spec
+	}
+	for name, binding := range bindings {
+		if binding.ref == nil && binding.input == "" {
+			params[name] = binding.literal
+			continue
+		}
+		params[name] = placeholderValue(byName[name], binding.label)
+	}
+	return params
+}
+
+func placeholderValue(spec module.ParamSpec, label string) any {
+	placeholder := "<" + label + ">"
+	switch spec.Type {
+	case module.ParamInteger:
+		if spec.Default != nil {
+			return spec.Default
+		}
+		if spec.Range != nil {
+			return spec.Range.Min
+		}
+		return 0
+	case module.ParamBoolean:
+		return false
+	case module.ParamStringList, module.ParamPathList:
+		return []string{placeholder}
+	default:
+		if len(spec.Choices) > 0 {
+			return spec.Choices[0]
+		}
+		return placeholder
+	}
+}
+
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func validScenarioIdentifier(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, char := range name {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '_' || char == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/runner/scenario_run.go
+++ b/internal/runner/scenario_run.go
@@ -1,0 +1,388 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/0xv1n/macnoise/internal/audit"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+// ScenarioReportVersion identifies the JSON execution report contract.
+const ScenarioReportVersion = "1.0"
+
+// ScenarioReport is the deterministic, versioned result of one scenario run.
+// Step order follows the preflighted execution order.
+type ScenarioReport struct {
+	SchemaVersion string               `json:"schema_version"`
+	Scenario      string               `json:"scenario"`
+	Source        string               `json:"source"`
+	RunID         string               `json:"run_id,omitempty"`
+	Workspace     string               `json:"workspace,omitempty"`
+	StartedAt     time.Time            `json:"started_at"`
+	FinishedAt    time.Time            `json:"finished_at"`
+	Status        string               `json:"status"`
+	Inputs        module.Params        `json:"inputs,omitempty"`
+	Outputs       module.Params        `json:"outputs,omitempty"`
+	Steps         []ScenarioStepReport `json:"steps"`
+	Error         string               `json:"error,omitempty"`
+}
+
+// ScenarioStepReport records one expanded module invocation or include.
+type ScenarioStepReport struct {
+	ID            string               `json:"id"`
+	Module        string               `json:"module,omitempty"`
+	Include       string               `json:"include,omitempty"`
+	OnError       string               `json:"on_error"`
+	Status        string               `json:"status"`
+	StartedAt     time.Time            `json:"started_at,omitempty"`
+	FinishedAt    time.Time            `json:"finished_at,omitempty"`
+	Outputs       module.Params        `json:"outputs,omitempty"`
+	CleanupStatus string               `json:"cleanup_status"`
+	CleanupError  string               `json:"cleanup_error,omitempty"`
+	Error         string               `json:"error,omitempty"`
+	Steps         []ScenarioStepReport `json:"steps,omitempty"`
+}
+
+type cleanupTask struct {
+	report *ScenarioStepReport
+	run    func() error
+}
+
+type scenarioExecution struct {
+	ctx       context.Context
+	registry  *module.Registry
+	emit      module.EventEmitter
+	opts      Options
+	workspace string
+	cleanups  []cleanupTask
+}
+
+// RunScenario preflights and executes a scenario, then returns its report even
+// when execution or cleanup fails.
+func RunScenario(ctx context.Context, path string, emit module.EventEmitter, opts Options) (report ScenarioReport, resultErr error) {
+	registry := opts.Registry
+	if registry == nil {
+		registry = &module.DefaultRegistry
+	}
+	plan, err := preflightScenario(path, opts.ScenarioInputs, registry)
+	if err != nil {
+		return ScenarioReport{SchemaVersion: ScenarioReportVersion, Source: path, Status: "failed", Error: err.Error()}, err
+	}
+
+	workspace, err := os.MkdirTemp("", "macnoise-scenario-")
+	if err != nil {
+		return ScenarioReport{}, fmt.Errorf("scenario: create workspace: %w", err)
+	}
+	if err := os.Chmod(workspace, 0o700); err != nil {
+		_ = os.RemoveAll(workspace)
+		return ScenarioReport{}, fmt.Errorf("scenario: secure workspace: %w", err)
+	}
+
+	start := time.Now().UTC()
+	report = ScenarioReport{
+		SchemaVersion: ScenarioReportVersion,
+		Scenario:      plan.scenario.Name,
+		Source:        plan.path,
+		RunID:         opts.RunID,
+		Workspace:     workspace,
+		StartedAt:     start,
+		Status:        "running",
+		Inputs:        reportInputs(plan),
+	}
+	fmt.Fprintf(os.Stderr, "Running scenario: %s\n", plan.scenario.Name)
+	if plan.scenario.Description != "" {
+		fmt.Fprintf(os.Stderr, "  %s\n", plan.scenario.Description)
+	}
+
+	execution := scenarioExecution{ctx: ctx, registry: registry, emit: emit, opts: opts, workspace: workspace}
+	inputValues, err := resolvePlanInputs(plan.inputs, nil, nil, false)
+	if err == nil {
+		var outputs module.Params
+		report.Steps, outputs, err = execution.runPlan(plan, inputValues)
+		report.Outputs = redactScenarioOutputs(outputs, plan.outputs)
+	}
+	resultErr = err
+
+	for index := len(execution.cleanups) - 1; index >= 0; index-- {
+		task := execution.cleanups[index]
+		if cleanupErr := task.run(); cleanupErr != nil {
+			task.report.Status = "failed"
+			task.report.Error = joinMessage(task.report.Error, cleanupErr.Error())
+			resultErr = errors.Join(resultErr, cleanupErr)
+		}
+	}
+
+	if opts.NoCleanup {
+		fmt.Fprintf(os.Stderr, "scenario workspace retained at %s (--no-cleanup)\n", workspace)
+	} else if cleanupErr := os.RemoveAll(workspace); cleanupErr != nil {
+		resultErr = errors.Join(resultErr, fmt.Errorf("scenario: remove workspace: %w", cleanupErr))
+	}
+
+	stepsPassed, stepsFailed, totalSteps := reportCounts(report.Steps)
+	if opts.AuditLog != nil {
+		data := audit.LifecycleData{
+			StartTime:   start,
+			EndTime:     time.Now().UTC(),
+			StepsPassed: stepsPassed,
+			StepsFailed: stepsFailed,
+			TotalSteps:  totalSteps,
+		}
+		if resultErr != nil {
+			data.GenerateError = resultErr.Error()
+		}
+		resultErr = errors.Join(resultErr, opts.AuditLog.LogScenario(plan.scenario.Name, plan.path, data))
+	}
+
+	report.FinishedAt = time.Now().UTC()
+	switch {
+	case errors.Is(resultErr, context.Canceled), errors.Is(resultErr, context.DeadlineExceeded):
+		report.Status = "interrupted"
+	case resultErr != nil:
+		report.Status = "failed"
+	case opts.DryRun:
+		report.Status = "previewed"
+	default:
+		report.Status = "passed"
+	}
+	if resultErr != nil {
+		report.Error = resultErr.Error()
+	}
+	return report, resultErr
+}
+
+func (e *scenarioExecution) runPlan(plan *scenarioPlan, inputValues module.Params) ([]ScenarioStepReport, module.Params, error) {
+	reports := make([]ScenarioStepReport, len(plan.steps))
+	stepValues := make(map[string]module.Params)
+	var runErr error
+	stopped := false
+
+	for index, step := range plan.steps {
+		report := &reports[index]
+		report.ID = step.id
+		report.Module = step.module
+		report.Include = step.includePath
+		report.OnError = step.policy
+		report.Status = "skipped"
+		report.CleanupStatus = "not_started"
+
+		if stopped {
+			continue
+		}
+		if err := e.ctx.Err(); err != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("scenario %q interrupted before %s: %w", plan.scenario.Name, step.id, err))
+			stopped = true
+			continue
+		}
+
+		report.StartedAt = time.Now().UTC()
+		var stepErr error
+		var outputs module.Params
+		if step.include != nil {
+			childInputs, err := resolvePlanInputs(step.include.inputs, inputValues, stepValues, e.opts.DryRun)
+			if err != nil {
+				stepErr = err
+			} else {
+				report.Steps, outputs, stepErr = e.runPlan(step.include, childInputs)
+			}
+			report.CleanupStatus = "not_applicable"
+		} else {
+			params, err := resolveBindings(step.params, inputValues, stepValues, e.opts.DryRun, e.moduleParamSpecs(step.module))
+			if err != nil {
+				stepErr = err
+			} else {
+				gen, _ := e.registry.Get(step.module)
+				invocationOpts := e.opts
+				invocationOpts.workspace = e.workspace
+				invocationOpts.invocationOutput = &outputs
+				registered := false
+				invocationOpts.deferCleanup = func(run func() error) {
+					registered = true
+					report.CleanupStatus = "pending"
+					e.cleanups = append(e.cleanups, cleanupTask{report: report, run: run})
+				}
+				invocationOpts.cleanupResult = func(status, message string) {
+					report.CleanupStatus = status
+					report.CleanupError = message
+				}
+				stepErr = RunSingle(e.ctx, gen, params, e.emit, invocationOpts)
+				if !registered {
+					report.CleanupStatus = "not_required"
+				}
+				if e.opts.DryRun && stepErr == nil {
+					outputs = previewOutputs(step.outputs)
+				}
+			}
+		}
+		report.FinishedAt = time.Now().UTC()
+		report.Outputs = redactOutputs(outputs, step.outputs)
+		stepValues[step.id] = outputs
+
+		if err := e.ctx.Err(); err != nil {
+			report.Status = "interrupted"
+			report.Error = errors.Join(stepErr, err).Error()
+			runErr = errors.Join(runErr, fmt.Errorf("scenario %q interrupted during %s: %w", plan.scenario.Name, step.id, err))
+			stopped = true
+			continue
+		}
+		if stepErr != nil {
+			report.Status = "failed"
+			report.Error = stepErr.Error()
+			fmt.Fprintf(os.Stderr, "%s error: %v\n", step.id, stepErr)
+			runErr = errors.Join(runErr, fmt.Errorf("%s: %w", step.id, stepErr))
+			if step.policy == "stop" {
+				stopped = true
+			}
+			continue
+		}
+		if e.opts.DryRun {
+			report.Status = "previewed"
+		} else {
+			report.Status = "passed"
+		}
+	}
+
+	exported := make(module.Params, len(plan.outputs))
+	for name, binding := range plan.outputs {
+		value, err := resolveBinding(binding, inputValues, stepValues, e.opts.DryRun, module.ParamSpec{Name: name, Type: binding.typeName})
+		if err != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("scenario %q output %q: %w", plan.scenario.Name, name, err))
+			continue
+		}
+		exported[name] = value
+	}
+	return reports, exported, runErr
+}
+
+func (e *scenarioExecution) moduleParamSpecs(name string) []module.ParamSpec {
+	gen, _ := e.registry.Get(name)
+	return gen.ParamSpecs()
+}
+
+func resolvePlanInputs(bindings map[string]valueBinding, parentInputs module.Params, parentSteps map[string]module.Params, preview bool) (module.Params, error) {
+	values := make(module.Params, len(bindings))
+	for _, name := range sortedKeys(bindings) {
+		binding := bindings[name]
+		value, err := resolveBinding(binding, parentInputs, parentSteps, preview, module.ParamSpec{Name: name, Type: binding.typeName})
+		if err != nil {
+			return nil, fmt.Errorf("input %q: %w", name, err)
+		}
+		values[name] = value
+	}
+	return values, nil
+}
+
+func resolveBindings(bindings map[string]valueBinding, inputs module.Params, steps map[string]module.Params, preview bool, specs []module.ParamSpec) (module.Params, error) {
+	byName := make(map[string]module.ParamSpec, len(specs))
+	for _, spec := range specs {
+		byName[spec.Name] = spec
+	}
+	params := make(module.Params, len(bindings))
+	for _, name := range sortedKeys(bindings) {
+		value, err := resolveBinding(bindings[name], inputs, steps, preview, byName[name])
+		if err != nil {
+			return nil, fmt.Errorf("parameter %q: %w", name, err)
+		}
+		params[name] = value
+	}
+	return params, nil
+}
+
+func resolveBinding(binding valueBinding, inputs module.Params, steps map[string]module.Params, preview bool, spec module.ParamSpec) (any, error) {
+	switch {
+	case binding.input != "":
+		value, ok := inputs[binding.input]
+		if !ok {
+			return nil, fmt.Errorf("input %q has no runtime value", binding.input)
+		}
+		return value, nil
+	case binding.ref != nil:
+		if outputs, ok := steps[binding.ref.step]; ok {
+			if value, ok := outputs[binding.ref.name]; ok {
+				return value, nil
+			}
+		}
+		if preview {
+			return placeholderValue(spec, binding.label), nil
+		}
+		return nil, fmt.Errorf("output %s.%s has no runtime value", binding.ref.step, binding.ref.name)
+	default:
+		return binding.literal, nil
+	}
+}
+
+func previewOutputs(specs map[string]module.OutputSpec) module.Params {
+	outputs := make(module.Params, len(specs))
+	for name, spec := range specs {
+		outputs[name] = placeholderValue(module.ParamSpec{Name: name, Type: spec.Type}, "runtime:"+name)
+	}
+	return outputs
+}
+
+func redactOutputs(outputs module.Params, specs map[string]module.OutputSpec) module.Params {
+	redacted := make(module.Params, len(outputs))
+	for name, value := range outputs {
+		if specs[name].Sensitive {
+			redacted[name] = module.RedactedValue
+		} else {
+			redacted[name] = value
+		}
+	}
+	return redacted
+}
+
+func redactScenarioOutputs(outputs module.Params, specs map[string]valueBinding) module.Params {
+	redacted := make(module.Params, len(outputs))
+	for name, value := range outputs {
+		if specs[name].sensitive {
+			redacted[name] = module.RedactedValue
+		} else {
+			redacted[name] = value
+		}
+	}
+	return redacted
+}
+
+func reportInputs(plan *scenarioPlan) module.Params {
+	inputs := make(module.Params, len(plan.inputs))
+	for name, binding := range plan.inputs {
+		switch {
+		case binding.sensitive:
+			inputs[name] = module.RedactedValue
+		case binding.literal != nil:
+			inputs[name] = binding.literal
+		default:
+			inputs[name] = "<" + binding.label + ">"
+		}
+	}
+	return inputs
+}
+
+func reportCounts(reports []ScenarioStepReport) (passed, failed, total int) {
+	for _, report := range reports {
+		if report.Module != "" {
+			total++
+			switch report.Status {
+			case "passed", "previewed":
+				passed++
+			case "failed":
+				failed++
+			}
+		}
+		childPassed, childFailed, childTotal := reportCounts(report.Steps)
+		passed += childPassed
+		failed += childFailed
+		total += childTotal
+	}
+	return passed, failed, total
+}
+
+func joinMessage(first, second string) string {
+	if first == "" {
+		return second
+	}
+	return first + "; " + second
+}

--- a/internal/runner/scenario_runtime_test.go
+++ b/internal/runner/scenario_runtime_test.go
@@ -1,0 +1,397 @@
+package runner_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/0xv1n/macnoise/internal/runner"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+type artifactFlow struct {
+	mu             sync.Mutex
+	cleanupOrder   []string
+	generatedPaths map[string]string
+	consumedSecret string
+	generateCalls  int
+}
+
+type artifactModule struct {
+	name string
+	flow *artifactFlow
+	path string
+}
+
+func (m *artifactModule) Info() module.ModuleInfo {
+	return module.ModuleInfo{Name: m.name, Category: "scenario_test"}
+}
+
+func (m *artifactModule) ParamSpecs() []module.ParamSpec {
+	switch m.name {
+	case "flow_create":
+		return []module.ParamSpec{{Name: "content", Type: module.ParamString, Required: true}}
+	case "flow_modify":
+		return []module.ParamSpec{{Name: "path", Type: module.ParamPath, Required: true}}
+	case "flow_archive":
+		return []module.ParamSpec{{Name: "source", Type: module.ParamPath, Required: true}}
+	case "secret_consumer":
+		return []module.ParamSpec{{Name: "secret", Type: module.ParamString, Required: true, Sensitive: true}}
+	default:
+		return nil
+	}
+}
+
+func (m *artifactModule) OutputSpecs() []module.OutputSpec {
+	switch m.name {
+	case "flow_create", "flow_modify":
+		return []module.OutputSpec{{Name: "path", Type: module.ParamPath}}
+	case "flow_archive":
+		return []module.OutputSpec{{Name: "archive", Type: module.ParamPath}}
+	case "secret_source":
+		return []module.OutputSpec{{Name: "value", Type: module.ParamString, Sensitive: true}}
+	default:
+		return nil
+	}
+}
+
+func (m *artifactModule) CheckPrereqs(context.Context, module.Params) error { return nil }
+
+func (m *artifactModule) Generate(ctx context.Context, params module.Params, _ module.EventEmitter) error {
+	m.flow.mu.Lock()
+	m.flow.generateCalls++
+	m.flow.mu.Unlock()
+	workspace := module.WorkspaceFromContext(ctx)
+	if workspace == "" {
+		return errors.New("missing scenario workspace")
+	}
+	switch m.name {
+	case "flow_create":
+		m.path = filepath.Join(workspace, "artifact.txt")
+		if err := os.WriteFile(m.path, []byte(params.String("content", "")), 0o600); err != nil {
+			return err
+		}
+		m.recordPath(m.path)
+		return module.PublishOutput(ctx, "path", m.path)
+	case "flow_modify":
+		m.path = params.String("path", "")
+		data, err := os.ReadFile(m.path)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(m.path, append(data, []byte(" modified")...), 0o600); err != nil {
+			return err
+		}
+		m.recordPath(m.path)
+		return module.PublishOutput(ctx, "path", m.path)
+	case "flow_archive":
+		source := params.String("source", "")
+		data, err := os.ReadFile(source)
+		if err != nil {
+			return err
+		}
+		if string(data) != "original modified" {
+			return errors.New("archive did not receive modified artifact")
+		}
+		m.path = filepath.Join(workspace, "artifact.archive")
+		if err := os.WriteFile(m.path, data, 0o600); err != nil {
+			return err
+		}
+		m.recordPath(source)
+		return module.PublishOutput(ctx, "archive", m.path)
+	case "secret_source":
+		return module.PublishOutput(ctx, "value", "classified")
+	case "secret_consumer":
+		m.flow.mu.Lock()
+		m.flow.consumedSecret = params.String("secret", "")
+		m.flow.mu.Unlock()
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (m *artifactModule) DryRun(params module.Params) []string {
+	return []string{"preview " + m.name}
+}
+
+func (m *artifactModule) Cleanup(ctx context.Context) error {
+	if module.WorkspaceFromContext(ctx) == "" {
+		return errors.New("cleanup lost scenario workspace")
+	}
+	m.flow.mu.Lock()
+	m.flow.cleanupOrder = append(m.flow.cleanupOrder, m.name)
+	m.flow.mu.Unlock()
+	if m.path != "" && m.name != "flow_modify" {
+		return os.Remove(m.path)
+	}
+	return nil
+}
+
+func (m *artifactModule) recordPath(path string) {
+	m.flow.mu.Lock()
+	defer m.flow.mu.Unlock()
+	if m.flow.generatedPaths == nil {
+		m.flow.generatedPaths = make(map[string]string)
+	}
+	m.flow.generatedPaths[m.name] = path
+}
+
+func flowRegistry(flow *artifactFlow, names ...string) *module.Registry {
+	registry := &module.Registry{}
+	for _, name := range names {
+		name := name
+		registry.Register(func() module.Generator { return &artifactModule{name: name, flow: flow} })
+	}
+	return registry
+}
+
+func writeScenarioFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestScenarioDataflowWorkspaceAndReverseCleanup(t *testing.T) {
+	flow := &artifactFlow{}
+	registry := flowRegistry(flow, "flow_create", "flow_modify", "flow_archive")
+	path := writeScenarioFile(t, t.TempDir(), "flow.yaml", `version: 1
+name: artifact flow
+on_error: stop
+inputs:
+  content:
+    type: string
+    required: true
+steps:
+  - id: create
+    module: flow_create
+    params:
+      content:
+        input: content
+  - id: modify
+    module: flow_modify
+    params:
+      path:
+        output: create.path
+  - id: archive
+    module: flow_archive
+    params:
+      source:
+        output: modify.path
+outputs:
+  archive:
+    output: archive.archive
+`)
+
+	report, err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{
+		Registry:       registry,
+		RunID:          "flow-run",
+		ScenarioInputs: module.Params{"content": "original"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Status != "passed" || len(report.Steps) != 3 {
+		t.Fatalf("report = %+v", report)
+	}
+	if got, want := flow.cleanupOrder, []string{"flow_archive", "flow_modify", "flow_create"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("cleanup order = %v, want %v", got, want)
+	}
+	if flow.generatedPaths["flow_create"] != flow.generatedPaths["flow_modify"] || flow.generatedPaths["flow_modify"] != flow.generatedPaths["flow_archive"] {
+		t.Fatalf("steps did not consume one artifact: %#v", flow.generatedPaths)
+	}
+	if _, err := os.Stat(report.Workspace); !os.IsNotExist(err) {
+		t.Fatalf("workspace survived cleanup: %v", err)
+	}
+	for _, step := range report.Steps {
+		if step.CleanupStatus != "ok" {
+			t.Errorf("%s cleanup = %q", step.ID, step.CleanupStatus)
+		}
+	}
+}
+
+func TestScenarioPreflightRejectsLaterErrorBeforeMutation(t *testing.T) {
+	flow := &artifactFlow{}
+	registry := flowRegistry(flow, "flow_create")
+	path := writeScenarioFile(t, t.TempDir(), "invalid.yaml", `version: 1
+name: invalid before mutation
+steps:
+  - module: flow_create
+    params:
+      content: should-not-run
+  - module: missing_module
+`)
+
+	report, err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: registry})
+	if err == nil || !strings.Contains(err.Error(), `module "missing_module" not found`) {
+		t.Fatalf("RunScenario error = %v", err)
+	}
+	if flow.generateCalls != 0 {
+		t.Fatalf("preflight failure allowed %d mutation(s)", flow.generateCalls)
+	}
+	if report.Workspace != "" {
+		t.Fatalf("preflight failure created workspace %q", report.Workspace)
+	}
+}
+
+func TestScenarioIncludeDataflowAndCycleValidation(t *testing.T) {
+	flow := &artifactFlow{}
+	registry := flowRegistry(flow, "secret_source", "secret_consumer")
+	dir := t.TempDir()
+	writeScenarioFile(t, dir, "child.yaml", `version: 1
+name: child
+steps:
+  - id: source
+    module: secret_source
+outputs:
+  secret:
+    output: source.value
+`)
+	parent := writeScenarioFile(t, dir, "parent.yaml", `version: 1
+name: parent
+steps:
+  - id: child
+    include: child.yaml
+  - module: secret_consumer
+    params:
+      secret:
+        output: child.secret
+`)
+
+	report, err := runner.RunScenario(context.Background(), parent, discardEvent, runner.Options{Registry: registry})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flow.consumedSecret != "classified" {
+		t.Fatalf("include output = %q", flow.consumedSecret)
+	}
+	if len(report.Steps[0].Steps) != 1 || report.Steps[0].Outputs["secret"] != module.RedactedValue {
+		t.Fatalf("include report did not redact output: %+v", report.Steps[0])
+	}
+
+	writeScenarioFile(t, dir, "a.yaml", "version: 1\nname: a\nsteps:\n  - include: b.yaml\n")
+	b := writeScenarioFile(t, dir, "b.yaml", "version: 1\nname: b\nsteps:\n  - include: a.yaml\n")
+	if err := runner.ValidateScenario(b, nil, registry); err == nil || !strings.Contains(err.Error(), "include cycle") {
+		t.Fatalf("cycle validation error = %v", err)
+	}
+
+	for index := 0; index < 10; index++ {
+		body := "version: 1\nname: depth\nsteps:\n"
+		if index == 9 {
+			body += "  - module: secret_source\n"
+		} else {
+			body += "  - include: depth_" + strconv.Itoa(index+1) + ".yaml\n"
+		}
+		writeScenarioFile(t, dir, "depth_"+strconv.Itoa(index)+".yaml", body)
+	}
+	if err := runner.ValidateScenario(filepath.Join(dir, "depth_0.yaml"), nil, registry); err == nil || !strings.Contains(err.Error(), "include depth exceeds") {
+		t.Fatalf("depth validation error = %v", err)
+	}
+}
+
+func TestScenarioStepFailurePolicyAndOutputContract(t *testing.T) {
+	flow := &artifactFlow{}
+	registry := flowRegistry(flow, "secret_consumer")
+	registry.Register(func() module.Generator { return &missingOutputModule{} })
+	path := writeScenarioFile(t, t.TempDir(), "continue.yaml", `version: 1
+name: continue one invocation
+on_error: stop
+steps:
+  - module: missing_output
+    on_error: continue
+  - module: secret_consumer
+    params:
+      secret: reached
+`)
+
+	report, err := runner.RunScenario(context.Background(), path, discardEvent, runner.Options{Registry: registry})
+	if err == nil || !strings.Contains(err.Error(), `did not publish declared output "value"`) {
+		t.Fatalf("RunScenario error = %v", err)
+	}
+	if flow.consumedSecret != "reached" || report.Steps[0].OnError != "continue" || report.Steps[1].Status != "passed" {
+		t.Fatalf("per-invocation policy report = %+v, consumed = %q", report, flow.consumedSecret)
+	}
+}
+
+type missingOutputModule struct{}
+
+func (*missingOutputModule) Info() module.ModuleInfo {
+	return module.ModuleInfo{Name: "missing_output", Category: "scenario_test"}
+}
+func (*missingOutputModule) ParamSpecs() []module.ParamSpec { return nil }
+func (*missingOutputModule) OutputSpecs() []module.OutputSpec {
+	return []module.OutputSpec{{Name: "value", Type: module.ParamString}}
+}
+func (*missingOutputModule) CheckPrereqs(context.Context, module.Params) error { return nil }
+func (*missingOutputModule) Generate(context.Context, module.Params, module.EventEmitter) error {
+	return nil
+}
+func (*missingOutputModule) DryRun(module.Params) []string { return nil }
+func (*missingOutputModule) Cleanup(context.Context) error { return nil }
+
+func TestScenarioCancellationOverridesContinueAndCleansUp(t *testing.T) {
+	flow := &artifactFlow{}
+	registry := flowRegistry(flow, "flow_create", "flow_modify")
+	ctx, cancel := context.WithCancel(context.Background())
+	registry.Register(func() module.Generator {
+		return &cancelModule{name: "cancel_now", cancel: cancel, flow: flow}
+	})
+	path := writeScenarioFile(t, t.TempDir(), "cancel.yaml", `version: 1
+name: cancel
+on_error: continue
+steps:
+  - module: flow_create
+    params:
+      content: original
+  - module: cancel_now
+  - module: flow_modify
+    params:
+      path: never
+`)
+
+	report, err := runner.RunScenario(ctx, path, discardEvent, runner.Options{Registry: registry})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunScenario error = %v", err)
+	}
+	if report.Status != "interrupted" || report.Steps[2].Status != "skipped" {
+		t.Fatalf("cancellation report = %+v", report)
+	}
+	if got, want := flow.cleanupOrder, []string{"cancel_now", "flow_create"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("cleanup order = %v, want %v", got, want)
+	}
+}
+
+type cancelModule struct {
+	name   string
+	cancel context.CancelFunc
+	flow   *artifactFlow
+}
+
+func (m *cancelModule) Info() module.ModuleInfo {
+	return module.ModuleInfo{Name: m.name, Category: "scenario_test"}
+}
+func (m *cancelModule) ParamSpecs() []module.ParamSpec                    { return nil }
+func (m *cancelModule) CheckPrereqs(context.Context, module.Params) error { return nil }
+func (m *cancelModule) Generate(context.Context, module.Params, module.EventEmitter) error {
+	m.flow.mu.Lock()
+	m.flow.generateCalls++
+	m.flow.mu.Unlock()
+	m.cancel()
+	return nil
+}
+func (m *cancelModule) DryRun(module.Params) []string { return nil }
+func (m *cancelModule) Cleanup(context.Context) error {
+	m.flow.mu.Lock()
+	defer m.flow.mu.Unlock()
+	m.flow.cleanupOrder = append(m.flow.cleanupOrder, m.name)
+	return nil
+}

--- a/modules/xpc/enumerate_integration_test.go
+++ b/modules/xpc/enumerate_integration_test.go
@@ -87,8 +87,13 @@ func TestXPCEnumerate_EmitsPerDomain(t *testing.T) {
 		if ev.EventType != "xpc_enumerate" {
 			t.Errorf("EventType = %q, want xpc_enumerate", ev.EventType)
 		}
-		if ev.Outcome != module.OutcomeExecuted {
-			t.Errorf("Success = false for domain %v; an unreadable domain is still valid telemetry", ev.Details["domain"])
+		accessible, ok := ev.Details["accessible"].(bool)
+		if !ok {
+			t.Errorf("accessible = %#v, want bool", ev.Details["accessible"])
+		} else if accessible && ev.Outcome != module.OutcomeExecuted {
+			t.Errorf("Outcome = %q for readable domain %v, want executed", ev.Outcome, ev.Details["domain"])
+		} else if !accessible && ev.Outcome != module.OutcomeDenied {
+			t.Errorf("Outcome = %q for unreadable domain %v, want denied", ev.Outcome, ev.Details["domain"])
 		}
 		if ev.Details["domain"] == "" {
 			t.Error("event is missing the domain it enumerated")

--- a/pkg/module/catalog.go
+++ b/pkg/module/catalog.go
@@ -8,15 +8,16 @@ package module
 // rather than tagging those shared structs, so the telemetry event schema
 // (which already serialises ModuleInfo.MITRE) is left untouched.
 type CatalogEntry struct {
-	Name        string         `json:"name"`
-	Category    Category       `json:"category"`
-	Description string         `json:"description"`
-	Privileges  Privilege      `json:"privileges"`
-	MinMacOS    string         `json:"min_macos,omitempty"`
-	Tags        []string       `json:"tags,omitempty"`
-	EventTypes  []string       `json:"event_types,omitempty"`
-	MITRE       []CatalogMITRE `json:"mitre,omitempty"`
-	Params      []CatalogParam `json:"params,omitempty"`
+	Name        string          `json:"name"`
+	Category    Category        `json:"category"`
+	Description string          `json:"description"`
+	Privileges  Privilege       `json:"privileges"`
+	MinMacOS    string          `json:"min_macos,omitempty"`
+	Tags        []string        `json:"tags,omitempty"`
+	EventTypes  []string        `json:"event_types,omitempty"`
+	MITRE       []CatalogMITRE  `json:"mitre,omitempty"`
+	Params      []CatalogParam  `json:"params,omitempty"`
+	Outputs     []CatalogOutput `json:"outputs,omitempty"`
 }
 
 // CatalogMITRE is one ATT&CK reference in a CatalogEntry. SubTechnique is the
@@ -41,6 +42,14 @@ type CatalogParam struct {
 	Choices     []string      `json:"choices,omitempty"`
 }
 
+// CatalogOutput is one typed scenario value published by a module.
+type CatalogOutput struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Type        ParamType `json:"type"`
+	Sensitive   bool      `json:"sensitive"`
+}
+
 // NewCatalogEntry builds the catalog view of a module from its Info and
 // parameter specs.
 func NewCatalogEntry(g Generator) CatalogEntry {
@@ -60,6 +69,12 @@ func NewCatalogEntry(g Generator) CatalogEntry {
 	for _, s := range specs {
 		params = append(params, CatalogParam(s))
 	}
+	var outputs []CatalogOutput
+	if provider, ok := g.(OutputProvider); ok {
+		for _, spec := range provider.OutputSpecs() {
+			outputs = append(outputs, CatalogOutput(spec))
+		}
+	}
 
 	return CatalogEntry{
 		Name:        info.Name,
@@ -71,5 +86,6 @@ func NewCatalogEntry(g Generator) CatalogEntry {
 		EventTypes:  info.EventTypes,
 		MITRE:       mitre,
 		Params:      params,
+		Outputs:     outputs,
 	}
 }

--- a/pkg/module/catalog_test.go
+++ b/pkg/module/catalog_test.go
@@ -26,6 +26,9 @@ func (catalogTestGen) ParamSpecs() []ParamSpec {
 		{Name: "target", Description: "the target", Type: ParamString, Required: true, Sensitive: true, Default: "1.2.3.4", Example: "10.0.0.1"},
 	}
 }
+func (catalogTestGen) OutputSpecs() []OutputSpec {
+	return []OutputSpec{{Name: "path", Description: "created path", Type: ParamPath}}
+}
 func (catalogTestGen) CheckPrereqs(ctx context.Context, params Params) error { return nil }
 func (catalogTestGen) Generate(context.Context, Params, EventEmitter) error  { return nil }
 func (catalogTestGen) DryRun(Params) []string                                { return nil }
@@ -50,5 +53,8 @@ func TestNewCatalogEntry(t *testing.T) {
 	}
 	if len(e.Params) != 1 || e.Params[0].Name != "target" || e.Params[0].Type != ParamString || !e.Params[0].Required || !e.Params[0].Sensitive || e.Params[0].Default != "1.2.3.4" {
 		t.Errorf("params mapped wrong: %+v", e.Params)
+	}
+	if len(e.Outputs) != 1 || e.Outputs[0].Name != "path" || e.Outputs[0].Type != ParamPath {
+		t.Errorf("outputs mapped wrong: %+v", e.Outputs)
 	}
 }

--- a/pkg/module/context.go
+++ b/pkg/module/context.go
@@ -1,8 +1,15 @@
 package module
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 type runIDKey struct{}
+type workspaceKey struct{}
+type outputSinkKey struct{}
+
+type outputSink func(string, any) error
 
 // ContextWithRunID returns a child context carrying the run ID.
 func ContextWithRunID(ctx context.Context, id string) context.Context {
@@ -13,4 +20,32 @@ func ContextWithRunID(ctx context.Context, id string) context.Context {
 func RunIDFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(runIDKey{}).(string)
 	return v
+}
+
+// ContextWithWorkspace returns a child context carrying the private scenario
+// workspace. Runners, rather than modules, own its lifetime.
+func ContextWithWorkspace(ctx context.Context, path string) context.Context {
+	return context.WithValue(ctx, workspaceKey{}, path)
+}
+
+// WorkspaceFromContext returns the private scenario workspace, or an empty
+// string for a module invoked outside a scenario.
+func WorkspaceFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(workspaceKey{}).(string)
+	return v
+}
+
+// ContextWithOutputSink installs the output collector used by the runner.
+// It is public for runner integration; modules should call PublishOutput.
+func ContextWithOutputSink(ctx context.Context, sink func(string, any) error) context.Context {
+	return context.WithValue(ctx, outputSinkKey{}, outputSink(sink))
+}
+
+// PublishOutput publishes one declared output from Generate.
+func PublishOutput(ctx context.Context, name string, value any) error {
+	sink, _ := ctx.Value(outputSinkKey{}).(outputSink)
+	if sink == nil {
+		return fmt.Errorf("module output %q has no runner collector", name)
+	}
+	return sink(name, value)
 }

--- a/pkg/module/context_test.go
+++ b/pkg/module/context_test.go
@@ -17,3 +17,19 @@ func TestRunIDFromContext_EmptyWhenUnset(t *testing.T) {
 		t.Errorf("RunIDFromContext on bare context = %q, want empty", got)
 	}
 }
+
+func TestScenarioContextRoundTripsWorkspaceAndOutputs(t *testing.T) {
+	ctx := ContextWithWorkspace(context.Background(), "/private/workspace")
+	var name string
+	var value any
+	ctx = ContextWithOutputSink(ctx, func(gotName string, gotValue any) error {
+		name, value = gotName, gotValue
+		return nil
+	})
+	if err := PublishOutput(ctx, "path", "/private/workspace/file"); err != nil {
+		t.Fatal(err)
+	}
+	if WorkspaceFromContext(ctx) != "/private/workspace" || name != "path" || value != "/private/workspace/file" {
+		t.Fatalf("workspace = %q, output = %s:%v", WorkspaceFromContext(ctx), name, value)
+	}
+}

--- a/pkg/module/interface.go
+++ b/pkg/module/interface.go
@@ -57,6 +57,15 @@ type ParamSpec struct {
 	Choices     []string
 }
 
+// OutputSpec describes a typed value a module publishes for later scenario
+// steps. Declared outputs are required when Generate succeeds.
+type OutputSpec struct {
+	Name        string
+	Description string
+	Type        ParamType
+	Sensitive   bool
+}
+
 // IntegerRange defines inclusive bounds. A zero Max means no upper bound.
 type IntegerRange struct {
 	Min int `json:"min"`
@@ -261,4 +270,10 @@ type Generator interface {
 	Generate(ctx context.Context, params Params, emit EventEmitter) error
 	DryRun(params Params) []string
 	Cleanup(ctx context.Context) error
+}
+
+// OutputProvider is implemented by modules that publish values for scenario
+// dataflow. PublishOutput sends the values through the invocation context.
+type OutputProvider interface {
+	OutputSpecs() []OutputSpec
 }

--- a/pkg/module/params.go
+++ b/pkg/module/params.go
@@ -90,6 +90,48 @@ func ValidateParamSpecs(specs []ParamSpec) error {
 	return nil
 }
 
+// ValidateOutputSpecs checks that output names and types form a usable
+// scenario contract.
+func ValidateOutputSpecs(specs []OutputSpec) error {
+	seen := make(map[string]struct{}, len(specs))
+	for _, spec := range specs {
+		if spec.Name == "" {
+			return fmt.Errorf("output spec has an empty name")
+		}
+		if !validOutputName(spec.Name) {
+			return fmt.Errorf("output spec %q has an invalid name", spec.Name)
+		}
+		if _, exists := seen[spec.Name]; exists {
+			return fmt.Errorf("duplicate output spec %q", spec.Name)
+		}
+		seen[spec.Name] = struct{}{}
+		if !validParamType(spec.Type) {
+			return fmt.Errorf("output %q has invalid type %q", spec.Name, spec.Type)
+		}
+	}
+	return nil
+}
+
+func validOutputName(name string) bool {
+	for _, char := range name {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '_' || char == '-' {
+			continue
+		}
+		return false
+	}
+	return name != ""
+}
+
+// NormalizeOutput validates one published value and returns its declared
+// runtime type.
+func NormalizeOutput(spec OutputSpec, value any) (any, error) {
+	normalized, err := normalizeParamValue(ParamSpec{Name: spec.Name, Type: spec.Type}, value)
+	if err != nil {
+		return nil, fmt.Errorf("output: %w", err)
+	}
+	return normalized, nil
+}
+
 // RedactParams returns a copy of params with values declared sensitive by the
 // module contract replaced before they reach managed logs.
 func RedactParams(specs []ParamSpec, params Params) Params {

--- a/pkg/module/registry.go
+++ b/pkg/module/registry.go
@@ -28,6 +28,11 @@ func (r *Registry) Register(newGenerator Factory) {
 	if err := ValidateParamSpecs(gen.ParamSpecs()); err != nil {
 		panic(fmt.Sprintf("module: invalid parameters for %q: %v", name, err))
 	}
+	if provider, ok := gen.(OutputProvider); ok {
+		if err := ValidateOutputSpecs(provider.OutputSpecs()); err != nil {
+			panic(fmt.Sprintf("module: invalid outputs for %q: %v", name, err))
+		}
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if name == "" {


### PR DESCRIPTION
Adds scenario schema v1 with typed dataflow, preflighted includes, scenario-wide workspaces, reverse cleanup, per-step failure policy, cancellation, and JSON reports. This gives later primitive migrations a safe composition contract.\n\nValidation: Windows tests, vet, and lint; Darwin builds, integration compilation, and lint; full Mac unit and race-enabled integration suites.