### PR TITLE
refactor: add process execution primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ make build
 | Category | Description | Modules |
 |----------|-------------|---------|
 | `network` | Outbound connections, DNS, beaconing, listeners, reverse shells, TLS, exfiltration | net_connect, net_listen, net_beacon, net_revshell, net_dns, net_dns_exfil, net_tls, net_exfil |
-| `process` | Process spawning, signal delivery, dylib injection, discovery, Gatekeeper bypass, osascript | proc_spawn, proc_signal, proc_inject, proc_discovery, proc_gatekeeper, proc_osascript |
+| `process` | Process spawning, signal delivery, dylib injection, discovery, Gatekeeper bypass, osascript | proc_exec, proc_spawn, proc_signal, proc_inject, proc_discovery, proc_gatekeeper, proc_osascript |
 | `file` | File creation, modification, credential file and keychain reads, archiving, hiding, encryption | file_create, file_modify, file_browser_creds, file_cred_files, file_keychain_copy, file_archive, file_hide, file_encrypt |
 | `tcc` | TCC permission probes (FDA, Contacts, Keychain, Accessibility, Screen Recording) | tcc_fda, tcc_contacts, tcc_keychain, tcc_accessibility, tcc_screen_recording |
 | `endpoint_security` | ES framework event triggers, including .dmg mount and payload execution | es_file, es_process, es_mount |

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Scenarios chain modules into ordered sequences - a single YAML file that replays
 | `amos_atomic_stealer.yaml` | AMOS / Atomic Stealer: MaaS infostealer, Gatekeeper bypass, keychain dump, ZIP exfil, backdoor persistence |
 | `clickfix.yaml` | ClickFix: obfuscated one-liner pasted into Terminal, base64 decode, second-stage fetch, LaunchAgent persistence |
 | `ransomware.yaml` | Ransomware impact: stage plaintext decoys, encrypt them, then drop a ransom note |
+| `discovery.yaml` | Composed argv-based system, account, network, and security software discovery recipes |
+| `process_chain.yaml` | Three-process shell chain built from an explicit argument vector |
 
 The two APT scenarios follow real documented intrusion sequences, technique by technique - each YAML file cites the actual threat intel it's built from and annotates every step with the MITRE technique it exercises, so start there for the full breakdown rather than a retelling here.
 

--- a/cmd/macnoise/docs_test.go
+++ b/cmd/macnoise/docs_test.go
@@ -61,19 +61,20 @@ func TestDocsListEveryRegisteredModule(t *testing.T) {
 // module they invoke.
 func TestStockScenariosHaveValidInputs(t *testing.T) {
 	dir := filepath.Join("..", "..", "configs", "scenarios")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read %s: %v", dir, err)
-	}
-
-	for _, e := range entries {
-		if !strings.HasSuffix(e.Name(), ".yaml") {
-			continue
+	err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		path := filepath.Join(dir, e.Name())
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			return nil
+		}
 		if err := runner.ValidateScenario(path, nil, &module.DefaultRegistry); err != nil {
-			t.Errorf("%s: %v", e.Name(), err)
+			t.Errorf("%s: %v", path, err)
 		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
 	}
 }
 

--- a/configs/scenarios/discovery.yaml
+++ b/configs/scenarios/discovery.yaml
@@ -1,0 +1,17 @@
+version: 1
+name: macOS Discovery
+description: Composes focused argv-based recipes for system, account, network, and security software discovery
+on_error: continue
+
+steps:
+  - id: system
+    include: recipes/system_discovery.yaml
+
+  - id: accounts
+    include: recipes/account_discovery.yaml
+
+  - id: network
+    include: recipes/network_discovery.yaml
+
+  - id: security_software
+    include: recipes/security_software_discovery.yaml

--- a/configs/scenarios/process_chain.yaml
+++ b/configs/scenarios/process_chain.yaml
@@ -1,0 +1,21 @@
+version: 1
+name: Nested Process Chain
+description: Creates a three-process shell chain with an explicit argument vector
+on_error: stop
+
+steps:
+  # T1059.004 - Command and Scripting Interpreter: Unix Shell
+  - id: chain
+    module: proc_exec
+    params:
+      executable: /bin/sh
+      args:
+        - -c
+        - '"$@"'
+        - sh
+        - /bin/sh
+        - -c
+        - '"$@"'
+        - sh
+        - /usr/bin/printf
+        - "macnoise_process_chain\n"

--- a/configs/scenarios/recipes/account_discovery.yaml
+++ b/configs/scenarios/recipes/account_discovery.yaml
@@ -1,0 +1,23 @@
+version: 1
+name: Account Discovery Recipe
+description: Collects the current user and local account list with direct argv execution
+on_error: continue
+
+steps:
+  # T1033 - System Owner/User Discovery
+  - id: current_user
+    module: proc_exec
+    params:
+      executable: /usr/bin/id
+      args:
+        - -un
+
+  # T1087.001 - Account Discovery: Local Account
+  - id: local_accounts
+    module: proc_exec
+    params:
+      executable: /usr/bin/dscl
+      args:
+        - .
+        - -list
+        - /Users

--- a/configs/scenarios/recipes/network_discovery.yaml
+++ b/configs/scenarios/recipes/network_discovery.yaml
@@ -1,0 +1,11 @@
+version: 1
+name: Network Discovery Recipe
+description: Collects interface configuration with direct argv execution
+on_error: continue
+
+steps:
+  # T1016 - System Network Configuration Discovery
+  - id: interfaces
+    module: proc_exec
+    params:
+      executable: /sbin/ifconfig

--- a/configs/scenarios/recipes/security_software_discovery.yaml
+++ b/configs/scenarios/recipes/security_software_discovery.yaml
@@ -1,0 +1,46 @@
+version: 1
+name: Security Software Discovery Recipe
+description: Enumerates security controls, system extensions, firewall state, and running processes with direct argv execution
+on_error: continue
+
+steps:
+  # T1518.001 - Software Discovery: Security Software Discovery
+  - id: sip_status
+    module: proc_exec
+    params:
+      executable: /usr/bin/csrutil
+      args:
+        - status
+      accept_nonzero: true
+
+  - id: filevault_status
+    module: proc_exec
+    params:
+      executable: /usr/bin/fdesetup
+      args:
+        - status
+      accept_nonzero: true
+
+  - id: system_extensions
+    module: proc_exec
+    params:
+      executable: /usr/bin/systemextensionsctl
+      args:
+        - list
+      accept_nonzero: true
+
+  - id: application_firewall
+    module: proc_exec
+    params:
+      executable: /usr/libexec/ApplicationFirewall/socketfilterfw
+      args:
+        - --getglobalstate
+      accept_nonzero: true
+
+  - id: running_processes
+    module: proc_exec
+    params:
+      executable: /bin/ps
+      args:
+        - -axo
+        - comm=

--- a/configs/scenarios/recipes/system_discovery.yaml
+++ b/configs/scenarios/recipes/system_discovery.yaml
@@ -1,0 +1,33 @@
+version: 1
+name: System Discovery Recipe
+description: Collects macOS version, hardware, application, and model information with direct argv execution
+on_error: continue
+
+steps:
+  # T1082 - System Information Discovery
+  - id: macos_version
+    module: proc_exec
+    params:
+      executable: /usr/bin/sw_vers
+
+  - id: hardware
+    module: proc_exec
+    params:
+      executable: /usr/sbin/system_profiler
+      args:
+        - SPHardwareDataType
+
+  # T1518 - Software Discovery
+  - id: applications
+    module: proc_exec
+    params:
+      executable: /bin/ls
+      args:
+        - /Applications
+
+  - id: model
+    module: proc_exec
+    params:
+      executable: /usr/sbin/sysctl
+      args:
+        - hw.model

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -105,7 +105,7 @@ func networkActivity(eventType string) (int, string) {
 
 func processActivity(eventType string) (int, string) {
 	switch eventType {
-	case "process_spawn", "process_fork", "osascript_exec", "system_discovery",
+	case "process_exec", "process_spawn", "process_fork", "osascript_exec", "system_discovery",
 		"xattr_quarantine_set", "xattr_quarantine_remove", "spctl_status_check":
 		return 1, "Launch"
 	case "dylib_inject_attempt":

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -51,6 +51,7 @@ func TestClassify(t *testing.T) {
 		// process
 		{"process", "dylib_inject_attempt", 1007, 4},
 		{"process", "osascript_exec", 1007, 1},
+		{"process", "process_exec", 1007, 1},
 		{"process", "process_fork", 1007, 1},
 		{"process", "process_spawn", 1007, 1},
 		{"process", "signal_send", 1007, 99},

--- a/internal/subprocess/cancel_other.go
+++ b/internal/subprocess/cancel_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package subprocess
+
+import "os/exec"
+
+func configureCancellation(cmd *exec.Cmd) {}

--- a/internal/subprocess/cancel_unix.go
+++ b/internal/subprocess/cancel_unix.go
@@ -1,0 +1,24 @@
+//go:build unix
+
+package subprocess
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureCancellation(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}

--- a/internal/subprocess/run.go
+++ b/internal/subprocess/run.go
@@ -1,0 +1,34 @@
+// Package subprocess provides the shared lifecycle for synchronous child processes.
+package subprocess
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+)
+
+// Result records the observable result of a completed process invocation.
+type Result struct {
+	Output   []byte
+	ExitCode int
+}
+
+// Run executes one process, captures its combined output, and waits for it to exit.
+func Run(ctx context.Context, executable string, args ...string) (Result, error) {
+	result := Result{ExitCode: -1}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+
+	cmd := exec.CommandContext(ctx, executable, args...)
+	configureCancellation(cmd)
+	output, err := cmd.CombinedOutput()
+	result.Output = output
+	if cmd.ProcessState != nil {
+		result.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return result, errors.Join(ctxErr, err)
+	}
+	return result, err
+}

--- a/internal/subprocess/run_test.go
+++ b/internal/subprocess/run_test.go
@@ -1,0 +1,63 @@
+package subprocess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+)
+
+func TestRunCapturesOutputAndExitCode(t *testing.T) {
+	result, err := Run(context.Background(), os.Args[0], "-test.run=TestRunHelper", "--", "--macnoise-subprocess-helper", "0", "literal ; value")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if string(result.Output) != "literal ; value" || result.ExitCode != 0 {
+		t.Fatalf("result = %+v, want literal output and exit code 0", result)
+	}
+}
+
+func TestRunReturnsExitErrorAndCode(t *testing.T) {
+	result, err := Run(context.Background(), os.Args[0], "-test.run=TestRunHelper", "--", "--macnoise-subprocess-helper", "7", "failed")
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("Run error = %v, want process exit error", err)
+	}
+	if string(result.Output) != "failed" || result.ExitCode != 7 {
+		t.Fatalf("result = %+v, want failed output and exit code 7", result)
+	}
+}
+
+func TestRunCanceledBeforeStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err := Run(ctx, os.Args[0])
+	if !errors.Is(err, context.Canceled) || result.ExitCode != -1 {
+		t.Fatalf("Run = %+v, %v, want context.Canceled before start", result, err)
+	}
+}
+
+func TestRunHelper(t *testing.T) {
+	index := argumentIndex("--macnoise-subprocess-helper")
+	if index < 0 || len(os.Args) < index+3 {
+		return
+	}
+	code, err := strconv.Atoi(os.Args[index+1])
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(os.Args[index+2])
+	os.Exit(code)
+}
+
+func argumentIndex(want string) int {
+	for index, arg := range os.Args {
+		if arg == want {
+			return index
+		}
+	}
+	return -1
+}

--- a/internal/subprocess/run_unix_test.go
+++ b/internal/subprocess/run_unix_test.go
@@ -1,0 +1,51 @@
+//go:build unix
+
+package subprocess
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunCancellationTerminatesProcessGroup(t *testing.T) {
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	marker := filepath.Join(dir, "survived")
+	script := `(touch "$1"; sleep 1; touch "$2") & wait`
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := Run(ctx, "sh", "-c", script, "sh", ready, marker)
+		done <- err
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancellation")
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("descendant survived process-group cancellation: %v", err)
+	}
+}

--- a/modules/endpoint_security/es_mount.go
+++ b/modules/endpoint_security/es_mount.go
@@ -163,7 +163,7 @@ func (e *esMount) Generate(ctx context.Context, params module.Params, emit modul
 	}
 
 	unmountEv := output.NewEvent(info, "es_notify_unmount", module.OutcomeError, module.File(res.MountPoint), fmt.Sprintf("unmounting %s (triggers ES_EVENT_TYPE_NOTIFY_UNMOUNT)", res.MountPoint))
-	if out, err := exec.CommandContext(ctx, "hdiutil", detachArgs(res.MountPoint)...).CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "hdiutil", detachArgs(e.detachTarget())...).CombinedOutput(); err != nil {
 		unmountEv = output.WithError(unmountEv, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out))))
 		return emit(unmountEv)
 	}
@@ -248,13 +248,13 @@ func (e *esMount) Cleanup(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-// detachTarget prefers the mount point, falling back to the device node for an
-// image that attached without mounting a volume.
+// detachTarget uses the whole-disk node so every slice is detached. The mount
+// point is a fallback for unusual attach output that omits the device.
 func (e *esMount) detachTarget() string {
-	if e.mountPoint != "" {
-		return e.mountPoint
+	if e.device != "" {
+		return e.device
 	}
-	return e.device
+	return e.mountPoint
 }
 
 func init() {

--- a/modules/endpoint_security/es_mount_test.go
+++ b/modules/endpoint_security/es_mount_test.go
@@ -111,14 +111,14 @@ func TestCleanupIsNoOpWhenNothingWasMounted(t *testing.T) {
 	}
 }
 
-func TestDetachTargetPrefersMountPoint(t *testing.T) {
+func TestDetachTargetPrefersWholeDisk(t *testing.T) {
 	e := &esMount{device: "/dev/disk4", mountPoint: "/Volumes/MacNoiseDelivery"}
-	if got := e.detachTarget(); got != "/Volumes/MacNoiseDelivery" {
-		t.Errorf("detach target = %q, want the mount point", got)
+	if got := e.detachTarget(); got != "/dev/disk4" {
+		t.Errorf("detach target = %q, want the whole-disk device", got)
 	}
 
-	e = &esMount{device: "/dev/disk4"}
-	if got := e.detachTarget(); got != "/dev/disk4" {
-		t.Errorf("detach target = %q, want the device node as fallback", got)
+	e = &esMount{mountPoint: "/Volumes/MacNoiseDelivery"}
+	if got := e.detachTarget(); got != "/Volumes/MacNoiseDelivery" {
+		t.Errorf("detach target = %q, want the mount point as fallback", got)
 	}
 }

--- a/modules/endpoint_security/es_process.go
+++ b/modules/endpoint_security/es_process.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 
 	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/internal/subprocess"
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
@@ -69,8 +69,7 @@ func (e *esProcess) Generate(ctx context.Context, params module.Params, emit mod
 		fmt.Sprintf("executing %d-deep process fork/exec chain", depth))
 
 	chainArgs := buildExecChainArgs(depth, module.RunIDFromContext(ctx))
-	cmd := exec.CommandContext(ctx, chainArgs[0], chainArgs[1:]...)
-	out, err := cmd.CombinedOutput()
+	result, err := subprocess.Run(ctx, chainArgs[0], chainArgs[1:]...)
 	if err != nil {
 		ev = output.WithError(ev, err)
 		return errors.Join(err, emit(ev))
@@ -79,7 +78,7 @@ func (e *esProcess) Generate(ctx context.Context, params module.Params, emit mod
 	ev.Message = fmt.Sprintf("%d-deep exec chain completed (ES_EVENT_TYPE_NOTIFY_EXEC/FORK/EXIT)", depth)
 	ev = output.WithDetails(ev, map[string]any{
 		"chain_depth": depth,
-		"output":      string(out),
+		"output":      string(result.Output),
 		"es_events":   []string{"ES_EVENT_TYPE_NOTIFY_EXEC", "ES_EVENT_TYPE_NOTIFY_FORK", "ES_EVENT_TYPE_NOTIFY_EXIT"},
 	})
 	return emit(ev)

--- a/modules/process/README.md
+++ b/modules/process/README.md
@@ -9,6 +9,8 @@ Executes one executable with an exact argument list and no implicit shell. It pu
 
 ```bash
 macnoise run proc_exec --param executable=/usr/bin/id --param args=-un
+macnoise scenario configs/scenarios/discovery.yaml
+macnoise scenario configs/scenarios/process_chain.yaml
 ```
 
 ### `proc_spawn`

--- a/modules/process/README.md
+++ b/modules/process/README.md
@@ -4,6 +4,13 @@ Process spawning, signal delivery, dylib injection, system discovery, Gatekeeper
 
 ## Modules
 
+### `proc_exec`
+Executes one executable with an exact argument list and no implicit shell. It publishes the combined output and exit code for scenario dataflow. Set `accept_nonzero=true` when a completed non-zero exit is valid telemetry rather than a MacNoise error.
+
+```bash
+macnoise run proc_exec --param executable=/usr/bin/id --param args=-un
+```
+
 ### `proc_spawn`
 Spawns a shell command chain. Maps to T1059.004.
 

--- a/modules/process/discovery.go
+++ b/modules/process/discovery.go
@@ -3,10 +3,10 @@ package process
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/internal/subprocess"
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
@@ -100,18 +100,18 @@ func (p *procDiscovery) Generate(ctx context.Context, params module.Params, emit
 		}
 
 		ev := output.NewEvent(info, "system_discovery", module.OutcomeError, module.Process("sh", "/bin/sh", cmd, 0), fmt.Sprintf("running: %s", cmd))
-		out, err := exec.CommandContext(ctx, "sh", "-c", cmd).CombinedOutput()
+		result, err := subprocess.Run(ctx, "sh", "-c", cmd)
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		if err != nil {
 			ev.Outcome = module.OutcomeExecuted
 			ev.Message = fmt.Sprintf("discovery command returned error: %s", cmd)
-			ev = output.WithDetails(ev, map[string]any{"command": cmd, "output": string(out), "error": err.Error()})
+			ev = output.WithDetails(ev, map[string]any{"command": cmd, "output": string(result.Output), "error": err.Error()})
 		} else {
 			ev.Outcome = module.OutcomeExecuted
 			ev.Message = fmt.Sprintf("discovery command completed: %s", cmd)
-			ev = output.WithDetails(ev, map[string]any{"command": cmd, "output": string(out)})
+			ev = output.WithDetails(ev, map[string]any{"command": cmd, "output": string(result.Output)})
 		}
 		if err := emit(ev); err != nil {
 			return err

--- a/modules/process/discovery_exec_test.go
+++ b/modules/process/discovery_exec_test.go
@@ -120,8 +120,8 @@ func TestDiscoveryGenerate_CanceledDuringCommand(t *testing.T) {
 			var events []module.TelemetryEvent
 			done := make(chan error, 1)
 			go func() {
-				// exec leaves no descendant holding the output pipe after cancellation.
-				done <- (&procDiscovery{}).Generate(ctx, module.Params{"commands": fmt.Sprintf("printf started > '%s'; exec sleep 10", marker)}, func(ev module.TelemetryEvent) error {
+				// The shared lifecycle must terminate the shell and its child.
+				done <- (&procDiscovery{}).Generate(ctx, module.Params{"commands": fmt.Sprintf("printf started > '%s'; sleep 10", marker)}, func(ev module.TelemetryEvent) error {
 					events = append(events, ev)
 					return nil
 				})

--- a/modules/process/exec.go
+++ b/modules/process/exec.go
@@ -1,0 +1,108 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/internal/subprocess"
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+type procExec struct{}
+
+func (p *procExec) Info() module.ModuleInfo {
+	return module.ModuleInfo{
+		Name:        "proc_exec",
+		EventTypes:  []string{"process_exec"},
+		Description: "Executes an explicit argument vector without invoking an implicit shell",
+		Category:    module.CategoryProcess,
+		Tags:        []string{"execution", "argv", "process"},
+		Privileges:  module.PrivilegeNone,
+		Author:      "0xv1n",
+		MinMacOS:    "12.0",
+	}
+}
+
+func (p *procExec) ParamSpecs() []module.ParamSpec {
+	return []module.ParamSpec{
+		{Name: "executable", Description: "Executable name or path", Type: module.ParamString, Default: "/usr/bin/true", Example: "/usr/bin/id"},
+		{Name: "args", Description: "Exact arguments passed to the executable", Type: module.ParamStringList, Sensitive: true, Default: []string{}, Example: []string{"-un"}},
+		{Name: "accept_nonzero", Description: "Treat a completed non-zero exit as generated telemetry", Type: module.ParamBoolean, Default: false, Example: true},
+	}
+}
+
+func (p *procExec) OutputSpecs() []module.OutputSpec {
+	return []module.OutputSpec{
+		{Name: "output", Description: "Combined standard output and standard error", Type: module.ParamString, Sensitive: true},
+		{Name: "exit_code", Description: "Process exit code", Type: module.ParamInteger},
+	}
+}
+
+func (p *procExec) CheckPrereqs(ctx context.Context, params module.Params) error { return nil }
+
+func (p *procExec) Generate(ctx context.Context, params module.Params, emit module.EventEmitter) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	executable := params.String("executable", "/usr/bin/true")
+	args := params.Strings("args", nil)
+	argv := append([]string{executable}, args...)
+	info := p.Info()
+	ev := output.NewEvent(info, "process_exec", module.OutcomeError,
+		module.Process(filepath.Base(executable), executable, executable, 0),
+		fmt.Sprintf("executing %s with %d argument(s)", executable, len(args)))
+
+	result, runErr := subprocess.Run(ctx, executable, args...)
+	if ctx.Err() != nil {
+		return errors.Join(runErr, ctx.Err())
+	}
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(runErr, &exitErr) {
+			ev = output.WithError(ev, runErr)
+			return errors.Join(runErr, emit(ev))
+		}
+	}
+
+	publishErr := errors.Join(
+		module.PublishOutput(ctx, "output", string(result.Output)),
+		module.PublishOutput(ctx, "exit_code", result.ExitCode),
+	)
+	details := map[string]any{"argv": argv, "output": string(result.Output), "exit_code": result.ExitCode}
+	if runErr != nil && !params.Bool("accept_nonzero", false) {
+		ev = output.WithError(ev, runErr)
+		ev = output.WithDetails(ev, details)
+		return errors.Join(runErr, publishErr, emit(ev))
+	}
+
+	ev.Outcome = module.OutcomeExecuted
+	if runErr != nil {
+		ev.Message = fmt.Sprintf("%s exited %d (accepted)", executable, result.ExitCode)
+		details["error"] = runErr.Error()
+	} else {
+		ev.Message = fmt.Sprintf("%s exited 0", executable)
+	}
+	ev = output.WithDetails(ev, details)
+	return errors.Join(publishErr, emit(ev))
+}
+
+func (p *procExec) DryRun(params module.Params) []string {
+	argv := append([]string{params.String("executable", "/usr/bin/true")}, params.Strings("args", nil)...)
+	quoted := make([]string, len(argv))
+	for index, arg := range argv {
+		quoted[index] = strconv.Quote(arg)
+	}
+	return []string{"exec: " + strings.Join(quoted, " ")}
+}
+
+func (p *procExec) Cleanup(ctx context.Context) error { return nil }
+
+func init() {
+	module.Register(func() module.Generator { return &procExec{} })
+}

--- a/modules/process/exec_test.go
+++ b/modules/process/exec_test.go
@@ -1,0 +1,131 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/0xv1n/macnoise/pkg/module"
+)
+
+func TestProcExecGenerate_PreservesArgumentsAndPublishesOutputs(t *testing.T) {
+	ctx, outputs := execOutputContext()
+	var events []module.TelemetryEvent
+	params := helperExecParams(0, "literal ; $(not-a-shell)")
+	if err := (&procExec{}).Generate(ctx, params, captureExecEvents(&events)); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(events) != 1 || events[0].Outcome != module.OutcomeExecuted {
+		t.Fatalf("events = %+v, want one executed event", events)
+	}
+	if outputs["output"] != "literal ; $(not-a-shell)" || outputs["exit_code"] != 0 {
+		t.Fatalf("outputs = %+v", outputs)
+	}
+	argv, ok := events[0].Details["argv"].([]string)
+	if !ok || argv[len(argv)-1] != "literal ; $(not-a-shell)" {
+		t.Fatalf("argv details = %#v", events[0].Details["argv"])
+	}
+}
+
+func TestProcExecGenerate_NonzeroPolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		acceptNonzero bool
+		wantErr       bool
+	}{
+		{name: "error", wantErr: true},
+		{name: "accepted", acceptNonzero: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, outputs := execOutputContext()
+			var events []module.TelemetryEvent
+			params := helperExecParams(9, "failed")
+			params["accept_nonzero"] = tt.acceptNonzero
+			err := (&procExec{}).Generate(ctx, params, captureExecEvents(&events))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Generate = %v, wantErr %v", err, tt.wantErr)
+			}
+			if outputs["exit_code"] != 9 || len(events) != 1 {
+				t.Fatalf("outputs = %+v; events = %+v", outputs, events)
+			}
+			wantOutcome := module.OutcomeError
+			if tt.acceptNonzero {
+				wantOutcome = module.OutcomeExecuted
+			}
+			if events[0].Outcome != wantOutcome {
+				t.Fatalf("outcome = %s, want %s", events[0].Outcome, wantOutcome)
+			}
+		})
+	}
+}
+
+func TestProcExecGenerate_CanceledBeforeExecution(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var events []module.TelemetryEvent
+	err := (&procExec{}).Generate(ctx, helperExecParams(0, "ignored"), captureExecEvents(&events))
+	if !errors.Is(err, context.Canceled) || len(events) != 0 {
+		t.Fatalf("Generate = %v, events = %+v; want cancellation without event", err, events)
+	}
+}
+
+func TestProcExecContract(t *testing.T) {
+	p := &procExec{}
+	specs := p.ParamSpecs()
+	if specs[0].Default != "/usr/bin/true" || !specs[1].Sensitive {
+		t.Fatalf("parameter specs = %+v", specs)
+	}
+	outputs := p.OutputSpecs()
+	if len(outputs) != 2 || !outputs[0].Sensitive || outputs[1].Type != module.ParamInteger {
+		t.Fatalf("output specs = %+v", outputs)
+	}
+}
+
+func execOutputContext() (context.Context, module.Params) {
+	outputs := module.Params{}
+	ctx := module.ContextWithOutputSink(context.Background(), func(name string, value any) error {
+		outputs[name] = value
+		return nil
+	})
+	return ctx, outputs
+}
+
+func helperExecParams(exitCode int, output string) module.Params {
+	return module.Params{
+		"executable": os.Args[0],
+		"args":       []string{"-test.run=TestProcExecHelper", "--", "--macnoise-proc-exec-helper", strconv.Itoa(exitCode), output},
+	}
+}
+
+func TestProcExecHelper(t *testing.T) {
+	index := procExecArgumentIndex("--macnoise-proc-exec-helper")
+	if index < 0 || len(os.Args) < index+3 {
+		return
+	}
+	code, err := strconv.Atoi(os.Args[index+1])
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(os.Args[index+2])
+	os.Exit(code)
+}
+
+func procExecArgumentIndex(want string) int {
+	for index, arg := range os.Args {
+		if arg == want {
+			return index
+		}
+	}
+	return -1
+}
+
+func captureExecEvents(events *[]module.TelemetryEvent) module.EventEmitter {
+	return func(ev module.TelemetryEvent) error {
+		*events = append(*events, ev)
+		return nil
+	}
+}

--- a/modules/process/gatekeeper.go
+++ b/modules/process/gatekeeper.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/internal/subprocess"
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
@@ -65,9 +65,9 @@ func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emi
 		quarantineVal = "0081;00000000;macnoise-" + runID + ";"
 	}
 	setEv := output.NewEvent(info, "xattr_quarantine_set", module.OutcomeError, module.File(targetPath), fmt.Sprintf("setting quarantine xattr on %s", targetPath))
-	setOut, setErr := exec.CommandContext(ctx, "xattr", "-w", "com.apple.quarantine", quarantineVal, targetPath).CombinedOutput()
+	setResult, setErr := subprocess.Run(ctx, "xattr", "-w", "com.apple.quarantine", quarantineVal, targetPath)
 	if setErr != nil {
-		setEv = output.WithError(setEv, fmt.Errorf("%v: %s", setErr, setOut))
+		setEv = output.WithError(setEv, fmt.Errorf("%v: %s", setErr, setResult.Output))
 		if err := emit(setEv); err != nil {
 			return err
 		}
@@ -80,9 +80,9 @@ func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emi
 		}
 
 		rmEv := output.NewEvent(info, "xattr_quarantine_remove", module.OutcomeError, module.File(targetPath), fmt.Sprintf("removing quarantine xattr from %s", targetPath))
-		rmOut, rmErr := exec.CommandContext(ctx, "xattr", "-d", "com.apple.quarantine", targetPath).CombinedOutput()
+		rmResult, rmErr := subprocess.Run(ctx, "xattr", "-d", "com.apple.quarantine", targetPath)
 		if rmErr != nil {
-			rmEv = output.WithError(rmEv, fmt.Errorf("%v: %s", rmErr, rmOut))
+			rmEv = output.WithError(rmEv, fmt.Errorf("%v: %s", rmErr, rmResult.Output))
 		} else {
 			rmEv.Outcome = module.OutcomeExecuted
 			rmEv.Message = fmt.Sprintf("removed com.apple.quarantine from %s", targetPath)
@@ -94,15 +94,15 @@ func (p *procGatekeeper) Generate(ctx context.Context, params module.Params, emi
 	}
 
 	spctlEv := output.NewEvent(info, "spctl_status_check", module.OutcomeError, module.Process("spctl", "/usr/sbin/spctl", "spctl --status", 0), "checking Gatekeeper status via spctl --status")
-	spctlOut, spctlErr := exec.CommandContext(ctx, "spctl", "--status").CombinedOutput()
+	spctlResult, spctlErr := subprocess.Run(ctx, "spctl", "--status")
 	if spctlErr != nil {
 		spctlEv.Outcome = module.OutcomeExecuted
 		spctlEv.Message = "Gatekeeper status check returned error (expected on some configs)"
-		spctlEv = output.WithDetails(spctlEv, map[string]any{"output": string(spctlOut), "error": spctlErr.Error()})
+		spctlEv = output.WithDetails(spctlEv, map[string]any{"output": string(spctlResult.Output), "error": spctlErr.Error()})
 	} else {
 		spctlEv.Outcome = module.OutcomeExecuted
-		spctlEv.Message = fmt.Sprintf("Gatekeeper status: %s", strings.TrimSpace(string(spctlOut)))
-		spctlEv = output.WithDetails(spctlEv, map[string]any{"output": string(spctlOut)})
+		spctlEv.Message = fmt.Sprintf("Gatekeeper status: %s", strings.TrimSpace(string(spctlResult.Output)))
+		spctlEv = output.WithDetails(spctlEv, map[string]any{"output": string(spctlResult.Output)})
 	}
 	return emit(spctlEv)
 }

--- a/modules/process/osascript.go
+++ b/modules/process/osascript.go
@@ -3,11 +3,11 @@ package process
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"runtime"
 	"strings"
 
 	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/internal/subprocess"
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
@@ -102,11 +102,11 @@ func (p *procOsascript) Generate(ctx context.Context, params module.Params, emit
 	info := p.Info()
 
 	ev := output.NewEvent(info, "osascript_exec", module.OutcomeError, module.Process("osascript", "/usr/bin/osascript", script, 0), fmt.Sprintf("executing %s via osascript", language))
-	out, err := exec.CommandContext(ctx, "osascript", "-l", language, "-e", script).CombinedOutput()
+	result, err := subprocess.Run(ctx, "osascript", "-l", language, "-e", script)
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	safeOutput := sanitizeOsascriptOutput(script, string(out))
+	safeOutput := sanitizeOsascriptOutput(script, string(result.Output))
 	if err != nil {
 		ev.Outcome = module.OutcomeExecuted
 		ev.Message = fmt.Sprintf("osascript returned error (telemetry generated): %v", err)

--- a/modules/process/spawn.go
+++ b/modules/process/spawn.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 
 	"github.com/0xv1n/macnoise/internal/output"
+	"github.com/0xv1n/macnoise/internal/subprocess"
 	"github.com/0xv1n/macnoise/pkg/module"
 )
 
@@ -54,15 +54,14 @@ func (p *procSpawn) Generate(ctx context.Context, params module.Params, emit mod
 	info := p.Info()
 
 	ev := output.NewEvent(info, "process_spawn", module.OutcomeError, module.Process("sh", "/bin/sh", command, 0), fmt.Sprintf("spawning: sh -c %q", command))
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
-	out, err := cmd.CombinedOutput()
+	result, err := subprocess.Run(ctx, "sh", "-c", command)
 	if err != nil {
 		ev = output.WithError(ev, err)
 		return errors.Join(err, emit(ev))
 	}
 	ev.Outcome = module.OutcomeExecuted
 	ev.Message = fmt.Sprintf("process exited 0: sh -c %q", command)
-	ev = output.WithDetails(ev, map[string]any{"command": command, "output": string(out)})
+	ev = output.WithDetails(ev, map[string]any{"command": command, "output": string(result.Output)})
 	return emit(ev)
 }
 


### PR DESCRIPTION
Adds exact-argv execution with typed outputs and a shared cancellation lifecycle. Composes process-chain and discovery scenarios, migrates existing synchronous process modules, and fixes whole-disk detach behavior found by macOS CI.\n\nValidation: all PR checks pass, including macOS integration tests and Darwin amd64/arm64 builds.